### PR TITLE
Generate shorter replication group Ids

### DIFF
--- a/bin/disco_elasticache.py
+++ b/bin/disco_elasticache.py
@@ -50,7 +50,9 @@ def run():
             size = 'N/A'
             if cluster['Status'] == 'available':
                 size = len(cluster['NodeGroups'][0]['NodeGroupMembers'])
-            print("{0:<25} {1:5} {2:>5}".format(cluster['ReplicationGroupId'], cluster['Status'], size))
+            print("{0:<25} {1:5} {2:>5}".format(cluster['ReplicationGroupDescription'],
+                                                cluster['Status'],
+                                                size))
     elif args['update']:
         if args['--cluster']:
             disco_elasticache.update(args['--cluster'])

--- a/bin/disco_elasticache.py
+++ b/bin/disco_elasticache.py
@@ -50,7 +50,7 @@ def run():
             size = 'N/A'
             if cluster['Status'] == 'available':
                 size = len(cluster['NodeGroups'][0]['NodeGroupMembers'])
-            print("{0:<25} {1:5} {2:>5}".format(cluster['ReplicationGroupDescription'],
+            print("{0:<25} {1:5} {2:>5}".format(cluster['Description'],
                                                 cluster['Status'],
                                                 size))
     elif args['update']:

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -92,7 +92,7 @@ class DiscoElastiCache(object):
                 self._modify_redis_cluster(cluster_name, engine_version,
                                            parameter_group, auto_failover, domain_name)
             else:
-                logging.info('Unable update to cache cluster %s. Its status is not available',
+                logging.error('Unable to update cache cluster %s. Its status is not available',
                              cache_cluster['Description'])
 
     def update_all(self):

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -93,7 +93,7 @@ class DiscoElastiCache(object):
                                            parameter_group, auto_failover, domain_name)
             else:
                 logging.error('Unable to update cache cluster %s. Its status is not available',
-                             cache_cluster['Description'])
+                              cache_cluster['Description'])
 
     def update_all(self):
         """Update all clusters in environment to match config"""

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.61"
+__version__ = "1.0.62"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -82,7 +82,8 @@ class DiscoElastiCacheTests(TestCase):
         self.replication_groups = [
             {
                 'ReplicationGroupId': self.elasticache._get_redis_replication_group_id('old-cache'),
-                'ReplicationGroupDescription': 'unittest-old-cache',
+                'Description': 'unittest-old-cache',
+                'Status': 'available',
                 'NodeGroups': [{
                     'PrimaryEndpoint': {
                         'Address': 'old-cache.example.com'
@@ -91,7 +92,8 @@ class DiscoElastiCacheTests(TestCase):
             },
             {
                 'ReplicationGroupId': self.elasticache._get_redis_replication_group_id('cache2'),
-                'ReplicationGroupDescription': 'unittest-cache2',
+                'Description': 'unittest-cache2',
+                'Status': 'available',
                 'NodeGroups': [{
                     'PrimaryEndpoint': {
                         'Address': 'cache2.example.com'
@@ -100,7 +102,8 @@ class DiscoElastiCacheTests(TestCase):
             },
             {
                 'ReplicationGroupId': self.elasticache._get_redis_replication_group_id('cache'),
-                'ReplicationGroupDescription': 'unittest2-cache',
+                'Description': 'unittest2-cache',
+                'Status': 'available'
             }
         ]
 
@@ -155,7 +158,7 @@ class DiscoElastiCacheTests(TestCase):
 
         self.assertEquals(len(clusters), 2)
 
-        ids = [cluster['ReplicationGroupDescription'] for cluster in clusters]
+        ids = [cluster['Description'] for cluster in clusters]
         self.assertEquals(set(['unittest-old-cache', 'unittest-cache2']), set(ids))
 
     def test_create_redis_cluster(self):

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -279,3 +279,10 @@ class DiscoElastiCacheTests(TestCase):
         ]
 
         self.elasticache.conn.delete_cache_subnet_group.assert_has_calls(delete_group_calls, any_order=True)
+
+    def test_get_replication_group_id(self):
+        """Test that replication group Ids follow the AWS rules for Ids"""
+        group_id = self.elasticache._get_redis_replication_group_id('test-name')
+
+        self.assertLessEqual(16, len(group_id))
+        self.assertTrue(group_id[0].isalpha())


### PR DESCRIPTION
Redis Replication Group Ids are limited to 16 characters in Elasticache which is really short when including the environment name in the Id (for example 'production-' is 11 characters) 

Remove the limit by generating non-human readable Ids and storing the actual name in the description

Also a little bit of cleanup by renaming some functions