### PR TITLE
Dynamically allocate IP ranges for VPCs and metanetworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,16 +1068,17 @@ ranges can also be defined with `intranet_cidr`, `tunnel_cidr`,
 
 The IP range for a VPC can also be dynamically alocated with the `ip_space` and `vpc_cidr_size` options. For example:
 
+    [envtype:sandbox]
     ip_space=10.0.0.0/16
     vpc_cidr_size=20
     
 A random IP range of size `vpc_cidr_size` inside of `ip_space` will be allocated for the VPC.
-The IP range chosen will not overlap with any existing VPCs or else an error will be thrown
-if its not possible. 
+The IP range chosen will not overlap with any existing VPCs or, if its not possible, an error will be thrown.
 
 In the same way, the IP range of the metaworks can be dynamically allocated
 by specifying `auto` for the metanetwork cidr options. For example:
 
+    [envtype:sandbox]
     intranet_cidr=auto
     tunnel_cidr=auto
     maintenance_cidr=auto

--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,28 @@ ranges can also be defined with `intranet_cidr`, `tunnel_cidr`,
     Usually the problem is not as severe as there are only 2-4
     Availability zones per region.
 
+##### Dynamic IP ranges
+
+The IP range for a VPC can also be dynamically alocated with the `ip_space` and `vpc_cidr_size` options. For example:
+
+    ip_space=10.0.0.0/16
+    vpc_cidr_size=20
+    
+A random IP range of size `vpc_cidr_size` inside of `ip_space` will be allocated for the VPC.
+The IP range chosen will not overlap with any existing VPCs or else an error will be thrown
+if its not possible. 
+
+In the same way, the IP range of the metaworks can be dynamically allocated
+by specifying `auto` for the metanetwork cidr options. For example:
+
+    intranet_cidr=auto
+    tunnel_cidr=auto
+    maintenance_cidr=auto
+    dmz_cidr=10.0.1.0/24
+
+The IP range of the VPC will be automatically divided to allocate the metanetworks. 
+The `auto` option can be used together with statically defined IP ranges for different metanetworks. 
+
 #### Security Group (firewall) Settings
 
 Each metanetwork have many Security Group rules associated with it. Each

