### PR TITLE
Enabling ssh agent forwarding for disco_bake.py bake depending on dis…

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -18,6 +18,7 @@ import dateutil.parser
 from pytz import UTC
 
 from . import normalize_path, read_config
+from .disco_aws_util import is_truthy
 from .resource_helper import wait_for_sshable, keep_trying, wait_for_state
 from .disco_storage import DiscoStorage
 from .disco_remote_exec import DiscoRemoteExec, SSH_DEFAULT_OPTIONS
@@ -205,7 +206,8 @@ class DiscoBake(object):
         else:
             repo_ip = self.repo_instance().private_ip_address
 
-        self.remotecmd(instance, [script, hostclass, repo_ip], log_on_error=True)
+        forward_agent = is_truthy(self.hc_option_default(hostclass, "forward_agent", "False"))
+        self.remotecmd(instance, [script, hostclass, repo_ip], log_on_error=True, forward_agent=forward_agent)
 
     def ami_stages(self):
         """ Return list of configured ami stages"""

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -18,7 +18,6 @@ import dateutil.parser
 from pytz import UTC
 
 from . import normalize_path, read_config
-from .disco_aws_util import is_truthy
 from .resource_helper import wait_for_sshable, keep_trying, wait_for_state
 from .disco_storage import DiscoStorage
 from .disco_remote_exec import DiscoRemoteExec, SSH_DEFAULT_OPTIONS
@@ -206,8 +205,7 @@ class DiscoBake(object):
         else:
             repo_ip = self.repo_instance().private_ip_address
 
-        forward_agent = is_truthy(self.hc_option_default(hostclass, "forward_agent", "False"))
-        self.remotecmd(instance, [script, hostclass, repo_ip], log_on_error=True, forward_agent=forward_agent)
+        self.remotecmd(instance, [script, hostclass, repo_ip], log_on_error=True, forward_agent=True)
 
     def ami_stages(self):
         """ Return list of configured ami stages"""

--- a/disco_aws_automation/disco_remote_exec.py
+++ b/disco_aws_automation/disco_remote_exec.py
@@ -73,9 +73,12 @@ class DiscoRemoteExec(object):
             # Remove the temporary directory
             shutil.rmtree(tempdir)
 
+    # R0914 Allow more than 15 local variables so we can pass a lot of options to ssh
+    # pylint: disable=R0914
     @staticmethod
     def remotecmd(address, remote_command, user, stdin=None,
-                  nothrow=False, jump_address=None, log_on_error=None, ssh_options=()):
+                  nothrow=False, jump_address=None, log_on_error=None,
+                  ssh_options=(), forward_agent=None):
         """
         Runs the passed in command on a remote host, via a jump host if a jump_address
         is provided.
@@ -90,6 +93,8 @@ class DiscoRemoteExec(object):
         # Build up command to get from tunnel to final dest
         final_hop = ["ssh"]
         final_hop.extend(common_flags)
+        if forward_agent:
+            final_hop.extend(["-A"])
         final_hop.append("-l{0}".format(user))
         final_hop.append(address)
         final_hop.extend(ssh_options)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.61"
+__version__ = "1.0.62"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/sample_configuration/disco_aws.ini
+++ b/sample_configuration/disco_aws.ini
@@ -64,10 +64,6 @@ ami_stages=untested failed tested
 prod_baker=jenkins
 phase=2
 
-# Controls whether the local SSH Agent is forwarded to the hostclass during bake
-# Can also be set at the hostclass level
-forward_agent=False
-
 # account ids to promote tested AMIs to
 prod_account_ids=
 

--- a/sample_configuration/disco_aws.ini
+++ b/sample_configuration/disco_aws.ini
@@ -64,6 +64,10 @@ ami_stages=untested failed tested
 prod_baker=jenkins
 phase=2
 
+# Controls whether the local SSH Agent is forwarded to the hostclass during bake
+# Can also be set at the hostclass level
+forward_agent=False
+
 # account ids to promote tested AMIs to
 prod_account_ids=
 


### PR DESCRIPTION
@IlyaSukhanov @pchand-amplify @aoskotsky-amplify @jichen-amplify 

Enabled forwarding your ssh agent via configuration file for ```disco_bake.py bake```

Does anyone think it would be useful to have an ```--forward-agent``` option for ```disco_aws.py exec``` and/or ```disco_ssh.py```?