### PR TITLE
fix the zookeeper ip in user data

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -154,7 +154,7 @@ class DiscoAWS(object):
         data["owner"] = owner or getpass.getuser()
         data["credential_buckets"] = " ".join(self.vpc.get_credential_buckets(self._project_name))
         data["zookeepers"] = "[\\\"{0}:2181\\\"]".format(
-            self._get_hostclass_ip_address((fixed_ip_hostclass['zookeeper'], ""))
+            self._get_hostclass_ip_address(fixed_ip_hostclass['zookeeper'], "")
         )
         data["is_testing"] = "1" if testing else "0"
         data["eip"] = self.hostclass_option_default(hostclass, "eip")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.82"
+__version__ = "1.0.83"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
`_get_hostclass_ip_address` takes 2 arguments but we are passing a tuple containing 2 fields by accident. This causes the zookeeper IP in user data to be set to `None`