### PR TITLE
Rebooting the instance during spinup,

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -275,7 +275,7 @@ class DiscoRDS(object):
                     self.client.reboot_db_instance,
                     DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
                     ForceFailover=False
-                    )
+                   )
 
     def get_db_instances(self, status=None):
         """

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -274,8 +274,7 @@ class DiscoRDS(object):
         keep_trying(RDS_STATE_POLL_INTERVAL,
                     self.client.reboot_db_instance,
                     DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
-                    ForceFailover=False
-                   )
+                    ForceFailover=False)
 
     def get_db_instances(self, status=None):
         """

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -270,6 +270,12 @@ class DiscoRDS(object):
             "Engine", "LicenseModel", "DBSubnetGroupName", "PubliclyAccessible",
             "MasterUsername", "Port", "CharacterSetName", "StorageEncrypted"])
         self.client.modify_db_instance(ApplyImmediately=apply_immediately, **params)
+        logging.info("Rebooting cluster to apply Param group %s", instance_params["DBInstanceIdentifier"])
+        keep_trying(RDS_STATE_POLL_INTERVAL,
+                    self.client.reboot_db_instance,
+                    DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
+                    ForceFailover=False
+                    )
 
     def get_db_instances(self, status=None):
         """

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.71"
+__version__ = "1.0.72"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
 so the parameter group is applied. This fixes all the performance issues we've been seeing in CI-txdb