### PR TITLE
Add ami_available_wait_time as a config variable in disco_aws.ini

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -116,7 +116,7 @@ class DiscoBake(object):
 
     def hc_option(self, hostclass, key):
         '''
-        Returns an option from the [hostclass] section of the disco_aws.ini config file it it is set,
+        Returns an option from the [hostclass] section of the disco_aws.ini config file if it is set,
         otherwise it returns that value from the [bake] section if it is set,
         otherwise it returns that value from the DEFAULT_CONFIG_SECTION if it is set.
         '''
@@ -404,7 +404,8 @@ class DiscoBake(object):
 
             DiscoBake._tag_ami_with_metadata(image, stage, source_ami_id, productline)
 
-            wait_for_state(image, u'available', 600)
+            wait_for_state(image, u'available',
+                           int(self.hc_option_default(hostclass, "ami_available_wait_time", "600")))
             logging.info("Created %s AMI %s", image_name, image_id)
         except EarlyExitException as early_exit:
             logging.info(str(early_exit))

--- a/sample_configuration/disco_aws.ini
+++ b/sample_configuration/disco_aws.ini
@@ -29,6 +29,7 @@ default_domain_name=dev.sample_project.net
 default_domain_name@staging=staging.sample_project.net
 default_domain_name@production=production.sample_project.net
 default_product_line=teamname
+default_ami_available_wait_time=600
 
 [test]
 hostclass=mhcdiscointegrationtests
@@ -63,6 +64,7 @@ data_destination=/opt/wgen/discoaws
 ami_stages=untested failed tested
 prod_baker=jenkins
 phase=2
+ami_available_wait_time=600
 
 # account ids to promote tested AMIs to
 prod_account_ids=


### PR DESCRIPTION
@pchand-amplify 

so that we can specify how much time, in seconds, we should wait for an ami to become available after baking