### PR TITLE
Add clone command to disco_rds.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of Contents
   * [Chaos](#chaos)
   * [ElastiCache](#elasticache)
   * [Elasticsearch](#elasticsearch)
+  * [RDS](#rds)
   * [Testing a hostclass](#testing-hostclasses)
 
 
@@ -1842,7 +1843,7 @@ List cache clusters from ElastiCache
 
     disco_elasticache.py [--env ENV] list
 
-Create/update the clusters in a environment from the `disco_elasticache.ini config
+Create/update the clusters in a environment from the `disco_elasticache.ini` config
 
     disco_elasticache.py [--env ENV] update [--cluster CLUSTER]
 
@@ -1925,6 +1926,59 @@ The CNAME provided by Route 53 can also be used:
 `https://es-logger-foo.aws.example.com/_plugin/kibana/`
 
 NOTE: When using CNAME, certificate will show as invalid because it was issued for *.us-west-2.es.amazonaws.com.
+
+RDS
+-------------------
+
+RDS provides databases as a service. Creating a new database instances with Asiaq involves
+editing the `disco_rds.ini` config file and running `disco_rds.py`. Route53 CNAMEs are automatically created for each RDS instance
+
+
+### Configuration
+The following configuration is available for RDS. A section is needed for each RDS instance in every VPC. The section names are formatted as `[VPC Name]-[Database Name]`
+
+    [ci-foodb]
+    allocated_storage=100
+    db_instance_class=db.m4.2xlarge
+    engine=oracle-se2
+    engine_version=12.1.0.2.v2
+    iops=1000
+    master_username=masteruser
+    port=1521
+    storage_encrypted=True
+    multi_az=True
+Options:
+
+-   `allocated_storage` Database size in GB
+-   `db_instance_class` The instance type to use for database instances
+-   `engine` The type of database such as Oracle or Postgres
+-   `engine_version` The database version to use
+-   `iops` Provisioned IOPS 
+-   `master_username` Master username for connecting to the database
+-   `port` [Default 5432 for Postgres, 1521 for Oracle]
+-   `storage_encrypted` [Default True]
+-   `multi_az` [Default True]
+
+### Commands for managing RDS
+List RDS instances for an environment. Optionally display database URL.
+
+    disco_rds.py list [--env ENV] [--url]
+
+Create/update the RDS clusters in a environment from the `disco_rds.ini` config. Updates all RDS clusters in an environment by default or optionally specify a cluster to update.
+
+    disco_rds.py update [--env ENV] [--cluster CLUSTER]
+    
+Delete a RDS cluster.
+
+    disco_rds.py delete [--env ENV] [--cluster CLUSTER] [--skip-final-snapshot]
+    
+Delete old database snapshots.
+
+    disco_rds.py cleanup_snapshots [--env ENV] [--age DAYS]
+    
+Clone a database from a different environment into the current environment. The new database will copy all configuration options from the source database and use the most recent database snapshot from source database.
+
+    disco_rds.py clone [--env ENV] --source-db SOURCE_DB --source-env SOURCE_ENV
 
 Testing Hostclasses
 -------------------

--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -45,7 +45,8 @@ def get_parser():
     parser_delete.set_defaults(mode="delete")
     parser_delete.add_argument("--env", dest="env", required=False, default=None,
                                help="The environment containing the RDS cluster")
-    parser_delete.add_argument("--cluster", dest="cluster", required=True, help="Cluster to delete")
+    parser_delete.add_argument("--cluster", dest="cluster", required=True,
+                               help="Cluster name (RDS Database Instance Identifier) to delete")
     parser_delete.add_argument("--skip-final-snapshot", dest="skip_final_snapshot", action='store_const',
                                const=True, default=False, help="Do not take final snapshot. Drops all data!")
 
@@ -62,7 +63,9 @@ def get_parser():
     parser_clone.add_argument('--env', dest='env', required=False, default=None,
                               help='The environment containing the RDS cluster(s)')
     parser_clone.add_argument('--source-db', dest='source_db', required=True,
-                              help='Database identifier of the database to clone', type=str)
+                              help='Name of the database to clone', type=str)
+    parser_clone.add_argument('--source-env', dest='source_env', required=True,
+                              help='Name of environment of source database', type=str)
     return parser
 
 
@@ -101,7 +104,7 @@ def run():
     elif args.mode == "cleanup_snapshots":
         rds.cleanup_snapshots(args.days)
     elif args.mode == "clone":
-        rds.clone(args.source_db)
+        rds.clone(args.source_env, args.source_db)
 
 
 if __name__ == "__main__":

--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -55,6 +55,14 @@ def get_parser():
     parser_cleanup_snapshots.set_defaults(mode="cleanup_snapshots")
     parser_cleanup_snapshots.add_argument('--age', dest='days', required=False,
                                           help='Minimum age of Snapshots to expire', type=int, default=30)
+
+    # clone Mode
+    parser_clone = subparsers.add_parser("clone", help="Create a new database from an existing database")
+    parser_clone.set_defaults(mode="clone")
+    parser_clone.add_argument('--env', dest='env', required=False, default=None,
+                              help='The environment containing the RDS cluster(s)')
+    parser_clone.add_argument('--source-db', dest='source_db', required=True,
+                              help='Database identifier of the database to clone', type=str)
     return parser
 
 
@@ -90,8 +98,10 @@ def run():
             rds.update_all_clusters_in_vpc()
     elif args.mode == "delete":
         rds.delete_db_instance(args.cluster, skip_final_snapshot=args.skip_final_snapshot)
-    elif args.mode == 'cleanup_snapshots':
+    elif args.mode == "cleanup_snapshots":
         rds.cleanup_snapshots(args.days)
+    elif args.mode == "clone":
+        rds.clone(args.source_db)
 
 
 if __name__ == "__main__":

--- a/disco_aws_automation/disco_creds.py
+++ b/disco_aws_automation/disco_creds.py
@@ -44,6 +44,10 @@ class DiscoS3Bucket(object):
         else:
             raise KeyError("%s does not exist in bucket %s" % (key_name, self.bucket.name))
 
+    def key_exists(self, key_name):
+        '''Returns True if a key exists in the bucket'''
+        return self.bucket.get_key(key_name)
+
     def load_config(self, key):
         """Deserializes ConfigParser from the contents of the specified key's value"""
         config = ConfigParser()

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -481,18 +481,18 @@ class DiscoRDS(object):
         except botocore.exceptions.ClientError:
             return None
 
-    def clone(self, env_name, database_name):
+    def clone(self, source_vpc, source_db):
         """
         Spinup a copy of a given database into the current environment
 
         Args:
-            env_name (str): the VPC where the source database is located
-            database_name (str): the source database name
+            source_vpc (str): the VPC where the source database is located
+            source_db (str): the source database name
         """
-        source_db_identifier = self._get_instance_identifier(env_name, database_name)
-        clone_db_identifier = self._get_instance_identifier(self.vpc_name, database_name)
+        source_db_identifier = self._get_instance_identifier(source_vpc, source_db)
+        clone_db_identifier = self._get_instance_identifier(self.vpc_name, source_db)
 
-        instance_params = self.get_instance_parameters(env_name, database_name)
+        instance_params = self.get_instance_parameters(source_vpc, source_db)
 
         if self._get_db_instance(clone_db_identifier):
             raise RDSEnvironmentError(
@@ -510,7 +510,7 @@ class DiscoRDS(object):
                                 custom_snapshot=self.get_final_snapshot(source_db_identifier))
 
         # Create/Update CloudWatch Alarms for this instance
-        self.spinup_alarms(database_name)
+        self.spinup_alarms(source_db)
 
         # Create a DNS record for this instance
         self.setup_dns(clone_db_identifier)

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -79,7 +79,7 @@ class DiscoRDS(object):
         """Read the RDS config file and extract the boolean value, or return default if missing"""
         return is_truthy(self.config_with_default(section, param, default))
 
-    def get_master_password(self, instance_identifier):
+    def get_master_password(self, env_name, database_name):
         """
         Get the Master Password for instance stored in the S3 bucket
         """
@@ -87,17 +87,17 @@ class DiscoRDS(object):
 
         try:
             # for backwards compatibility check the old style keys containing the env name
+            instance_identifier = self._get_instance_identifier(env_name, database_name)
             s3_password_key = 'rds/{0}/master_user_password'.format(instance_identifier)
             return DiscoS3Bucket(bucket_name).get_key(s3_password_key)
         except KeyError:
-            # get the name portion of the instance identifier without the env name
-            database_class = self._get_database_class(instance_identifier)
-            s3_password_key = 'rds/{0}/master_user_password'.format(database_class)
+            # if a key doesn't exist for the database identifier then try the database name
+            s3_password_key = 'rds/{0}/master_user_password'.format(database_name)
             return DiscoS3Bucket(bucket_name).get_key(s3_password_key)
 
-    def get_instance_parameters(self, instance_identifier):
+    def get_instance_parameters(self, env_name, database_name):
         """Read the config file and extract the Instance related parameters"""
-        section = instance_identifier
+        section = instance_identifier = self._get_instance_identifier(env_name, database_name)
         db_engine = self.config_rds.get(section, 'engine')
         engine_family = db_engine.split('-')[0]
         default_license = DEFAULT_LICENSE.get(engine_family)
@@ -115,7 +115,7 @@ class DiscoRDS(object):
             'EngineVersion': self.config_rds.get(section, 'engine_version'),
             'Iops': self.config_integer(section, 'iops', 0),
             'LicenseModel': self.config_with_default(section, 'license_model', default_license),
-            'MasterUserPassword': self.get_master_password(instance_identifier),
+            'MasterUserPassword': self.get_master_password(env_name, database_name),
             'MasterUsername': self.config_rds.get(section, 'master_username'),
             'MultiAZ': self.config_truthy(section, 'multi_az'),
             'Port': self.config_integer(section, 'port', default_port),
@@ -133,12 +133,12 @@ class DiscoRDS(object):
         intranet = [sg for sg in security_groups if sg.tags and sg.tags.get("meta_network") == "intranet"][0]
         return intranet.id
 
-    def update_cluster(self, instance_identifier):
+    def update_cluster(self, database_name):
         """
         Run the RDS Cluster update
         """
-        instance_params = self.get_instance_parameters(instance_identifier)
-        database_class = self._get_database_class(instance_identifier)
+        instance_identifier = self._get_instance_identifier(self.vpc_name, database_name)
+        instance_params = self.get_instance_parameters(self.vpc_name, database_name)
 
         if self._get_db_instance(instance_identifier):
             self.modify_db_instance(instance_params)
@@ -149,11 +149,11 @@ class DiscoRDS(object):
             group_family = self.get_db_parameter_group_family(
                 instance_params["Engine"], instance_params["EngineVersion"])
             logging.debug("creating parameter group %s with family %s", group_name, group_family)
-            self.recreate_db_parameter_group(database_class, group_name, group_family)
+            self.recreate_db_parameter_group(database_name, group_name, group_family)
             self.create_db_instance(instance_params)
 
         # Create/Update CloudWatch Alarms for this instance
-        self.spinup_alarms(database_class)
+        self.spinup_alarms(database_name)
 
         # Create a DNS record for this instance
         self.setup_dns(instance_identifier)
@@ -179,14 +179,14 @@ class DiscoRDS(object):
         disco_route53.delete_record(self.domain_name, instance_record_name, 'CNAME')
         disco_route53.create_record(self.domain_name, instance_record_name, 'CNAME', instance_endpoint)
 
-    def spinup_alarms(self, database_class):
+    def spinup_alarms(self, database_name):
         """
         Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
         """
         logging.debug("Configuring Cloudwatch alarms ")
         disco_alarm_config = DiscoAlarmsConfig(self.vpc_name)
         disco_alarm = DiscoAlarm()
-        instance_alarms = disco_alarm_config.get_alarms(database_class)
+        instance_alarms = disco_alarm_config.get_alarms(database_name)
         disco_alarm.create_alarms(instance_alarms)
 
     def update_all_clusters_in_vpc(self):
@@ -194,10 +194,12 @@ class DiscoRDS(object):
         Updates every RDS instance in the current VPC to match the configuration
         """
         sections = [section for section in self.config_rds.sections()
-                    if section.split("-")[0] == self.vpc_name]
+                    if section.startswith(self.vpc_name) + '-']
         logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
         for section in sections:
-            self.update_cluster(section)
+            # the section names are database identifiers
+            database_identifier = section
+            self.update_cluster(self._get_database_name(self.vpc_name, database_identifier))
 
     def recreate_db_subnet_group(self, db_subnet_group_name):
         """
@@ -361,7 +363,7 @@ class DiscoRDS(object):
         if instances_in_bad_state:
             raise RDSEnvironmentError("Cowardly refusing to delete the following RDS clusters because their"
                                       " state does not allow for a snapshot to be taken: {}".format(
-                ", ".join(instances_in_bad_state)))
+                                          ", ".join(instances_in_bad_state)))
 
         for instance in instances:
             self.delete_db_instance(instance["DBInstanceIdentifier"])
@@ -404,7 +406,7 @@ class DiscoRDS(object):
                                                                'MinimumEngineVersion': 'someversion',
                                                                'ApplyMethod': 'pending-reboot'}])
 
