### PR TITLE
Hash ELB Names

### DIFF
--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -44,9 +44,11 @@ def run():
 
     if args['list']:
         format_string = "{0:<32} {1:32} {2:50}"
-        print(format_string.format("Load Balancer Name", "Availability Zones", "Human-friendly Load Balancer Name"), file=sys.stderr)
-        for elb_info in sorted(DiscoELB(vpc).list()):
-            print(format_string.format(elb_info['load_balancer_name'], elb_info['availability_zones'], elb_info["elb_name"]))
+        print(format_string.format("Load Balancer Name", "Availability Zones",
+                                   "Human-friendly Load Balancer Name"), file=sys.stderr)
+        for elb_info in sorted(DiscoELB(vpc).list_for_display()):
+            print(format_string.format(elb_info['load_balancer_name'], elb_info['availability_zones'],
+                                       elb_info["elb_name"]))
     elif args['update']:
         DiscoAWS(config, env).update_elb(args['--hostclass'])
 

--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -43,10 +43,10 @@ def run():
         sys.exit(1)
 
     if args['list']:
-        format_string = "{0:<50} {1:32}"
-        print(format_string.format("Load Balancer Name", "Availability Zones"), file=sys.stderr)
+        format_string = "{0:<32} {1:32} {2:50}"
+        print(format_string.format("Load Balancer Name", "Availability Zones", "Human-friendly Load Balancer Name"), file=sys.stderr)
         for elb_info in sorted(DiscoELB(vpc).list()):
-            print(format_string.format(elb_info['elb_name'], elb_info['availability_zones']))
+            print(format_string.format(elb_info['load_balancer_name'], elb_info['availability_zones'], elb_info["elb_name"]))
     elif args['update']:
         DiscoAWS(config, env).update_elb(args['--hostclass'])
 

--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -43,8 +43,10 @@ def run():
         sys.exit(1)
 
     if args['list']:
-        for elb in sorted(DiscoELB(vpc).list()):
-            print("{0:<20} {1:25}".format(elb['LoadBalancerName'], ','.join(elb['AvailabilityZones'])))
+        format_string = "{0:<50} {1:32}"
+        print(format_string.format("Load Balancer Name", "Availability Zones"), file=sys.stderr)
+        for elb_info in sorted(DiscoELB(vpc).list()):
+            print(format_string.format(elb_info['elb_name'], elb_info['availability_zones']))
     elif args['update']:
         DiscoAWS(config, env).update_elb(args['--hostclass'])
 

--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -43,12 +43,11 @@ def run():
         sys.exit(1)
 
     if args['list']:
-        format_string = "{0:<32} {1:32} {2:50}"
-        print(format_string.format("Load Balancer Name", "Availability Zones",
-                                   "Human-friendly Load Balancer Name"), file=sys.stderr)
+        format_string = "{0:<50} {1:33} {2}"
+        print(format_string.format("ELB Name", "Availability Zones", "ELB Id"), file=sys.stderr)
         for elb_info in sorted(DiscoELB(vpc).list_for_display()):
-            print(format_string.format(elb_info['load_balancer_name'], elb_info['availability_zones'],
-                                       elb_info["elb_name"]))
+            print(format_string.format(elb_info['elb_name'], elb_info['availability_zones'],
+                                       elb_info["elb_id"]))
     elif args['update']:
         DiscoAWS(config, env).update_elb(args['--hostclass'])
 

--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -85,7 +85,7 @@ class DiscoAlarmConfig(object):
             return {key: value}
 
         if self.namespace == 'AWS/ELB':
-            return {'LoadBalancerName': DiscoELB.get_elb_name(self.environment, self.hostclass)}
+            return {'LoadBalancerName': DiscoELB.get_elb_id(self.environment, self.hostclass)}
 
         value = "_".join([self.environment, self.hostclass])
         if self.custom_metric:

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -25,6 +25,20 @@ def is_truthy(value):
     return value and value.lower() in YES_LIST
 
 
