### PR TITLE
moto version <= 0.4.23

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.77"
+__version__ = "1.0.78"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,5 +8,6 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-moto>=0.4.10,<1
+# moto 0.4.24 is breaking our unit tests
+moto>=0.4.10,<=0.4.23
 six>=1.7.3


### PR DESCRIPTION
Making sure moto version doesn't go pass 0.4.23 because 0.4.24 apparently is breaking our unit tests.