### PR TITLE
Changed post-bake shutdown command.

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -392,7 +392,7 @@ class DiscoBake(object):
             # for root login in production and we shutdown via the shutdown command to make
             # sure the snapshot is of a clean filesystem that won't trigger fsck on start.
             # We use nothrow to ignore ssh's 255 exit code on shutdown of centos7
-            self.remotecmd(instance, ["rm -Rf /root/.ssh/authorized_keys ; shutdown now -P"], nothrow=True)
+            self.remotecmd(instance, ["rm -Rf /root/.ssh/authorized_keys ; shutdown now -h"], nothrow=True)
             wait_for_state(instance, u'stopped', 300)
             logging.info("Creating snapshot from instance")
 
@@ -682,7 +682,9 @@ class DiscoBake(object):
         elif hostclass:
             filters = {}
             filters["name"] = "{0} *".format(hostclass)
-            amis = self.ami_filter(self.get_amis(filters=filters), stage, product_line)
+            amis = self.get_amis(filters=filters)
+            logging.debug("AMI search for %s found %s", filters, amis)
+            amis = self.ami_filter(amis, stage, product_line)
             return max(amis, key=self.ami_timestamp) if amis else None
         else:
             raise ValueError("Must specify either hostclass or AMI")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.79"
+__version__ = "1.0.80"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.84"
+__version__ = "1.0.85"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.85"
+__version__ = "1.0.86"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Using shutdown -P appears to not actually shut down our CentOS5 instance: switching to shutdown -h, which should "do the right thing" under more circumstances.

Rumor has it there was a reason not to do this originally, in which case we may have to get clever and selective about how we use this.