+def chunker(sequence, size):
+    """
+    Creates a generator that yields chunks of sequence in the given size
+
+    for group in chunker(range(0, 20), 5):
+        print group
+    # [0, 1, 2, 3, 4]
+    # [5, 6, 7, 8, 9]
+    # [10, 11, 12, 13, 14]
+    # [15, 16, 17, 18, 19]
+    """
+    return (sequence[position:position + size] for position in xrange(0, len(sequence), size))
+
+
 def run_gracefully(main_function):
     """
     Run a "main" function with standardized exception trapping, to make it easy

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -18,6 +18,17 @@ class EasyExit(Exception):
     pass
 
 
+def get_tag_value(tag_list, key):
+    """
+    Given a list of dictionaries representing tags, returns the value of the given key, or None if the key
+    cannot be found.
+    """
+    for tag in tag_list:
+        if tag["Key"] == key:
+            return tag["Value"]
+    return None
+
+
 def is_truthy(value):
     """
     Return true if value resembles a affirmation

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -82,7 +82,8 @@ class DiscoELB(object):
             load_balancer_name = tag_description["LoadBalancerName"]
             # If they have an 'elb_name' tag, use that instead of the actual LoadBalancerName
             elb_name = self._get_tag_value(tag_description, "elb_name") or load_balancer_name
-            elb = filter(lambda x: x["LoadBalancerName"] == load_balancer_name, elbs_in_env)[0]
+            elb = [elb_in_env["LoadBalancerName"] for elb_in_env in elbs_in_env
+                   if elb_in_env["LoadBalancerName"] == load_balancer_name][0]
             availability_zones = ','.join(elb["AvailabilityZones"])
 
             elb_infos.append({

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -80,16 +80,16 @@ class DiscoELB(object):
 
         # Populate our ELB info dicts
         for tag_description in tag_descriptions:
-            load_balancer_name = tag_description["LoadBalancerName"]
+            elb_id = tag_description["LoadBalancerName"]
             # If they have an 'elb_name' tag, use that instead of the actual LoadBalancerName
-            elb_name = get_tag_value(tag_description["Tags"], "elb_name") or load_balancer_name
+            elb_name = get_tag_value(tag_description["Tags"], "elb_name") or elb_id 
             elb = [elb_in_env for elb_in_env in elbs_in_env
-                   if elb_in_env["LoadBalancerName"] == load_balancer_name][0]
+                   if elb_in_env["LoadBalancerName"] == elb_id][0]
             availability_zones = ','.join(elb["AvailabilityZones"])
 
             elb_infos.append({
                 "elb_name": elb_name,
-                "load_balancer_name": load_balancer_name,
+                "elb_id": elb_id,
                 "availability_zones": availability_zones
             })
 

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -83,7 +83,7 @@ class DiscoELB(object):
             load_balancer_name = tag_description["LoadBalancerName"]
             # If they have an 'elb_name' tag, use that instead of the actual LoadBalancerName
             elb_name = get_tag_value(tag_description["Tags"], "elb_name") or load_balancer_name
-            elb = [elb_in_env["LoadBalancerName"] for elb_in_env in elbs_in_env
+            elb = [elb_in_env for elb_in_env in elbs_in_env
                    if elb_in_env["LoadBalancerName"] == load_balancer_name][0]
             availability_zones = ','.join(elb["AvailabilityZones"])
 

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -10,6 +10,7 @@ import hashlib
 import boto3
 import botocore
 
+from .disco_aws_util import get_tag_value
 from .disco_route53 import DiscoRoute53
 from .disco_acm import DiscoACM
 from .disco_iam import DiscoIAM
@@ -81,7 +82,7 @@ class DiscoELB(object):
         for tag_description in tag_descriptions:
             load_balancer_name = tag_description["LoadBalancerName"]
             # If they have an 'elb_name' tag, use that instead of the actual LoadBalancerName
-            elb_name = self._get_tag_value(tag_description, "elb_name") or load_balancer_name
+            elb_name = get_tag_value(tag_description["Tags"], "elb_name") or load_balancer_name
             elb = [elb_in_env["LoadBalancerName"] for elb_in_env in elbs_in_env
                    if elb_in_env["LoadBalancerName"] == load_balancer_name][0]
             availability_zones = ','.join(elb["AvailabilityZones"])
@@ -93,12 +94,6 @@ class DiscoELB(object):
             })
 
         return elb_infos