--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -32,9 +32,10 @@ class DiscoMetaNetwork(object):
     Representation of a disco meta-network. Contains a subnet for each availability zone,
     along with a route table which is applied all the subnets.
     """
-    def __init__(self, name, vpc):
+    def __init__(self, name, vpc, network_cidr):
         self.vpc = vpc
         self.name = name
+        self.network_cidr = IPNetwork(network_cidr)
         self._route_table = None  # lazily initialized
         self._security_group = None  # lazily initialized
         self._subnets = None  # lazily initialized
@@ -141,9 +142,8 @@ class DiscoMetaNetwork(object):
         zone_cidr_offset = ceil(log(len(zones), 2))
         logging.debug("zone_offset: %s", zone_cidr_offset)
 
-        network_cidr = IPNetwork(self.vpc.get_config("{0}_cidr".format(self.name)))
-        zone_cidrs = network_cidr.subnet(
-            int(network_cidr.prefixlen + zone_cidr_offset)
+        zone_cidrs = self.network_cidr.subnet(
+            int(self.network_cidr.prefixlen + zone_cidr_offset)
         )
 
         subnets = []

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -6,6 +6,7 @@ environments, and between an environment and the internet.  In particular non-VP
 
 import logging
 import random
+from itertools import groupby
 
 import time
 from ConfigParser import ConfigParser
@@ -167,6 +168,13 @@ class DiscoVPC(object):
         if self._networks:
             return self._networks
 
+        self._networks = self._get_meta_networks()
+
+        return self._networks
+
+    def _create_new_meta_networks(self):
+        """Read the VPC config and create the DiscoMetaNetwork objects that should exist in a new VPC"""
+
         # don't create networks we haven't defined
         # a map of network names to the configured cidr value or "auto"
         networks = {network: self.get_config("{0}_cidr".format(network))
@@ -190,7 +198,7 @@ class DiscoVPC(object):
         # keep a list of the cidrs used by the meta networks in case we need to pick a random one
         used_cidrs = [cidr for cidr in networks.values() if cidr != 'auto']
 
-        self._networks = {}
+        metanetworks = {}
         for network_name, cidr in networks.iteritems():
             # pick a random ip range if there isn't one configured for the network in the config
             if cidr == 'auto':
@@ -199,10 +207,44 @@ class DiscoVPC(object):
                 if not cidr:
                     raise VPCConfigError("Can't create metanetwork %s. No subnets available", network_name)
 
-            self._networks[network_name] = DiscoMetaNetwork(network_name, self, cidr)
+            metanetworks[network_name] = DiscoMetaNetwork(network_name, self, cidr)
             used_cidrs.append(cidr)
 
-        return self._networks
+        return metanetworks
+
+    def _get_meta_networks(self):
+        """Create DiscoMetaNetwork objects by querying an existing VPC"""
+        meta_networks = {}
+
+        # meta networks are not an AWS concept. They are a custom grouping of subnets that we created
+        # Therefore, we can't query AWS for the meta networks of a VPC
+        # But we can infer them by looking at the subnets of a VPC
+        subnets = self.vpc.connection.get_all_subnets(filters={
+            'vpcId': self.vpc.id
+        })
+
+        # sort the subnets before grouping them by meta network
+        subnets = sorted(subnets, key=lambda x: x.tags['meta_network'])
+
+        # a meta network is a group of subnets so we can discover the meta networks by looking at the subnets
+        for name, subnet_iter in groupby(subnets, lambda x: x.tags['meta_network']):
+            subnets = list(subnet_iter)
+
+            # calculate how big the meta network must have been if we divided it into the subnets that we see
+            subnet_cidr_offset = int(ceil(log(len(subnets), 2)))
+
+            # pick one of the subnets to do our math from
+            subnet_network = IPNetwork(subnets[0].cidr_block)
+
+            meta_network_size = subnet_network.prefixlen - subnet_cidr_offset
+
+            # the meta network cidr is the cidr of one of the subnets but with a smaller prefix
+            subnet_network.prefixlen = meta_network_size
+            meta_network_cidr = subnet_network.cidr
+
+            meta_networks[name] = DiscoMetaNetwork(name, self, meta_network_cidr)
+
+        return meta_networks
 
     def find_instance_route_table(self, instance):
         """ Return route tables corresponding to instance """
@@ -455,6 +497,7 @@ class DiscoVPC(object):
         vpc_conn.modify_vpc_attribute(self.vpc.id, enable_dns_hostnames=True)
 
         # Create metanetworks (subnets, route_tables and security groups)
+        self._networks = self._create_new_meta_networks()
         for network in self.networks.itervalues():
             network.create()
 

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -5,15 +5,19 @@ environments, and between an environment and the internet.  In particular non-VP
 """
 
 import logging
+import random
+
 import time
 from ConfigParser import ConfigParser
+from math import ceil, log
 
 import boto
 import boto.ec2
 from boto.vpc import VPCConnection
 from boto.exception import EC2ResponseError
+from netaddr import IPNetwork, IPSet
 
-from . import read_config
+from . import read_config, normalize_path
 from .resource_helper import keep_trying, wait_for_state
 from .disco_log_metrics import DiscoLogMetrics
 from .disco_alarm import DiscoAlarm
