### PR TITLE
Enable app hostclass specific test hostclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of Contents
   * [Route53](#route53)
   * [Chaos](#chaos)
   * [ElastiCache](#elasticache)
+  * [Testing a hostclass](#testing-hostclasses)
 
 
 History
@@ -1850,3 +1851,101 @@ Create/update the clusters in a environment from the `disco_elasticache.ini conf
 Delete a cache cluster
 
     disco_elasticache.py [--env ENV] delete --cluster CLUSTER
+
+Testing Hostclasses
+-------------------
+
+Asiaq supports two kinds of tests for a hostclass out of the box. There are *smoke tests* and *integration tests*. As a rule of thumb, smoke tests test if the hostclass is working internally. Integration tests test if the hostclass is able to interact with external services correctly. An example of a smoke test might be making sure that the apache service started correctly. An example of an integration test might be making sure that the hostclass can communicate with an external database.
+
+### Smoke Tests
+
+Asiaq always waits for smoke tests to run on a newly provision hostclass, unless explicitly told not to, either on the command line or in a pipeline file. Asiaq itself simply polls the instance until a ```smoketest``` tag is added with a value of ```tested```. In the sample configuration provided, that tag is added by ```sample_configuration/discoroot/etc/init.d/disco-booted``` upon the successful completion of ```sample_configuration/discoroot/opt/wgen/bin/smoketest.unit.sh```
+
+Smoke tests can be added very easily. Here's an example of some smoke tests being added as part of a hostclass' init script. This example uses some generic functions for verifying services and other things on the hostclass. You can see what these generic functions do at ```sample_configuration/discoroot/opt/wgen/bin/get_status.sh```.
+
+```bash
+# add hostclass specfic smoketest checks.
+# otherwise smoketest.unit.sh will run without specific check.
+cat << SMOKETEST_CONF > /opt/wgen/etc/smoketest.conf
+verify_init_status rsyslog 2 3 4 5
+is_service_running rsyslog
+
+verify_init_status httpd 2 3 4 5
+is_service_running httpd
+
+get_status localhost 80 foo
+
+check_root_disk_space
+SMOKETEST_CONF
+```
+
+As part of the sample configuration, smoke tests also run on a timer during the normal operation of the instance. If the smoke tests fail at that point, they will trigger a termination of the instance, and autoscaling will presumably bring up a new instance of the hostclass. This behavior is controlled by ```sample_configuration/discoroot/opt/wgen/bin/smokealarm.sh``` and triggered by ```sample_configuration/discoroot/etc/cron.d/internal_smoketest```.
+
+For debugging reasons, it might sometimes be useful to disable the termination of an instance due to smoketests failing. The easiest way to accomplish this is to SSH into the instance before it has been termianted, and disable execution of the ```/opt/wgen/bin/mark_unhealthy.sh``` script.
+
+### Integration Tests
+
+Asiaq only runs integration tests of a hostclass when that hostclass is being tested or updated, typically through the use of ```disco_deploy.py test``` or ```disco_deploy.py update```. In general, integration tests take the form of executing a script on a designated hostclass and either pass or fail depending on the exit code returned by the script. The test script is also passed an argument, typically used to denote what exact test should be run.
+
+
+#### Configuration
+
+Configuration of integration tests is spread across two places, ```disco_aws.ini``` and the pipeline file.
+
+##### disco_aws.ini
+
+There are three configuration options for integration tests in ```disco_aws.ini```.
+
+```ini
+test_hostclass=mhcfootest
+test_user=integration_tester
+test_command=/opt/asiaq/bin/run_tests.sh
+```
+
+* test_hostclass
+  * The hostclass to execute ```test_command``` on. Typically a hostclass dedicated to testing one or more other hostclasses. For example, mhcfootest would probably be a hostclass dedicated to testing the mhcfoo hostclass.
+* test_user
+  * The user to execute ```test_command``` as.
+* test_command
+  * The command to execute the tests on ```test_hostclass``` as the ```test_user```. Typically a shell script with some logic for handling the test argument that is passed to it. The exit code of this command determines whether or not the integration tests were successful.
+
+These options can be specified in two places in ```disco_aws.ini```, in the ```[test]``` section or in a given hostclass' section. Below is an example of specifying defaults in the ```[test]``` section and overriding them for the mhcfoo hostclass.
+
+```ini
+[test]
+test_hostclass=mhcgenerictester
+test_user=asiaq_tester
+test_command=/opt/asiaq/bin/run_tests.sh
+
+[mhcbar]
+...
+
+[mhcfoo]
+test_hostclass=mhcfootests
+```
+
+In this example, we set defaults in the ```[test]``` section for all hostclasses. Then ```[mhcfoo]``` overrides those defaults to specify a different test_hostclass for itself.
+
+
+##### Pipeline
+
+Integration tests are also configured in the pipeline file. As mentioned above, the ```test_command``` is passed an argument when run. This argument is defined in the pipeline file, under the ```integration_test``` entry in the pipeline. If the entry is empty, then no integration test will be run during ```disco_deploy.py test``` or ```disco_deploy.py update```. Instead, those commands will simply wait for the hostclass to pass its smoke tests and pass if those pass.
+
+Here's an example of a hostclass with integration tests and one without integration tests in the pipeline, using some of the example hostclasses from above:
+
+```csv
+sequence,hostclass,min_size,desired_size,max_size,instance_type,extra_disk,iops,smoke_test,integration_test,deployable
+1,mhcgenerictest,1,1,1,c4.large,,,no,,yes
+1,mhcfootest,1,1,1,c4.large,,,no,,yes
+1,mhcbar,2,2,2,m4.large,,,no,mhcbar_integration,yes
+1,mhcfoo,2,2,2,m4.large,,,no,mhcfoo_integration,yes
+1,mhcnointegrationtests,2,2,2,m4.large,,,no,,yes
+```
+
+In the above pipeline, mhcbar will be integration tested by passing ```mhcbar_integration``` as the argument to the ```test_command``` on the generic ```test_hostclass``` defined in our example ```disco_aws.ini``` above. In contrast, mhcfoo will be integration tested by passing ```mhcfoo_integration``` as the argument to the ```test_command``` on it's specially defined ```test_hostclass```. And because mhcnointegrationtests left the ```integration_test``` column empty, no integration tests will be run for it.
+
+### Execution
+
+Integration tests are typically run when the AMI of the hostclass is being tested or updated. The current workflow is that the existing instances of a hostclass are integration tested to ensure that if anything happens, Asiaq can rollback to *known-good* hosts. If those integration tests pass, Asiaq will spin up a new set of hostclasses with a ```is_testing``` with a value of ```1``` entry in their user-data. After those instances pass their smoke tests, Asiaq will run integration tests against them as well. If those tests pass, then the old instances are terminated and the new instances are setup to begin serving traffic from any ELBs that were created for the group, and their ```is_testing``` entry in their user-data is set to ```0```.
+
+This process is expected to be significantly changed as Asiaq adopts blue-green deployments.

--- a/bin/disco_deploy.py
+++ b/bin/disco_deploy.py
@@ -79,9 +79,6 @@ def run():
     deploy = DiscoDeploy(
         aws, test_aws, DiscoBake(config, aws.connection),
         pipeline_definition=pipeline_definition,
-        test_hostclass=aws.config('hostclass', 'test'),
-        test_user=aws.config('user', 'test'),
-        test_command=aws.config('command', 'test'),
         ami=args.get("--ami"), hostclass=args.get("--hostclass"),
         allow_any_hostclass=args["--allow-any-hostclass"])
 

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -35,10 +35,7 @@ class DiscoDeploy(object):
         :param allow_any_hostclass do not restrict to hostclasses in the pipeline definition
         :param config: Configuration object to use.
         '''
-        if config:
-            self._config = config
-        else:
-            self._config = read_config()
+        self._config = config or read_config()
 
         self._restrict_amis = [ami] if ami else None
         self._restrict_hostclass = hostclass
@@ -319,7 +316,7 @@ class DiscoDeploy(object):
         This method puts all AMIs not matching the passed in AMI into maintenance mode.
         If tests pass the old instances are left in maintenance mode, otherwise they are returned to normal.
         '''
-        hostclass = self._disco_bake.ami_hostclass(ami)
+        hostclass = DiscoBake.ami_hostclass(ami)
         self._set_maintenance_mode(hostclass, self._get_old_instances(ami.id), True)
         ret = self.run_integration_tests(ami)
         if not ret:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.66"
+__version__ = "1.0.67"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.64"
+__version__ = "1.0.65"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/sample_configuration/disco_aws.ini
+++ b/sample_configuration/disco_aws.ini
@@ -32,9 +32,9 @@ default_product_line=teamname
 default_ami_available_wait_time=600
 
 [test]
-hostclass=mhcdiscointegrationtests
-command=/opt/wgen/disco_integration_tests/bin/run_tests.sh
-user=disco_tester
+test_hostclass=mhcdiscointegrationtests
+test_command=/opt/wgen/disco_integration_tests/bin/run_tests.sh
+test_user=disco_tester
 
 [iam]
 saml_provider_name=

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -80,6 +80,7 @@ class DiscoDeployTests(TestCase):
         inst = create_autospec(boto.ec2.instance.Instance)
         inst.id = 'i-' + ''.join(random.choice("0123456789abcdef") for _ in range(8))
         inst.image_id = 'ami-' + ''.join(random.choice("0123456789abcdef") for _ in range(8))
+        inst.tags = {"hostclass": "hostclass_being_tested"}
         return inst
 
     def add_ami(self, name, stage, state=u'available'):
@@ -432,7 +433,7 @@ class DiscoDeployTests(TestCase):
     def test_set_maintenance_mode_on(self):
         '''_set_maintenance_mode makes expected remotecmd call'''
         self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(0, ""))
-        self._ci_deploy._set_maintenance_mode(instances=["i-1"], mode_on=True)
+        self._ci_deploy._set_maintenance_mode(hostclass="mhcfoo", instances=["i-1"], mode_on=True)
         self._ci_deploy._disco_aws.remotecmd.assert_called_with(
             "i-1", ["sudo", "/opt/wgen/bin/maintenance-mode.sh", "on"],
             user="test_user", nothrow=True)
@@ -441,7 +442,7 @@ class DiscoDeployTests(TestCase):
         '''_set_maintenance_mode handles errors'''
         self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(1, ""))
         self.assertRaises(MaintenanceModeError, self._ci_deploy._set_maintenance_mode,
-                          instances=["i-1"], mode_on=False)
+                          hostclass="foo", instances=["i-1"], mode_on=False)
         self._ci_deploy._disco_aws.remotecmd.assert_called_with(
             "i-1", ["sudo", "/opt/wgen/bin/maintenance-mode.sh", "off"],
             user="test_user", nothrow=True)


### PR DESCRIPTION
I'm not very pleased with how I'm handling the backwards compatibility for the [test] block, but I didn't want to have this be merged and break people's jobs. Suggestions on a better way to do it welcome. We can always remove the hoops I'm jumping through after we've had a chance to go around and make sure everyone's configs are updated.