-
-    def _get_tag_value(self, tag_description, key):
-        for tag in tag_description["Tags"]:
-            if tag["Key"] == key:
-                return tag["Value"]
-        return None
 
     def get_cname(self, hostclass, domain_name, testing=False):
         """Get the expected subdomain for an ELB for a hostclass"""

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -80,6 +80,7 @@ class DiscoELB(object):
 
             elb_infos.append({
                 "elb_name": elb_name,
+                "load_balancer_name": load_balancer_name,
                 "availability_zones": availability_zones
             })
 

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -82,7 +82,7 @@ class DiscoELB(object):
         for tag_description in tag_descriptions:
             elb_id = tag_description["LoadBalancerName"]
             # If they have an 'elb_name' tag, use that instead of the actual LoadBalancerName
-            elb_name = get_tag_value(tag_description["Tags"], "elb_name") or elb_id 
+            elb_name = get_tag_value(tag_description["Tags"], "elb_name") or elb_id
             elb = [elb_in_env for elb_in_env in elbs_in_env
                    if elb_in_env["LoadBalancerName"] == elb_id][0]
             availability_zones = ','.join(elb["AvailabilityZones"])

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.85"
+__version__ = "1.0.86"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_alarm.py
+++ b/test/unit/test_disco_alarm.py
@@ -194,5 +194,5 @@ class DiscoAlarmTests(TestCase):
 
         alarm_configs = disco_alarms_config.get_alarms('mhcbanana')
         self.assertEqual(1, len(alarm_configs))
-        self.assertEquals({'LoadBalancerName': DiscoELB.get_elb_name('testenv', 'mhcbanana')},
+        self.assertEquals({'LoadBalancerName': DiscoELB.get_elb_id('testenv', 'mhcbanana')},
                           alarm_configs[0].dimensions)

--- a/test/unit/test_disco_alarm.py
+++ b/test/unit/test_disco_alarm.py
@@ -9,6 +9,7 @@ from disco_aws_automation import DiscoAlarm, DiscoAlarmsConfig
 from disco_aws_automation import DiscoAlarmConfig
 from disco_aws_automation import DiscoSNS
 from disco_aws_automation import AlarmConfigError
+from disco_aws_automation import DiscoELB
 from test.helpers.patch_disco_aws import get_mock_config
 
 TOPIC_ARN = "arn:aws:sns:us-west-2:123456789012:ci"
@@ -193,4 +194,5 @@ class DiscoAlarmTests(TestCase):
 
         alarm_configs = disco_alarms_config.get_alarms('mhcbanana')
         self.assertEqual(1, len(alarm_configs))
-        self.assertEquals({'LoadBalancerName': 'testenv-mhcbanana'}, alarm_configs[0].dimensions)
+        self.assertEquals({'LoadBalancerName': DiscoELB.get_elb_name('testenv', 'mhcbanana')},
+                          alarm_configs[0].dimensions)

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -91,7 +91,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb()
         self.disco_elb.elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -103,7 +103,7 @@ class DiscoELBTests(TestCase):
             Scheme='internal',
             Tags=[{
                 "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
 
     @mock_elb
@@ -115,7 +115,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb()
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -127,7 +127,7 @@ class DiscoELBTests(TestCase):
             Scheme='internal',
             Tags=[{
                 "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
 
     @mock_elb
@@ -137,7 +137,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb(public=True)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -148,7 +148,7 @@ class DiscoELBTests(TestCase):
             SecurityGroups=['sec-1'],
             Tags=[{
                 "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
 
     @mock_elb
@@ -158,7 +158,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb(tls=True)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTPS',
                 'LoadBalancerPort': 443,
@@ -171,7 +171,7 @@ class DiscoELBTests(TestCase):
             Scheme='internal',
             Tags=[{
                 "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
 
     @mock_elb
@@ -182,7 +182,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(instance_protocol='TCP', instance_port=25,
                          elb_protocol='TCP', elb_port=25)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'TCP',
                 'LoadBalancerPort': 25,
@@ -194,7 +194,7 @@ class DiscoELBTests(TestCase):
             Scheme='internal',
             Tags=[{
                 "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
 
     @mock_elb
@@ -206,7 +206,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(idle_timeout=100)
 
         client.modify_load_balancer_attributes.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             LoadBalancerAttributes={'ConnectionDraining': {'Enabled': False, 'Timeout': 0},
                                     'ConnectionSettings': {'IdleTimeout': 100}}
         )
@@ -220,7 +220,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(connection_draining_timeout=100)
 
         client.modify_load_balancer_attributes.assert_called_once_with(
-            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             LoadBalancerAttributes={'ConnectionDraining': {'Enabled': True, 'Timeout': 100}}
         )
 
@@ -264,8 +264,8 @@ class DiscoELBTests(TestCase):
     def test_wait_for_instance_health(self):
         """Test that we can wait for instances attached to an ELB to enter a specific state"""
         self._create_elb(hostclass='mhcbar')
-        elb_name = self.disco_elb.get_elb_name(TEST_ENV_NAME, 'mhcbar')
+        elb_id = self.disco_elb.get_elb_id(TEST_ENV_NAME, 'mhcbar')
         instances = [{"InstanceId": "i-123123aa"}]
-        self.disco_elb.elb_client.register_instances_with_load_balancer(LoadBalancerName=elb_name,
+        self.disco_elb.elb_client.register_instances_with_load_balancer(LoadBalancerName=elb_id,
                                                                         Instances=instances)
         self.disco_elb.wait_for_instance_health_state(hostclass='mhcbar')

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -91,7 +91,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb()
         self.disco_elb.elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -100,7 +100,11 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
-            Scheme='internal')
+            Scheme='internal',
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+            }])
 
     @mock_elb
     def test_get_elb_internal_no_tls(self):
@@ -111,7 +115,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb()
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -120,7 +124,11 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
-            Scheme='internal')
+            Scheme='internal',
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+            }])
 
     @mock_elb
     def test_get_elb_external(self):
@@ -129,7 +137,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb(public=True)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTP',
                 'LoadBalancerPort': 80,
@@ -137,7 +145,11 @@ class DiscoELBTests(TestCase):
                 'InstancePort': 80
             }],
             Subnets=['sub-1'],
-            SecurityGroups=['sec-1'])
+            SecurityGroups=['sec-1'],
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+            }])
 
     @mock_elb
     def test_get_elb_with_tls(self):
