### PR TITLE
Fix parsing alarm names for metrics that have underscores

### DIFF
--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -117,7 +117,21 @@ class DiscoAlarmConfig(object):
         Raises AlarmConfigError if unable to parse the alarm name.
         """
         parts = name.split("_")
-        if len(parts) == 5:
+        if len(parts) > 5:
+            # alarm names that have extra underscores
+            # Assume this means the metric name portion has underscores
+            # FIXME this won't work if the alarm is missing a team name AND the metric name has underscores
+            # FIXME consider using different delimiters in the future
+            return {
+                "team": parts[0],
+                "env": parts[1],
+                "hostclass": parts[2],
+                # some metric names have '_'. Assume that any extra '_' in the alarm name are the metric name
+                "metric_name": '_'.join(parts[3:-1]),
+                "threshold_type": parts[-1],
+            }
+        elif len(parts) == 5:
+            # alarm names that contain a team name and a metric name without underscores
             return {
                 "team": parts[0],
                 "env": parts[1],
@@ -126,6 +140,7 @@ class DiscoAlarmConfig(object):
                 "threshold_type": parts[4],
             }
         elif len(parts) == 4:
+            # alarm names that don't contain a team name and a metric name without underscores
             return {
                 "team": None,
                 "env": parts[0],

--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -117,7 +117,7 @@ class DiscoAlarmConfig(object):
         Raises AlarmConfigError if unable to parse the alarm name.
         """
         parts = name.split("_")
-        if len(parts) > 5:
+        if len(parts) >= 5:
             # alarm names that have extra underscores
             # Assume this means the metric name portion has underscores
             # FIXME this won't work if the alarm is missing a team name AND the metric name has underscores
@@ -129,15 +129,6 @@ class DiscoAlarmConfig(object):
                 # some metric names have '_'. Assume that any extra '_' in the alarm name are the metric name
                 "metric_name": '_'.join(parts[3:-1]),
                 "threshold_type": parts[-1],
-            }
-        elif len(parts) == 5:
-            # alarm names that contain a team name and a metric name without underscores
-            return {
-                "team": parts[0],
-                "env": parts[1],
-                "hostclass": parts[2],
-                "metric_name": parts[3],
-                "threshold_type": parts[4],
             }
         elif len(parts) == 4:
             # alarm names that don't contain a team name and a metric name without underscores

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.87"
+__version__ = "1.0.88"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_alarm.py
+++ b/test/unit/test_disco_alarm.py
@@ -133,6 +133,18 @@ class DiscoAlarmTests(TestCase):
         self.assertEqual(
             DiscoAlarmConfig.decode_alarm_name("rocket_ci_mhcscone_CPUUtilization_max"), expected)
 
+    def test_decode_alarm_name_extra_underscores(self):
+        """Decoding Team based Alarm Names works with metric names containing underscores"""
+        expected = {
+            "team": "rocket",
+            "env": "ci",
+            "hostclass": "mhcscone",
+            "metric_name": "HTTPCode_Backend_5xx",
+            "threshold_type": "max",
+        }
+        self.assertEqual(
+            DiscoAlarmConfig.decode_alarm_name("rocket_ci_mhcscone_HTTPCode_Backend_5xx_max"), expected)
+
     def test_decode_bogus_alarm_name_raises(self):
         """decode_alarm_name raises on bogus name"""
         self.assertRaises(AlarmConfigError, DiscoAlarmConfig.decode_alarm_name, "bogus")


### PR DESCRIPTION
The alarm name is generated from the metric name, environment name, hostclass name and team team. 
We try to split those components out of the alarm name but the split logic breaks if the metric name has underscores such as `HTTPCode_Backend_500`