@@ -41,13 +45,11 @@ class DiscoVPC(object):
     """
 
     def __init__(self, environment_name, environment_type, vpc=None, config_file=None):
-        if config_file:
-            self.config = ConfigParser()
-            self.config.read(config_file)
-        else:
-            self.config = read_config(CONFIG_FILE)
+        self.config_file = config_file or CONFIG_FILE
+
         self.environment_name = environment_name
         self.environment_type = environment_type
+        self._config = None  # lazily initialized
         self._peerings = None  # lazily initialized
         self._region = None  # lazily initialized
         self._networks = None  # lazily initialized
@@ -65,6 +67,18 @@ class DiscoVPC(object):
             self.vpc = vpc
         else:
             self._configure_environment()
+
+    @property
+    def config(self):
+        """lazy load config"""
+        if not self._config:
+            try:
+                config = ConfigParser()
+                config.read(normalize_path(self.config_file))
+                self._config = config
+            except Exception:
+                return None
+        return self._config
 
     def get_config(self, option, default=None):
         '''Returns appropriate configuration for the current environment'''
@@ -152,11 +166,42 @@ class DiscoVPC(object):
         """A dictionary containing each metanetwork name with its DiscoMetaNetwork class"""
         if self._networks:
             return self._networks
-        self._networks = {
-            network: DiscoMetaNetwork(network, self)
-            for network in NETWORKS.keys()
-            if self.get_config("{0}_cidr".format(network))  # don't create networks we haven't defined
-        }
+
+        # don't create networks we haven't defined
+        # a map of network names to the configured cidr value or "auto"
+        networks = {network: self.get_config("{0}_cidr".format(network))
+                    for network in NETWORKS.keys()
+                    if self.get_config("{0}_cidr".format(network))}
+
+        if len(networks) < 1:
+            raise VPCConfigError('No Metanetworks configured for VPC %s' % self.environment_name)
+
+        # calculate the extra cidr bits needed to represent the networks
+        # for example breaking a /20 VPC into 4 meta networks will create /22 sized networks
+        cidr_offset = ceil(log(len(networks), 2))
+        vpc_size = IPNetwork(self.vpc.cidr_block).prefixlen
+        meta_network_size = vpc_size + cidr_offset
+
+        # /32 is the smallest possible network
+        if meta_network_size > 32:
+            raise VPCConfigError('Unable to create %s metanetworks in /%s size VPC'
+                                 % (len(networks), vpc_size))
+
+        # keep a list of the cidrs used by the meta networks in case we need to pick a random one
+        used_cidrs = [cidr for cidr in networks.values() if cidr != 'auto']
+
+        self._networks = {}
+        for network_name, cidr in networks.iteritems():
+            # pick a random ip range if there isn't one configured for the network in the config
+            if cidr == 'auto':
+                cidr = DiscoVPC.get_random_free_subnet(self.vpc.cidr_block, meta_network_size, used_cidrs)
+
+                if not cidr:
+                    raise VPCConfigError("Can't create metanetwork %s. No subnets available", network_name)
+
+            self._networks[network_name] = DiscoMetaNetwork(network_name, self, cidr)
+            used_cidrs.append(cidr)
+
         return self._networks
 
     def find_instance_route_table(self, instance):
@@ -378,9 +423,26 @@ class DiscoVPC(object):
         """Create a new disco style environment VPC"""
         vpc_cidr = self.get_config("vpc_cidr")
 
+        # if a vpc_cidr is not configured then allocate one dynamically
+        if not vpc_cidr:
+            ip_space = self.get_config("ip_space")
+            vpc_size = self.get_config("vpc_cidr_size")
+
+            if not ip_space and vpc_size:
+                raise VPCConfigError('Cannot create VPC %s. ip_space or vpc_cidr_size missing'
+                                     % self.environment_name)
+
+            # get the cidr for all other VPCs so we can avoid overlapping with other VPCs
+            occupied_network_cidrs = [vpc.cidr_block for vpc in self.list_vpcs()]
+
+            vpc_cidr = DiscoVPC.get_random_free_subnet(ip_space, int(vpc_size), occupied_network_cidrs)
+
+            if vpc_cidr is None:
+                raise VPCConfigError('Cannot create VPC %s. No subnets available' % self.environment_name)
+
         # Create VPC
         vpc_conn = VPCConnection()
-        self.vpc = vpc_conn.create_vpc(self.get_config("vpc_cidr"))
+        self.vpc = vpc_conn.create_vpc(vpc_cidr)
         keep_trying(300, self.vpc.add_tag, "Name", self.environment_name)
         keep_trying(300, self.vpc.add_tag, "type", self.environment_type)
         logging.debug("vpc: %s", self.vpc)
@@ -753,7 +815,7 @@ class DiscoVPC(object):
     def create_peering_routes(vpc_conn, vpc_map, vpc_metanetwork_map, peering_conn):
         """ create/update routes via peering connections between VPCs """
         cidr_map = {
-            _: vpc_map[_].get_config("{0}_cidr".format(vpc_metanetwork_map[_]))
+            _: vpc_map[_].networks[vpc_metanetwork_map[_]].network_cidr
             for _ in vpc_map.keys()
         }
         route_table_map = {
@@ -827,3 +889,26 @@ class DiscoVPC(object):
                 vpc_conn.delete_vpc_peering_connection(peering.id)
             except EC2ResponseError:
                 raise RuntimeError('Failed to delete VPC Peering connection {}'.format(peering.id))
+
+    @staticmethod
+    def get_random_free_subnet(network_cidr, network_size, occupied_network_cidrs):
+        """
+        Pick a random available subnet from a bigger network
+        Args:
+            network_cidr (str): CIDR string describing a network
+            network_size (int): The number of bits for the CIDR of the subnet
+            occupied_network_cidrs (List[str]): List of CIDR strings describing existing networks
+                                                to avoid overlapping with
+
+        Returns str: The CIDR of a randomly chosen subnet that doesn't intersect with
+                     the ip ranges of any of the given other networks
+        """
+        possible_subnets = IPNetwork(network_cidr).subnet(int(network_size))
+        occupied_networks = [IPSet(IPNetwork(cidr)) for cidr in occupied_network_cidrs]
+
+        # find the subnets that don't overlap with any other networks
+        available_subnets = [subnet for subnet in possible_subnets
+                             if all([IPSet(subnet).isdisjoint(occupied_network)
+                                     for occupied_network in occupied_networks])]
+
+        return random.choice(available_subnets) if available_subnets else None

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -9,7 +9,6 @@ import random
 
 import time
 from ConfigParser import ConfigParser
-from math import ceil, log
 
 import boto
 import boto.ec2
@@ -17,6 +16,7 @@ from boto.vpc import VPCConnection
 from boto.exception import EC2ResponseError
 from netaddr import IPNetwork, IPSet
 
+from disco_aws_automation.network_helper import calc_subnet_offset
 from . import read_config, normalize_path
 from .resource_helper import keep_trying, wait_for_state
 from .disco_log_metrics import DiscoLogMetrics
@@ -187,7 +187,7 @@ class DiscoVPC(object):
 
         # calculate the extra cidr bits needed to represent the networks
         # for example breaking a /20 VPC into 4 meta networks will create /22 sized networks
-        cidr_offset = ceil(log(len(networks), 2))
+        cidr_offset = calc_subnet_offset(len(networks))
         vpc_size = IPNetwork(self.vpc.cidr_block).prefixlen
         meta_network_size = vpc_size + cidr_offset
 

--- a/disco_aws_automation/network_helper.py
+++ b/disco_aws_automation/network_helper.py
@@ -1,0 +1,18 @@
+"""
+This module has utility functions for working with networks
+"""
+
+from math import ceil, log
+
+
+def calc_subnet_offset(num_subnets):
+    """
+    Calculate the size difference between a network and its subnets if there are a certain number of
+    equally sized subnets
+
+
+    Returns (int): The difference in cidr bits of a network and the subnets.
+                   For example breaking a /20 network into 4 subnets will create /22 subnets returning 2.
+
+    """
+    return int(ceil(log(num_subnets, 2)))

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.80"
+__version__ = "1.0.81"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -1,0 +1,89 @@
+"""Tests of disco_vpc"""
+
+import unittest
+
+from mock import MagicMock, patch, PropertyMock
+from netaddr import IPSet
+
+from disco_aws_automation import DiscoVPC
+from test.helpers.patch_disco_aws import get_mock_config
+
+
+class DiscoVPCTests(unittest.TestCase):
+    """Test DiscoVPC"""
+
+    def test_get_random_free_subnet(self):
+        """Test getting getting a random subnet from a network"""
+        subnet = DiscoVPC.get_random_free_subnet('10.0.0.0/28', 30, [])
+
+        possible_subnets = ['10.0.0.0/30', '10.0.0.4/30', '10.0.0.8/30', '10.0.0.12/30']
+        self.assertIn(str(subnet), possible_subnets)
+
+    def test_get_random_free_subnet_returns_none(self):
+        """Test that None is returned if no subnets are available"""
+        used_subnets = ['10.0.0.0/30', '10.0.0.4/32', '10.0.0.8/30', '10.0.0.12/30']
+
+        subnet = DiscoVPC.get_random_free_subnet('10.0.0.0/28', 30, used_subnets)
+        IPSet(subnet)
+        self.assertIsNone(subnet)
+
+    # pylint: disable=unused-argument
+    @patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
+    @patch('disco_aws_automation.disco_vpc.VPCConnection')
+    def test_get_meta_networks(self, vpc_conn_mock, config_mock):
+        """Test getting meta networks with dynamic ip ranges"""
+        vpc_mock = MagicMock()
+        vpc_mock.cidr_block = '10.0.0.0/28'
+
+        config_mock.return_value = get_mock_config({
+            'envtype:auto-vpc-type': {
+                'vpc_cidr': '10.202.0.0/20',
+                'intranet_cidr': 'auto',
+                'tunnel_cidr': 'auto',
+                'dmz_cidr': 'auto',
+                'maintenance_cidr': 'auto'
+            }
+        })
+
+        auto_vpc = DiscoVPC('auto-vpc', 'auto-vpc-type', vpc_mock)
+
+        meta_networks = auto_vpc.networks
+        self.assertItemsEqual(['intranet', 'tunnel', 'dmz', 'maintenance'], meta_networks.keys())
+
+        expected_subnets = ['10.0.0.0/30', '10.0.0.4/30', '10.0.0.8/30', '10.0.0.12/30']
+        actual_subnets = [str(meta_network.network_cidr) for meta_network in meta_networks.values()]
+
+        self.assertItemsEqual(actual_subnets, expected_subnets)
+
+    # pylint: disable=unused-argument
+    @patch('disco_aws_automation.disco_vpc.DiscoSNS')
+    @patch('time.sleep')
+    @patch('disco_aws_automation.disco_vpc.DiscoVPC._wait_for_vgw_states')
+    @patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
+    @patch('disco_aws_automation.disco_vpc.VPCConnection')
+    def test_create_auto_vpc(self, vpc_conn_mock, config_mock, _wait_vgw_states_mock, sleep_mock, sns_mock):
+        """Test creating a VPC with a dynamic ip range"""
+        # FIXME This needs to mock way too many things. DiscoVPC needs to be refactored
+
+        config_mock.return_value = get_mock_config({
+            'envtype:auto-vpc-type': {
+                'ip_space': '10.0.0.0/24',
+                'vpc_cidr_size': '26',
+                'intranet_cidr': 'auto',
+                'tunnel_cidr': 'auto',
+                'dmz_cidr': 'auto',
+                'maintenance_cidr': 'auto'
+            }
+        })
+
+        def _create_vpc_mock(cidr):
+            vpc = MagicMock()
+            vpc.cidr_block = cidr
+            return vpc
+
+        vpc_conn_mock.return_value.create_vpc.side_effect = _create_vpc_mock
+
+        auto_vpc = DiscoVPC('auto-vpc', 'auto-vpc-type')
+
+        possible_vpcs = ['10.0.0.0/26', '10.0.0.64/26', '10.0.0.128/26', '10.0.0.192/26']
+        self.assertIn(str(auto_vpc.vpc.cidr_block), possible_vpcs)

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -30,8 +30,8 @@ class DiscoVPCTests(unittest.TestCase):
     # pylint: disable=unused-argument
     @patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
     @patch('disco_aws_automation.disco_vpc.VPCConnection')
-    def test_get_meta_networks(self, vpc_conn_mock, config_mock):
-        """Test getting meta networks with dynamic ip ranges"""
+    def test_create_meta_networks(self, vpc_conn_mock, config_mock):
+        """Test creating meta networks with dynamic ip ranges"""
         vpc_mock = MagicMock()
         vpc_mock.cidr_block = '10.0.0.0/28'
 

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -58,7 +58,7 @@ class DiscoVPCTests(unittest.TestCase):
     # pylint: disable=unused-argument
     @patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
     @patch('disco_aws_automation.disco_vpc.VPCConnection')
-    def test_create_meta_networks_mix_static_dynamic(self, vpc_conn_mock, config_mock):
+    def test_create_meta_networks_static_dynamic(self, vpc_conn_mock, config_mock):
         """Test creating meta networks with a mix of static and dynamic ip ranges"""
         vpc_mock = MagicMock()
         vpc_mock.cidr_block = '10.0.0.0/28'

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -37,7 +37,7 @@ class DiscoVPCTests(unittest.TestCase):
 
         config_mock.return_value = get_mock_config({
             'envtype:auto-vpc-type': {
-                'vpc_cidr': '10.202.0.0/20',
+                'vpc_cidr': '10.0.0.0/28',
                 'intranet_cidr': 'auto',
                 'tunnel_cidr': 'auto',
                 'dmz_cidr': 'auto',
@@ -47,7 +47,7 @@ class DiscoVPCTests(unittest.TestCase):
 
         auto_vpc = DiscoVPC('auto-vpc', 'auto-vpc-type', vpc_mock)
 
-        meta_networks = auto_vpc.networks
+        meta_networks = auto_vpc._create_new_meta_networks()
         self.assertItemsEqual(['intranet', 'tunnel', 'dmz', 'maintenance'], meta_networks.keys())
 
         expected_subnets = ['10.0.0.0/30', '10.0.0.4/30', '10.0.0.8/30', '10.0.0.12/30']


### PR DESCRIPTION
* Introduce `ip_space` and `vpc_cidr_size` options to `disco_vpc.ini` to automatically pick a ip range for VPCs
* Add an `auto` option to meta network cidr config to automatically pick a ip range for metanetworks

This is to remove some manual configuration steps when creating sandbox VPCs. IP ranges for VPCs and meta networks don't need to be manually configured in `disco_vpc.ini` anymore. The IP ranges are guaranteed to not overlap with other VPCs (or an error is thrown if thats not possible) to fix our problems with VPC peering.