### PR TITLE
Method name mismatch

### DIFF
--- a/disco_aws_automation/disco_sns.py
+++ b/disco_aws_automation/disco_sns.py
@@ -120,7 +120,7 @@ class DiscoSNS(object):
 
         topics_to_delete = DiscoSNS.get_topics_to_delete(existing_topics, desired_topics, env)
 
-        topics_to_delete_arn = [self.topic_arn_by_name(topic) for topic in topics_to_delete]
+        topics_to_delete_arn = [self.topic_arn_from_name(topic) for topic in topics_to_delete]
 
         subscriptions_to_delete = DiscoSNS.get_subscriptions_to_delete(existing_subscriptions_by_topic,
                                                                        desired_subscriptions_by_topic,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.63"
+__version__ = "1.0.64"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Update method name in disco_sns to `topic_arn_from_name` from `topic_arn_by_name` as it is not defined.
Traceback:
```python
File "disco_aws_automation/disco_sns.py", line 123, in update_sns_with_notifications
topics_to_delete_arn = [self.topic_arn_by_name(topic) for topic in topics_to_delete]
AttributeError: 'DiscoSNS' object has no attribute 'topic_arn_by_name'
```