### PR TITLE
Add project name to user-data

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -162,6 +162,7 @@ class DiscoAWS(object):
                 data["route_table_id_{0}".format(_)] = _tmp[_][0]
                 data["destination_cidr_block_{0}".format(_)] = _tmp[_][1]
         logging.debug("userdata: %s", data)
+        data["project_name"] = self.config("project_name")
         return data
 
     @staticmethod

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -161,8 +161,8 @@ class DiscoAWS(object):
             for _ in xrange(0, len(_tmp)):
                 data["route_table_id_{0}".format(_)] = _tmp[_][0]
                 data["destination_cidr_block_{0}".format(_)] = _tmp[_][1]
-        logging.debug("userdata: %s", data)
         data["project_name"] = self.config("project_name")
+        logging.debug("userdata: %s", data)
         return data
 
     @staticmethod

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.59"
+__version__ = "1.0.60"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
It would be convenient for some runtime scripts to know the name of the project without having to poke around at asiaq config files. This seems pretty harmless and a lot easier to work with.