### PR TITLE
Elasticache maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1831,7 +1831,7 @@ Options:
 -   `port` Port that Redis should be available on
 -   `parameter_group` The set of Redis parameters to use
 -   `num_nodes` Number of nodes in cache cluster
--   `maintenance_window` specifies the weekly time range (of atleast 1 hour) in UTC during which maintenance on the cache cluster is performed. Default maintenance window is from sun:1:00-sun:2:00. 
+-   `maintenance_window` specifies the weekly time range (of atleast 1 hour) in UTC during which maintenance on the cache cluster is performed. Default maintenance window is from sat:1:00-sat:2:00 EST or sat 05:00-06:00 UTC. 
 
 ElastiCache also depends on some configuration from `disco_aws.ini`
 

--- a/README.md
+++ b/README.md
@@ -1831,7 +1831,7 @@ Options:
 -   `port` Port that Redis should be available on
 -   `parameter_group` The set of Redis parameters to use
 -   `num_nodes` Number of nodes in cache cluster
--   `maintenance_window` Specifies the weekly time range during which maintenance on the cache cluster is performed. 
+-   `maintenance_window` Specifies the weekly time range (of atleast 1 hour) during which maintenance on the cache cluster is performed. 
 
 ElastiCache also depends on some configuration from `disco_aws.ini`
 

--- a/README.md
+++ b/README.md
@@ -1833,7 +1833,7 @@ The following configuration is available in `disco_elasticache.ini` to configure
     port=6379
     parameter_group=default.redis2.8
     num_nodes=2
-    maintenance_window=sun:5:00-sun:09:00
+    maintenance_window=sat:5:00-sat:06:00
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -1831,7 +1831,7 @@ Options:
 -   `port` Port that Redis should be available on
 -   `parameter_group` The set of Redis parameters to use
 -   `num_nodes` Number of nodes in cache cluster
--   `maintenance_window` Specifies the weekly time range (of atleast 1 hour) during which maintenance on the cache cluster is performed. 
+-   `maintenance_window` specifies the weekly time range (of atleast 1 hour) in UTC during which maintenance on the cache cluster is performed. Default maintenance window is from sun:1:00-sun:2:00. 
 
 ElastiCache also depends on some configuration from `disco_aws.ini`
 
