### PR TITLE
Bump boto3 dependency up to include Boto3Error.

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.78"
+__version__ = "1.0.79"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 boto>=2.38.0,<3
-boto3>=1.2.4,<2
+boto3>=1.3.1,<2
 docopt>=0.6.1,<1
 passlib>=1.6.1,<2
 pytz>=2014.7


### PR DESCRIPTION
The Boto3Error base class was introduced in version 1.3.0, and we use it, but only require boto3 version 1.2.4.