-    def recreate_db_parameter_group(self, database_class, db_parameter_group_name,
+    def recreate_db_parameter_group(self, database_name, db_parameter_group_name,
                                     db_parameter_group_family):
         """
         Check if there are any custom parameters for this instance
@@ -422,7 +424,7 @@ class DiscoRDS(object):
         # Extract the Custom Values from the config file
         custom_param_file = os.path.join(ASIAQ_CONFIG,
                                          'rds', 'engine_specific',
-                                         '{0}.ini'.format(database_class))
+                                         '{0}.ini'.format(database_name))
 
         if os.path.isfile(custom_param_file):
             custom_config = ConfigParser()
@@ -465,8 +467,12 @@ class DiscoRDS(object):
                 logging.info("Deleting Snapshot %s since its older than %d", snapshot_id, days)
                 self.client.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
 
-    def _get_database_class(self, instance_identifier):
-        return instance_identifier.split('-', 1)[1]
+    def _get_instance_identifier(self, env_name, database_name):
+        return env_name + '-' + database_name
+
+    def _get_database_name(self, env_name, instance_identifier):
+        identifier_prefix = len(env_name + '-')
+        return instance_identifier[identifier_prefix:]
 
     def _get_db_instance(self, instance_identifier):
         try:
@@ -474,29 +480,36 @@ class DiscoRDS(object):
         except botocore.exceptions.ClientError:
             return None
 
-    def clone(self, source_db_identifier):
-        """Clone a database"""
-        instance_params = self.get_instance_parameters(source_db_identifier)
-        database_class = self._get_database_class(source_db_identifier)
+    def clone(self, env_name, database_name):
+        """
+        Spinup a copy of a given database into the current environment
 
-        clone_db_identifier = self.vpc_name + '-' + database_class
+        Args:
+            env_name (str): the VPC where the source database is located
+            database_name (str): the source database name
+        """
+        source_db_identifier = self._get_instance_identifier(env_name, database_name)
+        clone_db_identifier = self._get_instance_identifier(self.vpc_name, database_name)
+
+        instance_params = self.get_instance_parameters(env_name, database_name)
 
         if self._get_db_instance(clone_db_identifier):
             raise RDSEnvironmentError(
-                'Cannot create clone instance %s because a database already exists with that name'
+                'Cannot create clone instance {0} because a database already exists with that name'
                 .format(clone_db_identifier)
             )
-        else:
-            instance_params['DBInstanceIdentifier'] = clone_db_identifier
-            instance_params['DBSubnetGroupName'] = clone_db_identifier
 
-            self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
+        # override some parameters to use the new instance id
+        instance_params['DBInstanceIdentifier'] = clone_db_identifier
+        instance_params['DBSubnetGroupName'] = clone_db_identifier
 
-            self.create_db_instance(instance_params,
-                                    custom_snapshot=self.get_final_snapshot(source_db_identifier))
+        self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
 
-            # Create/Update CloudWatch Alarms for this instance
-            self.spinup_alarms(database_class)
+        self.create_db_instance(instance_params,
+                                custom_snapshot=self.get_final_snapshot(source_db_identifier))
 
-            # Create a DNS record for this instance
-            self.setup_dns(clone_db_identifier)
+        # Create/Update CloudWatch Alarms for this instance
+        self.spinup_alarms(database_name)
+
+        # Create a DNS record for this instance
+        self.setup_dns(clone_db_identifier)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.79"
+__version__ = "1.0.80"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.78"
+__version__ = "1.0.79"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -2,9 +2,12 @@
 Tests of disco_rds
 """
 import unittest
+
 from mock import MagicMock, patch
 
 from disco_aws_automation.disco_rds import DiscoRDS
+from disco_aws_automation.exceptions import RDSEnvironmentError
+from test.helpers.patch_disco_aws import get_mock_config
 
 TEST_ENV_NAME = 'unittestenv'
 TEST_VPC_ID = 'vpc-56e10e3d'  # the hard coded VPC Id that moto will always return
@@ -19,32 +22,96 @@ def _get_vpc_mock():
     return vpc_mock
 
 
+def _get_key_mock(key_name):
+    if key_name == 'rds/db-name/master_user_password':
+        return 'database_name_key'
+    elif key_name == 'rds/unittestenv-db-id/master_user_password':
+        return 'database-id-key'
+    else:
+        raise KeyError("Key not found")
+
+
 class DiscoRDSTests(unittest.TestCase):
     """Test DiscoRDS class"""
 
+    def setUp(self):
+        self.rds = DiscoRDS(_get_vpc_mock())
+        self.rds.client = MagicMock()
+        self.rds.get_rds_security_group_id = MagicMock(return_value='fake_security_id')
+        self.rds.config_rds = get_mock_config({
+            'some-env-db-name': {
+                'engine': 'oracle',
+                'allocated_storage': '100',
+                'db_instance_class': 'db.m4.2xlarge',
+                'engine_version': '12.1.0.2.v2',
+                'master_username': 'foo'
+
+            }
+        })
+        self.rds.domain_name = 'example.com'
+
     def test_get_db_parameter_group_family(self):
         """Tests that get_db_parameter_group_family handles all the expected cases"""
-        rds = DiscoRDS(_get_vpc_mock())
-        self.assertEquals("postgresql9.3", rds.get_db_parameter_group_family("postgresql", "9.3.1"))
-        self.assertEquals("oracle-se2-12.1", rds.get_db_parameter_group_family("oracle-se2", "12.1.0.2.v2"))
-        self.assertEquals("mysql123.5", rds.get_db_parameter_group_family("MySQL", "123.5"))
+        self.assertEquals("postgresql9.3", self.rds.get_db_parameter_group_family("postgresql", "9.3.1"))
+        self.assertEquals("oracle-se2-12.1",
+                          self.rds.get_db_parameter_group_family("oracle-se2", "12.1.0.2.v2"))
+        self.assertEquals("mysql123.5", self.rds.get_db_parameter_group_family("MySQL", "123.5"))
 
-    def test_get_master_password(self):
-        """test getting the master password for an instance using either the db name or identifier"""
-        rds = DiscoRDS(_get_vpc_mock())
+    # pylint: disable=unused-argument
+    @patch('disco_aws_automation.DiscoS3Bucket.get_key', side_effect=_get_key_mock)
+    def test_get_master_password(self, get_key_mock):
+        """test getting the master password for an instance using either the db name or id as the s3 key"""
+        self.assertEquals('database_name_key', self.rds.get_master_password(TEST_ENV_NAME, 'db-name'))
+        self.assertEquals('database-id-key', self.rds.get_master_password(TEST_ENV_NAME, 'db-id'))
 
-        def _get_key_mock(key_name):
-            if key_name == 'rds/db-name/master_user_password':
-                return 'new-key'
-            elif key_name == 'rds/unittestenv-db-id/master_user_password':
-                return 'old-key'
-            else:
-                raise KeyError("Key not found")
+    # pylint: disable=unused-argument
+    @patch('disco_aws_automation.DiscoS3Bucket.get_key', side_effect=_get_key_mock)
+    def test_clone_existing_db(self, get_key_mock):
+        """test that cloning throws an error when the destination db already exists"""
+        self.rds.client.describe_db_snapshots.return_value = {
+            'DBInstances': [{
+                'DBInstanceIdentifier': 'unittestenv-db-name'
+            }]
+        }
 
-        with patch("disco_aws_automation.DiscoS3Bucket.get_key", side_effect=_get_key_mock):
-            self.assertEquals('new-key', rds.get_master_password(TEST_ENV_NAME, 'db-name'))
-            self.assertEquals('old-key', rds.get_master_password(TEST_ENV_NAME, 'db-id'))
+        with(self.assertRaises(RDSEnvironmentError)):
+            self.rds.clone('some-env', 'db-name')
 
+    # pylint: disable=unused-argument
+    @patch('disco_aws_automation.disco_rds.DiscoRoute53')
+    @patch('disco_aws_automation.DiscoS3Bucket.get_key', side_effect=_get_key_mock)
+    def test_clone(self, get_key_mock, r53_mock):
+        """test cloning a database"""
+        self.rds._get_db_instance = MagicMock(return_value=None)
+        self.rds.client.describe_db_snapshots.return_value = {
+            'DBSnapshots': [{
+                'DBSnapshotIdentifier': 'foo-snapshot'
+            }]
+        }
+        self.rds.client.describe_db_instances.return_value = {
+            'DBInstances': [{
+                'Endpoint': {
+                    'Address': 'foo.example.com'
+                }
+            }]
+        }
 
-if __name__ == '__main__':
-    unittest.main()
+        self.rds.clone('some-env', 'db-name')
+
+        self.rds.client.restore_db_instance_from_db_snapshot.assert_called_once_with(
+            AutoMinorVersionUpgrade=True,
+            DBInstanceClass='db.m4.2xlarge',
+            DBInstanceIdentifier='unittestenv-db-name',
+            DBSnapshotIdentifier='foo-snapshot',
+            DBSubnetGroupName='unittestenv-db-name',
+            Engine='oracle',
+            Iops=0,
+            LicenseModel='bring-your-own-license',
+            MultiAZ=True,
+            Port=1521,
+            PubliclyAccessible=False)
+
+        r53_mock.return_value.create_record.assert_called_once_with('example.com',
+                                                                    'unittestenv-db-name.example.com.',
+                                                                    'CNAME',
+                                                                    'foo.example.com')

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -2,17 +2,16 @@
 Tests of disco_rds
 """
 import unittest
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from disco_aws_automation.disco_rds import DiscoRDS
-
 
 TEST_ENV_NAME = 'unittestenv'
 TEST_VPC_ID = 'vpc-56e10e3d'  # the hard coded VPC Id that moto will always return
 
 
 def _get_vpc_mock():
-    "Nastily copied from test_disco_elb"
+    """Nastily copied from test_disco_elb"""
     vpc_mock = MagicMock()
     vpc_mock.environment_name = TEST_ENV_NAME
     vpc_mock.vpc = MagicMock()
@@ -21,14 +20,30 @@ def _get_vpc_mock():
 
 
 class DiscoRDSTests(unittest.TestCase):
-    '''Test DiscoRDS class'''
+    """Test DiscoRDS class"""
 
     def test_get_db_parameter_group_family(self):
-        "Tests that get_db_parameter_group_family handles all the expected cases"
+        """Tests that get_db_parameter_group_family handles all the expected cases"""
         rds = DiscoRDS(_get_vpc_mock())
         self.assertEquals("postgresql9.3", rds.get_db_parameter_group_family("postgresql", "9.3.1"))
         self.assertEquals("oracle-se2-12.1", rds.get_db_parameter_group_family("oracle-se2", "12.1.0.2.v2"))
         self.assertEquals("mysql123.5", rds.get_db_parameter_group_family("MySQL", "123.5"))
+
+    def test_get_master_password(self):
+        """test getting the master password for an instance"""
+        rds = DiscoRDS(_get_vpc_mock())
+
+        def _get_key_mock(key_name):
+            if key_name == 'rds/short-name/master_user_password':
+                return 'fake-key'
+            elif key_name == 'rds/unittestenv-old-name/master_user_password':
+                return 'fake-key'
+            else:
+                raise KeyError("Key not found")
+
+        with patch("disco_aws_automation.DiscoS3Bucket.get_key", side_effect=_get_key_mock):
+            self.assertEquals('fake-key', rds.get_master_password('short-name'))
+            self.assertEquals('fake-key', rds.get_master_password('unittestenv-old-name'))
 
 
 if __name__ == '__main__':

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -30,20 +30,20 @@ class DiscoRDSTests(unittest.TestCase):
         self.assertEquals("mysql123.5", rds.get_db_parameter_group_family("MySQL", "123.5"))
 
     def test_get_master_password(self):
-        """test getting the master password for an instance"""
+        """test getting the master password for an instance using either the db name or identifier"""
         rds = DiscoRDS(_get_vpc_mock())
 
         def _get_key_mock(key_name):
-            if key_name == 'rds/short-name/master_user_password':
-                return 'fake-key'
-            elif key_name == 'rds/unittestenv-old-name/master_user_password':
-                return 'fake-key'
+            if key_name == 'rds/db-name/master_user_password':
+                return 'new-key'
+            elif key_name == 'rds/unittestenv-db-id/master_user_password':
+                return 'old-key'
             else:
                 raise KeyError("Key not found")
 
         with patch("disco_aws_automation.DiscoS3Bucket.get_key", side_effect=_get_key_mock):
-            self.assertEquals('fake-key', rds.get_master_password('short-name'))
-            self.assertEquals('fake-key', rds.get_master_password('unittestenv-old-name'))
+            self.assertEquals('new-key', rds.get_master_password(TEST_ENV_NAME, 'db-name'))
+            self.assertEquals('old-key', rds.get_master_password(TEST_ENV_NAME, 'db-id'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a `disco_rds.py clone --env target_env --source-env source_env --source-db source_db` command

This will copy the configuration and latest snapshot to create a new database in another environment. The current use case is copying databases into sandbox environments. This could also be used for mirroring the prod and staging databases.

This only supports cloning into a different environment. In the future we can add support for creating a copy in the source's environment.

**Note**: I did some minor refactoring of the master password handling. We were previously storing the master password with a key that included the environment name like `ci-foodb` but the environment is already in the S3 bucket name so its redundant and causes  problems when using sandboxes. The new approach will look for either a `ci-foodb` key or a `foodb` key for backwards compatibility. 

**Future work for another PR:**
* Cloning from a specific snapshot other than the latest one
* Displaying a list of snapshots that can be cloned
* Cloning into the same environment as the source database but with a different name