### PR TITLE
database clones should have their own parameter groups

### DIFF
--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -96,7 +96,7 @@ def run():
             print(line)
     elif args.mode == "update":
         if args.cluster:
-            rds.update_cluster(args.cluster)
+            rds.update_cluster_by_id(args.cluster)
         else:
             rds.update_all_clusters_in_vpc()
     elif args.mode == "delete":

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -417,6 +417,13 @@ class DiscoRDS(object):
         Check if there are any custom parameters for this instance
         Custom Parameters are set in ./rds/engine_specific/{instance_identifier}.ini
         If this file doesn't exist, we'll use default RDS parameters
+        Args:
+            env_name (str): The environment name to use when reading the config file.
+                            This is only used in the section name of the config file.
+                            The parameter group is always created for the current environment
+            database_name:
+            db_parameter_group_name:
+            db_parameter_group_family:
         """
         try:
             self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -423,9 +423,9 @@ class DiscoRDS(object):
             env_name (str): The environment name to use when reading the config file.
                             This is only used in the section name of the config file.
                             The parameter group is always created for the current environment
-            database_name:
-            db_parameter_group_name:
-            db_parameter_group_family:
+            database_name (str): The database name such as 'txdb'
+            db_parameter_group_name (str): Usually the same as the database identifier such as 'ci-txdb'
+            db_parameter_group_family (str): Parameter group family such as 'oracle-se2-12.1'
         """
         try:
             self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.80"
+__version__ = "1.0.81"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -121,6 +121,11 @@ class DiscoRDSTests(unittest.TestCase):
             Port=1521,
             PubliclyAccessible=False)
 
+        self.rds.client.create_db_parameter_group.assert_called_once_with(
+            DBParameterGroupName='unittestenv-db-name',
+            DBParameterGroupFamily='oracle12.1',
+            Description='Custom params-unittestenv-db-name')
+
         r53_mock.return_value.create_record.assert_called_once_with('example.com',
                                                                     'unittestenv-db-name.example.com.',
                                                                     'CNAME',


### PR DESCRIPTION
This fixes a couple of issues that came out of the recent RDS clone PR https://github.com/amplifylitco/asiaq/pull/38.

Database clones should have their own parameter groups instead of referencing the same group as the source database. So that its safe to delete/modify the groups without the clones/source databases affecting each other.

The `disco_rds.py update --cluster <name>` command is supposed to take the database identifier (`ci-txdb`) instead of the database name (`txdb`)