### PR TITLE
Handle certificates more safely with ELB creation

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -40,8 +40,16 @@ class DiscoELB(object):
         return self._elb_client
 
     def get_certificate_arn(self, dns_name):
-        """Returns a Certificate from ACM if available with fallback to the legacy IAM server certs"""
-        return self.acm.get_certificate_arn(dns_name) or self.iam.get_certificate_arn(dns_name)
+        """
+        Returns a Certificate from ACM if available with fallback to the legacy IAM server certs
+
+        If no certificate is found from either ACM or IAM, returns None.
+        """
+        try:
+            return self.acm.get_certificate_arn(dns_name) or self.iam.get_certificate_arn(dns_name)
+        except Exception:
+            logging.info("Unable to find a SSL certificate for DNS entry %s", dns_name)
+            return None
 
     def list(self):
         """Returns all of the ELBs for the current environment"""
@@ -122,9 +130,12 @@ class DiscoELB(object):
                 'Protocol': elb_protocol,
                 'LoadBalancerPort': elb_port,
                 'InstanceProtocol': instance_protocol,
-                'InstancePort': instance_port,
-                'SSLCertificateId': self.get_certificate_arn(cname) or ''
+                'InstancePort': instance_port
             }
+
+            # Only try to lookup a cert if we are using a secure protocol for the ELB
+            if elb_protocol.upper() in ["HTTPS", "SSL"]:
+                listener['SSLCertificateId'] = self.get_certificate_arn(cname) or ''
 
             elb_args = {
                 'LoadBalancerName': elb_name,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.75"
+__version__ = "1.0.76"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -8,6 +8,8 @@ TEST_ENV_NAME = 'unittestenv'
 TEST_HOSTCLASS = 'mhcunit'
 TEST_VPC_ID = 'vpc-56e10e3d'  # the hard coded VPC Id that moto will always return
 TEST_DOMAIN_NAME = 'test.example.com'
+TEST_CERTIFICATE_ARN_ACM = "arn:aws:acm::123:blah"
+TEST_CERTIFICATE_ARN_IAM = "arn:aws:acm::123:blah"
 
 
 def _get_vpc_mock():
@@ -23,8 +25,8 @@ class DiscoELBTests(TestCase):
 
     def setUp(self):
         self.disco_elb = DiscoELB(_get_vpc_mock(), route53=MagicMock(), acm=MagicMock(), iam=MagicMock())
-        self.disco_elb.acm.get_certificate_arn = MagicMock(return_value="arn:aws:acm::123:blah")
-        self.disco_elb.iam.get_certificate_arn = MagicMock(return_value="arn:aws:iam::123:blah")
+        self.disco_elb.acm.get_certificate_arn = MagicMock(return_value=TEST_CERTIFICATE_ARN_ACM)
+        self.disco_elb.iam.get_certificate_arn = MagicMock(return_value=TEST_CERTIFICATE_ARN_IAM)
 
     # pylint: disable=too-many-arguments
     def _create_elb(self, hostclass=None, public=False, tls=False,
@@ -50,13 +52,13 @@ class DiscoELBTests(TestCase):
     @mock_elb
     def test_get_certificate_arn_prefers_acm(self):
         '''get_certificate_arn() prefers an ACM provided certificate'''
-        self.assertEqual(self.disco_elb.get_certificate_arn("dummy"), "arn:aws:acm::123:blah")
+        self.assertEqual(self.disco_elb.get_certificate_arn("dummy"), TEST_CERTIFICATE_ARN_ACM)
 
     @mock_elb
     def test_get_certificate_arn_fallback_to_iam(self):
         '''get_certificate_arn() uses an IAM certificate if no ACM cert available'''
         self.disco_elb.acm.get_certificate_arn = MagicMock(return_value=None)
-        self.assertEqual(self.disco_elb.get_certificate_arn("dummy"), "arn:aws:iam::123:blah")
+        self.assertEqual(self.disco_elb.get_certificate_arn("dummy"), TEST_CERTIFICATE_ARN_IAM)
 
     @mock_elb
     def test_get_cname(self):
@@ -91,8 +93,7 @@ class DiscoELBTests(TestCase):
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
                 'InstanceProtocol': 'HTTP',
-                'InstancePort': 80,
-                'SSLCertificateId': 'arn:aws:acm::123:blah'
+                'InstancePort': 80
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
@@ -112,8 +113,7 @@ class DiscoELBTests(TestCase):
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
                 'InstanceProtocol': 'HTTP',
-                'InstancePort': 80,
-                'SSLCertificateId': ''
+                'InstancePort': 80
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
@@ -131,8 +131,7 @@ class DiscoELBTests(TestCase):
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
                 'InstanceProtocol': 'HTTP',
-                'InstancePort': 80,
-                'SSLCertificateId': 'arn:aws:acm::123:blah'
+                'InstancePort': 80
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'])
@@ -150,7 +149,7 @@ class DiscoELBTests(TestCase):
                 'LoadBalancerPort': 443,
                 'InstanceProtocol': 'HTTP',
                 'InstancePort': 80,
-                'SSLCertificateId': 'arn:aws:acm::123:blah'
+                'SSLCertificateId': TEST_CERTIFICATE_ARN_ACM
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
@@ -169,8 +168,7 @@ class DiscoELBTests(TestCase):
                 'Protocol': 'TCP',
                 'LoadBalancerPort': 25,
                 'InstanceProtocol': 'TCP',
-                'InstancePort': 25,
-                'SSLCertificateId': 'arn:aws:acm::123:blah'
+                'InstancePort': 25
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],


### PR DESCRIPTION
If there are any exceptions when we try to get a certificate for an ELB, swallow them and log a warning message. ELB creation will still fail if we actually needed a certificate, but this will cut down on false-positives and make debugging the issue more straightforward.

Additionally, only try to get a certificate if the ELB protocol will be secure. No reason to try to get a certificate for the ELB if it will not be needed.