### PR TITLE
fix baking

### DIFF
--- a/disco_aws_automation/disco_remote_exec.py
+++ b/disco_aws_automation/disco_remote_exec.py
@@ -88,7 +88,7 @@ class DiscoRemoteExec(object):
         """
         is_reachable = DiscoRemoteExec._is_reachable(address)
 
-        if not is_reachable and not jump_address:
+        if not is_reachable and not jump_address and not nothrow:
             raise CommandError('Unable to run command {0}. {1} host is not reachable'
                                .format(remote_command, address))
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.67"
+__version__ = "1.0.68"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Do not throw an error if the host is unreachable for `disco_remote_exec` but `nothrow` is `True`

Accidentally broke baking with https://github.com/amplifylitco/asiaq/pull/22