### PR TITLE
Swallow proxy exception from requests

### DIFF
--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -41,6 +41,6 @@ class DiscoACM(object):
             certs = self.acm.list_certificates()["CertificateSummaryList"]
             cert = [cert['CertificateArn'] for cert in certs if cert['DomainName'] == dns_name]
             return cert[0] if cert else None
-        except botocore.exceptions.EndpointConnectionError:
+        except (botocore.exceptions.EndpointConnectionError, botocore.vendored.requests.exceptions.ConnectionError):
             # some versions of botocore(1.3.26) will try to connect to acm even if outside us-east-1
             return None

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -41,6 +41,7 @@ class DiscoACM(object):
             certs = self.acm.list_certificates()["CertificateSummaryList"]
             cert = [cert['CertificateArn'] for cert in certs if cert['DomainName'] == dns_name]
             return cert[0] if cert else None
-        except (botocore.exceptions.EndpointConnectionError, botocore.vendored.requests.exceptions.ConnectionError):
+        except (botocore.exceptions.EndpointConnectionError,
+                botocore.vendored.requests.exceptions.ConnectionError):
             # some versions of botocore(1.3.26) will try to connect to acm even if outside us-east-1
             return None

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.70"
+__version__ = "1.0.71"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
botocore.vendored.requests.exceptions.ConnectionError is thrown if the requests library that boto uses has an exception rather than the botocore libraries themselves. Swallow both to avoid a problem where we can't reach ACM due to proxy or some other issue.