@@ -146,7 +158,7 @@ class DiscoELBTests(TestCase):
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb(tls=True)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'HTTPS',
                 'LoadBalancerPort': 443,
@@ -156,7 +168,11 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
-            Scheme='internal')
+            Scheme='internal',
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+            }])
 
     @mock_elb
     def test_get_elb_with_tcp(self):
@@ -166,7 +182,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(instance_protocol='TCP', instance_port=25,
                          elb_protocol='TCP', elb_port=25)
         elb_client.create_load_balancer.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             Listeners=[{
                 'Protocol': 'TCP',
                 'LoadBalancerPort': 25,
@@ -175,7 +191,11 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=['sub-1'],
             SecurityGroups=['sec-1'],
-            Scheme='internal')
+            Scheme='internal',
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name_for_humans('unittestenv', 'mhcunit')
+            }])
 
     @mock_elb
     def test_get_elb_with_idle_timeout(self):
@@ -186,7 +206,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(idle_timeout=100)
 
         client.modify_load_balancer_attributes.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             LoadBalancerAttributes={'ConnectionDraining': {'Enabled': False, 'Timeout': 0},
                                     'ConnectionSettings': {'IdleTimeout': 100}}
         )
@@ -200,7 +220,7 @@ class DiscoELBTests(TestCase):
         self._create_elb(connection_draining_timeout=100)
 
         client.modify_load_balancer_attributes.assert_called_once_with(
-            LoadBalancerName='unittestenv-mhcunit',
+            LoadBalancerName=DiscoELB.get_elb_name('unittestenv', 'mhcunit'),
             LoadBalancerAttributes={'ConnectionDraining': {'Enabled': True, 'Timeout': 100}}
         )
 


### PR DESCRIPTION
AWS imposes a limit of 32 characters on ELB names. Because environment and hostclass names can very quickly exceed this limit, it would be safer to create a hash of our ELB name, and store that as the ELB Name instead. A human-readable name can be added as a tag and used for display purposes.