@@ -1851,4 +1851,4 @@ Create/update the clusters in a environment from the `disco_elasticache.ini conf
 
 Delete a cache cluster
 
-    disco_elasticache.py [--env ENV] delete --cluster CLUSTER
+   disco_elasticache.py [--env ENV] delete --cluster CLUSTER

--- a/README.md
+++ b/README.md
@@ -1822,6 +1822,7 @@ The following configuration is available in `disco_elasticache.ini` to configure
     port=6379
     parameter_group=default.redis2.8
     num_nodes=2
+    maintenance_window=sun:5:00-sun:09:00
 
 Options:
 
@@ -1830,6 +1831,7 @@ Options:
 -   `port` Port that Redis should be available on
 -   `parameter_group` The set of Redis parameters to use
 -   `num_nodes` Number of nodes in cache cluster
+-   `maintenance_window` Specifies the weekly time range during which maintenance on the cache cluster is performed. 
 
 ElastiCache also depends on some configuration from `disco_aws.ini`
 

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -62,7 +62,7 @@ class DiscoElastiCache(object):
         if not self._get_subnet_group(meta_network):
             self._create_subnet_group(meta_network)
 
-        maintenance_window = self._get_option(cluster_name, 'maintenance_window')
+        maintenance_window = self._get_option(cluster_name, 'maintenance_window') or "sun:1:00-sun:2:00"
         engine_version = self._get_option(cluster_name, 'engine_version')
         instance_type = self._get_option(cluster_name, 'instance_type')
         parameter_group = self._get_option(cluster_name, 'parameter_group')
@@ -197,7 +197,7 @@ class DiscoElastiCache(object):
                                   not allowed for T1 and T2 instance types.
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
-            maintenance_window(string): specifies the weekly time range during which
+            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) during which
                                         maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -198,8 +198,8 @@ class DiscoElastiCache(object):
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
             maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
-                                         which maintenance on the cache cluster is performed. Default 
-                                         maintenance window is from sun:1:00-sun:2:00.
+                                        which maintenance on the cache cluster is performed. Default
+                                        maintenance window is from sun:1:00-sun:2:00.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         description = self._get_redis_description(cluster_name)
@@ -246,8 +246,8 @@ class DiscoElastiCache(object):
             apply_immediately (bool): True to immediately update the cluster
                                       False to schedule update at next cluster maintenance window or restart
             maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
-                                         which maintenance on the cache cluster is performed. Default 
-                                         maintenance window is from sun:1:00-sun:2:00.
+                                        which maintenance on the cache cluster is performed. Default
+                                        maintenance window is from sun:1:00-sun:2:00.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         cluster = self._get_redis_cluster(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -87,7 +87,8 @@ class DiscoElastiCache(object):
         cache_cluster = self._get_redis_cluster(cluster_name)
         if not cache_cluster:
             self._create_redis_cluster(cluster_name, engine_version, num_nodes, instance_type,
-                                       parameter_group, port, meta_network, auto_failover, domain_name, tags, maintenance_window)
+                                       parameter_group, port, meta_network, auto_failover, domain_name, tags,
+                                       maintenance_window)
         else:
             if cache_cluster['Status'] == 'available':
                 self._modify_redis_cluster(cluster_name, engine_version,
@@ -196,7 +197,8 @@ class DiscoElastiCache(object):
                                   not allowed for T1 and T2 instance types.
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
-            maintenance_window(string): specifies the weekly time range during which maintenance on the cache cluster is performed. 
+            maintenance_window(string): specifies the weekly time range during which
+                                        maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         description = self._get_redis_description(cluster_name)
@@ -230,8 +232,8 @@ class DiscoElastiCache(object):
             subdomain = self._get_subdomain(cluster_name, domain_name)
             self.route53.create_record(domain_name, subdomain, 'CNAME', address)
 
-    def _modify_redis_cluster(self, cluster_name, engine_version, parameter_group,
-                              auto_failover, domain_name, maintenance_window,apply_immediately=True):
+    def _modify_redis_cluster(self, cluster_name, engine_version, parameter_group, auto_failover,
+                              domain_name, maintenance_window, apply_immediately=True):
         """
         Modify an existing Redis replication group
         Args:
@@ -242,7 +244,8 @@ class DiscoElastiCache(object):
             domain_name (str): Hosted zone where to create subdomain for cluster
             apply_immediately (bool): True to immediately update the cluster
                                       False to schedule update at next cluster maintenance window or restart
-            maintenance_window(string): specifies the weekly time range during which maintenance on the cache cluster is performed. 
+            maintenance_window(string): specifies the weekly time range during which
+                                        maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         cluster = self._get_redis_cluster(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -21,9 +21,8 @@ class DiscoElastiCache(object):
     """
     A simple class to manage ElastiCache
 
-    Default Maintenence windown is set as sat 1:00am to 2:00am EST.
+    Default Maintenence windown is set as sat 5:00am to 6:00am.
     The Preferred Maintenance Window works on UTC.
-    The equivalent UTC time is 5:00am to 6:00am.
     """
 
     DEFAULT_MAINTENANCE_WINDOW = "sat:05:00-sat:06:00"

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -64,7 +64,7 @@ class DiscoElastiCache(object):
         Args:
             cluster_name (str): name of cluster
             maintenance_window(str): accept Preferred Maintenance Window value
-                                    or assigns defaul value.
+                                    or assigns default value.
         """
         meta_network = self._get_option(cluster_name, 'meta_network') or self.aws.get_default_meta_network()
         if not self._get_subnet_group(meta_network):
@@ -205,7 +205,7 @@ class DiscoElastiCache(object):
                                   not allowed for T1 and T2 instance types.
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
-            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
+            maintenance_window(string): specifies the weekly time range (of at least 1 hour) in UTC during
                                         which maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
@@ -252,7 +252,7 @@ class DiscoElastiCache(object):
             domain_name (str): Hosted zone where to create subdomain for cluster
             apply_immediately (bool): True to immediately update the cluster
                                       False to schedule update at next cluster maintenance window or restart
-            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
+            maintenance_window(string): specifies the weekly time range (of at least 1 hour) in UTC during
                                         which maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -58,9 +58,10 @@ class DiscoElastiCache(object):
         Args:
             cluster_name (str): name of cluster
             maintenance_window(str): accept Preferred Maintenance Window value
-                                    or assigns defaul value from sun:1:00-sun:2:00.
+                                    or assigns defaul value from sat:1:00-sat:2:00 EST 
+                                    which is sat 05:00 to 06:00 UTC.
         """
-        default_maintenance_window = "sat:5:00-sat:6:00"
+        default_maintenance_window = "sat:05:00-sat:06:00"
         meta_network = self._get_option(cluster_name, 'meta_network') or self.aws.get_default_meta_network()
         if not self._get_subnet_group(meta_network):
             self._create_subnet_group(meta_network)
@@ -87,7 +88,6 @@ class DiscoElastiCache(object):
             'Key': 'environment',
             'Value': self.vpc.environment_name
         }]
-
         cache_cluster = self._get_redis_cluster(cluster_name)
         if not cache_cluster:
             self._create_redis_cluster(cluster_name, engine_version, num_nodes, instance_type,

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -20,7 +20,13 @@ from .resource_helper import throttled_call
 class DiscoElastiCache(object):
     """
     A simple class to manage ElastiCache
+
+    Default Maintenence windown is set as sat 1:00am to 2:00am EST.
+    The Preferred Maintenance Window works on UTC.
+    The equivalent UTC time is 5:00am to 6:00am.
     """
+
+    DEFAULT_MAINTENANCE_WINDOW = "sat:05:00-sat:06:00"
 
     def __init__(self, vpc, config_file='disco_elasticache.ini', aws=None, route53=None):
         self.vpc = vpc
@@ -58,16 +64,14 @@ class DiscoElastiCache(object):
         Args:
             cluster_name (str): name of cluster
             maintenance_window(str): accept Preferred Maintenance Window value
-                                    or assigns defaul value from sat:1:00-sat:2:00 EST 
-                                    which is sat 05:00 to 06:00 UTC.
+                                    or assigns defaul value.
         """
-        default_maintenance_window = "sat:05:00-sat:06:00"
         meta_network = self._get_option(cluster_name, 'meta_network') or self.aws.get_default_meta_network()
         if not self._get_subnet_group(meta_network):
             self._create_subnet_group(meta_network)
 
         maintenance_window = self._get_option(cluster_name,
-                                              'maintenance_window') or default_maintenance_window
+                                              'maintenance_window') or self.DEFAULT_MAINTENANCE_WINDOW
         engine_version = self._get_option(cluster_name, 'engine_version')
         instance_type = self._get_option(cluster_name, 'instance_type')
         parameter_group = self._get_option(cluster_name, 'parameter_group')

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -57,12 +57,16 @@ class DiscoElastiCache(object):
         Modifying tags, number of nodes, instance type, engine type, and port is not supported
         Args:
             cluster_name (str): name of cluster
+            maintenance_window(str): accept Preferred Maintenance Window value
+                                    or assigns defaul value from sun:1:00-sun:2:00.
         """
+        default_maintenance_window = "sat:5:00-sat:6:00"
         meta_network = self._get_option(cluster_name, 'meta_network') or self.aws.get_default_meta_network()
         if not self._get_subnet_group(meta_network):
             self._create_subnet_group(meta_network)
 
-        maintenance_window = self._get_option(cluster_name, 'maintenance_window') or "sun:1:00-sun:2:00"
+        maintenance_window = self._get_option(cluster_name,
+                                              'maintenance_window') or default_maintenance_window
         engine_version = self._get_option(cluster_name, 'engine_version')
         instance_type = self._get_option(cluster_name, 'instance_type')
         parameter_group = self._get_option(cluster_name, 'parameter_group')
@@ -198,8 +202,7 @@ class DiscoElastiCache(object):
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
             maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
-                                        which maintenance on the cache cluster is performed. Default
-                                        maintenance window is from sun:1:00-sun:2:00.
+                                        which maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         description = self._get_redis_description(cluster_name)
@@ -246,8 +249,7 @@ class DiscoElastiCache(object):
             apply_immediately (bool): True to immediately update the cluster
                                       False to schedule update at next cluster maintenance window or restart
             maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
-                                        which maintenance on the cache cluster is performed. Default
-                                        maintenance window is from sun:1:00-sun:2:00.
+                                        which maintenance on the cache cluster is performed.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         cluster = self._get_redis_cluster(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -197,8 +197,9 @@ class DiscoElastiCache(object):
                                   not allowed for T1 and T2 instance types.
             domain_name (str): hosted zone id to use for Route53 domain name
             tags (List[dict]): list of tags to add to replication group
-            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) during which
-                                        maintenance on the cache cluster is performed.
+            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
+                                         which maintenance on the cache cluster is performed. Default 
+                                         maintenance window is from sun:1:00-sun:2:00.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         description = self._get_redis_description(cluster_name)
@@ -244,8 +245,9 @@ class DiscoElastiCache(object):
             domain_name (str): Hosted zone where to create subdomain for cluster
             apply_immediately (bool): True to immediately update the cluster
                                       False to schedule update at next cluster maintenance window or restart
-            maintenance_window(string): specifies the weekly time range during which
-                                        maintenance on the cache cluster is performed.
+            maintenance_window(string): specifies the weekly time range (of atleast 1 hour) in UTC during
+                                         which maintenance on the cache cluster is performed. Default 
+                                         maintenance window is from sun:1:00-sun:2:00.
         """
         replication_group_id = self._get_redis_replication_group_id(cluster_name)
         cluster = self._get_redis_cluster(cluster_name)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -171,7 +171,7 @@ class DiscoElastiCache(object):
 
     # too many arguments and local variables for pylint
     # pylint: disable=R0913, R0914
-    def  _create_redis_cluster(self, cluster_name, engine_version, num_nodes, instance_type,
+    def _create_redis_cluster(self, cluster_name, engine_version, num_nodes, instance_type,
                               parameter_group,
                               port, meta_network_name, auto_failover, domain_name, tags, maintenance_window):
         """

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.63"
+__version__ = "1.0.64"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.64"
+__version__ = "1.0.65"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -74,7 +74,7 @@ class DiscoElastiCacheTests(TestCase):
                 'port': '1000',
                 'parameter_group': 'default',
                 'num_nodes': '5',
-                'auto_failover': 'true'
+                'auto_failover': 'true',
                 'maintenance_window':'sat:05:00-sat:09:00'
             }
         }))
@@ -179,7 +179,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
-            PreferredMaintenanceWindow= 'sun:10:00-sun:11:00'
+            PreferredMaintenanceWindow= 'sun:10:00-sun:11:00',
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},
@@ -200,7 +200,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
-            PreferredMaintenanceWindow= 'sun:10:00-sun:12:00'
+            PreferredMaintenanceWindow= 'sun:10:00-sun:12:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 
@@ -220,7 +220,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
-            PreferredMaintenanceWindow= 'sun:11:00-sun:12:00'
+            PreferredMaintenanceWindow= 'sun:11:00-sun:12:00',
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -65,7 +65,7 @@ class DiscoElastiCacheTests(TestCase):
                 'parameter_group': 'default',
                 'num_nodes': '5',
                 'auto_failover': 'true',
-                'maintenance_window':'sun:05:00-sun:09:00'
+                'maintenance_window': 'sun:10:00-sun:11:00'
             },
             'unittest:old-cache': {
                 'instance_type': 'cache.m1.small',
@@ -75,7 +75,7 @@ class DiscoElastiCacheTests(TestCase):
                 'parameter_group': 'default',
                 'num_nodes': '5',
                 'auto_failover': 'true',
-                'maintenance_window':'sat:05:00-sat:09:00'
+                'maintenance_window': 'sat:10:00-sat:12:00'
             }
         }))
 
@@ -179,7 +179,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
-            PreferredMaintenanceWindow= 'sun:10:00-sun:11:00',
+            PreferredMaintenanceWindow='sun:10:00-sun:11:00',
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},
@@ -200,7 +200,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
-            PreferredMaintenanceWindow= 'sun:10:00-sun:12:00',
+            PreferredMaintenanceWindow='sat:10:00-sat:12:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 
@@ -220,7 +220,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
-            PreferredMaintenanceWindow= 'sun:11:00-sun:12:00',
+            PreferredMaintenanceWindow='sun:10:00-sun:11:00',
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},
@@ -232,6 +232,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
+            PreferredMaintenanceWindow='sat:10:00-sat:12:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -64,7 +64,8 @@ class DiscoElastiCacheTests(TestCase):
                 'port': '1000',
                 'parameter_group': 'default',
                 'num_nodes': '5',
-                'auto_failover': 'true'
+                'auto_failover': 'true',
+                'maintenance_window':'sun:05:00-sun:09:00'
             },
             'unittest:old-cache': {
                 'instance_type': 'cache.m1.small',
@@ -74,6 +75,7 @@ class DiscoElastiCacheTests(TestCase):
                 'parameter_group': 'default',
                 'num_nodes': '5',
                 'auto_failover': 'true'
+                'maintenance_window':'sat:05:00-sat:09:00'
             }
         }))
 
@@ -177,6 +179,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
+            PreferredMaintenanceWindow= 'sun:10:00-sun:11:00'
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},
@@ -197,6 +200,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
+            PreferredMaintenanceWindow= 'sun:10:00-sun:12:00'
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 
@@ -216,6 +220,7 @@ class DiscoElastiCacheTests(TestCase):
             ReplicationGroupDescription='unittest-new-cache',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('new-cache'),
             SecurityGroupIds=['fake_security'],
+            PreferredMaintenanceWindow= 'sun:11:00-sun:12:00'
             Tags=[{'Key': 'product_line', 'Value': 'example_team'},
                   {'Key': 'owner', 'Value': MatchAnything()},
                   {'Key': 'name', 'Value': 'new-cache'},

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -198,7 +198,6 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
-            """Default maintenance window is Saturday 5:00am to 6:00am"""
             PreferredMaintenanceWindow='sat:05:00-sat:06:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -198,6 +198,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
+            """Default maintenance window is Saturday 5:00am to 6:00am"""
             PreferredMaintenanceWindow='sat:05:00-sat:06:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -74,11 +74,9 @@ class DiscoElastiCacheTests(TestCase):
                 'port': '1000',
                 'parameter_group': 'default',
                 'num_nodes': '5',
-                'auto_failover': 'true',
-                'maintenance_window': 'sat:10:00-sat:12:00'
+                'auto_failover': 'true'
             }
         }))
-
         self.elasticache.conn = MagicMock()
 
         self.replication_groups = [
@@ -200,7 +198,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
-            PreferredMaintenanceWindow='sat:10:00-sat:12:00',
+            PreferredMaintenanceWindow='sat:05:00-sat:06:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 
@@ -232,7 +230,7 @@ class DiscoElastiCacheTests(TestCase):
             AutomaticFailoverEnabled=True,
             CacheParameterGroupName='default',
             EngineVersion='2.8.6',
-            PreferredMaintenanceWindow='sat:10:00-sat:12:00',
+            PreferredMaintenanceWindow='sat:05:00-sat:06:00',
             ReplicationGroupId=self.elasticache._get_redis_replication_group_id('old-cache')
         )
 


### PR DESCRIPTION
Elasticache will now take the preferred maintenance window given in the config file and implement it for the corresponding cache cluster on update.