### PR TITLE
use ACM for all regions and support wildcard certificate domains

### DIFF
--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -22,7 +22,15 @@ class DiscoACM(object):
         self._acm = connection
 
     def _in_domain(self, domain, dns_name):
-        """Returns whether the host is in the ACM certificate domain"""
+        """
+        Returns whether the host is in the ACM certificate domain
+        Only supports top level domain wildcard matching
+        e.g. *.blah.com will match, but not *.*.blah.com
+        It would be good to use a standard library here if becomes available.
+        """
+        if not (domain and dns_name):
+            return False
+
         if dns_name == domain:
             return True
 
@@ -31,9 +39,9 @@ class DiscoACM(object):
         if not name:
             return False
 
-        domain_suffix = (domain[len(self.WILDCARD_PREFIX):]
-                         if domain.startswith(self.WILDCARD_PREFIX) else domain)
-        return subdomain.endswith(domain_suffix)
+        if domain.startswith(self.WILDCARD_PREFIX):
+            domain = domain[len(self.WILDCARD_PREFIX):]
+        return subdomain == domain
 
     @property
     def acm(self):

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -6,6 +6,9 @@ import logging
 import boto3
 import botocore
 
+CERT_SUMMARY_LIST_KEY = 'CertificateSummaryList'
+CERT_ARN_KEY = 'CertificateArn'
+DOMAIN_NAME_KEY = 'DomainName'
 
 class DiscoACM(object):
     """
@@ -36,7 +39,6 @@ class DiscoACM(object):
         """
         Lazily creates ACM connection
 
-        NOTE!!! As of 2016-02-11 ACM is not supported outside the us-east-1 region.
         Return None if service does not exist in current region
         """
         if not self._acm:
@@ -53,8 +55,8 @@ class DiscoACM(object):
             return None
 
         try:
-            certs = self.acm.list_certificates()["CertificateSummaryList"]
-            cert = [cert['CertificateArn'] for cert in certs if self._in_domain(cert['DomainName'], dns_name)]
+            certs = self.acm.list_certificates()[CERT_SUMMARY_LIST_KEY]
+            cert = [cert[CERT_ARN_KEY] for cert in certs if self._in_domain(cert[DOMAIN_NAME_KEY], dns_name)]
             return cert[0] if cert else None
         except (botocore.exceptions.EndpointConnectionError,
                 botocore.vendored.requests.exceptions.ConnectionError):

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -10,6 +10,7 @@ CERT_SUMMARY_LIST_KEY = 'CertificateSummaryList'
 CERT_ARN_KEY = 'CertificateArn'
 DOMAIN_NAME_KEY = 'DomainName'
 
+
 class DiscoACM(object):
     """
     A class to manage the Amazon Certificate Service

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -28,7 +28,7 @@ class DiscoACM(object):
             return False
 
         domain_suffix = (domain[len(self.WILDCARD_PREFIX):]
-            if domain.startswith(self.WILDCARD_PREFIX) else domain)
+                         if domain.startswith(self.WILDCARD_PREFIX) else domain)
         return subdomain.endswith(domain_suffix)
 
     @property

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -55,9 +55,11 @@ class DiscoACM(object):
             return None
 
         try:
-            certs = self.acm.list_certificates()[CERT_SUMMARY_LIST_KEY]
-            cert = [cert[CERT_ARN_KEY] for cert in certs if self._in_domain(cert[DOMAIN_NAME_KEY], dns_name)]
-            return cert[0] if cert else None
+            cert_summary = self.acm.list_certificates()[CERT_SUMMARY_LIST_KEY]
+            certs = [cert for cert in cert_summary if self._in_domain(cert[DOMAIN_NAME_KEY], dns_name)]
+            # determine the most specific domain match
+            certs.sort(key=lambda cert: len(cert[DOMAIN_NAME_KEY]), reverse=True)
+            return certs[0][CERT_ARN_KEY] if certs else None
         except (botocore.exceptions.EndpointConnectionError,
                 botocore.vendored.requests.exceptions.ConnectionError):
             # some versions of botocore(1.3.26) will try to connect to acm even if outside us-east-1

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -34,7 +34,7 @@ class DiscoACM(object):
         # sanity check left-most label
         name, subdomain = dns_name.split('.', 1)
         if not name or name == '*':
-            logging.error('Left-most label "{}" of "{}" is invalid'.format(name, dns_name))
+            logging.error('Left-most label "%s" of "%s" is invalid', name, dns_name)
             return False
 
         # exact match

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -31,14 +31,17 @@ class DiscoACM(object):
         if not (domain and dns_name):
             return False
 
+        # sanity check left-most label
+        name, subdomain = dns_name.split('.', 1)
+        if not name or name == '*':
+            logging.error('Left-most label "{}" of "{}" is invalid'.format(name, dns_name))
+            return False
+
+        # exact match
         if dns_name == domain:
             return True
 
         # handle wildcard cert domains
-        name, subdomain = dns_name.split('.', 1)
-        if not name:
-            return False
-
         if domain.startswith(self.WILDCARD_PREFIX):
             domain = domain[len(self.WILDCARD_PREFIX):]
         return subdomain == domain

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.95"
+__version__ = "1.0.96"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.88"
+__version__ = "1.0.89"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -6,16 +6,18 @@ from mock import MagicMock
 
 from disco_aws_automation import DiscoACM
 from disco_aws_automation.disco_acm import (
+    CERT_SUMMARY_LIST_KEY,
     CERT_ARN_KEY,
     DOMAIN_NAME_KEY
 )
 
 TEST_DOMAIN_NAME = 'test.example.com'
 TEST_WILDCARD_DOMAIN_NAME = '*.example.com'
-TEST_CERTIFICATE_ARN_ACM = "arn:aws:acm::123:blah"
+TEST_CERTIFICATE_ARN_ACM_EXACT = "arn:aws:acm::123:exact"
+TEST_CERTIFICATE_ARN_ACM_WILDCARD = "arn:aws:acm::123:wildcard"
 
-TEST_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM, DOMAIN_NAME_KEY: TEST_DOMAIN_NAME}
-TEST_WILDCARD_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM, DOMAIN_NAME_KEY: TEST_WILDCARD_DOMAIN_NAME}
+TEST_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM_EXACT, DOMAIN_NAME_KEY: TEST_DOMAIN_NAME}
+TEST_WILDCARD_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM_WILDCARD, DOMAIN_NAME_KEY: TEST_WILDCARD_DOMAIN_NAME}
 
 class DiscoACMTests(TestCase):
     '''Test disco_acm.py'''
@@ -26,10 +28,37 @@ class DiscoACMTests(TestCase):
 
     def test_get_certificate_arn_exact_match(self):
         """exact match between the host and cert work"""
-        self._acm.list_certificates.return_value = [TEST_CERT]
-        self.assertTrue(self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME))
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
+                         self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
+                         'Exact matching of host domain name to cert domain needs to be fixed.')
 
-    def test_get_certificate_arn_exact_match_wildcard(self):
-        """exact match between the host and wildcard cert do not work"""
-        self._acm.list_certificates.return_value = [TEST_WILDCARD_CERT]
-        self.assertFalse(self.disco_acm.get_certificate_arn(TEST_WILDCARD_DOMAIN_NAME))
+    def test_get_certificate_arn_wildcard_match(self):
+        """wildcard match between the host and cert work"""
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
+                         self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
+                         'Exact matching of host domain name to cert domain needs to be fixed.')
+
+    def test_get_certificate_arn_no_match(self):
+        """host that does not match cert domains should NOT return a cert"""
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
+                                                        [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertFalse(self.disco_acm.get_certificate_arn('non.existent.cert.domain'),
+                         'Matching of host domain name to cert domain is generating false positives.')
+
+    def test_get_certificate_arn_match_most_specific(self):
+        """
+        test both orderings of exact and wildcard matching cert domains
+        to ensure the host domain matches the most specific cert domain in both cases
+        """
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
+                                                        [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
+                         self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
+                         'Failed to match most specific cert domain.')
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
+                                                        [TEST_WILDCARD_CERT, TEST_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
+                         self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
+                         'Failed to match most specific cert domain.')

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -1,0 +1,35 @@
+"""
+Tests of disco_acm
+"""
+from unittest import TestCase
+from mock import MagicMock
+
+from disco_aws_automation import DiscoACM
+from disco_aws_automation.disco_acm import (
+    CERT_ARN_KEY,
+    DOMAIN_NAME_KEY
+)
+
+TEST_DOMAIN_NAME = 'test.example.com'
+TEST_WILDCARD_DOMAIN_NAME = '*.example.com'
+TEST_CERTIFICATE_ARN_ACM = "arn:aws:acm::123:blah"
+
+TEST_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM, DOMAIN_NAME_KEY: TEST_DOMAIN_NAME}
+TEST_WILDCARD_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM, DOMAIN_NAME_KEY: TEST_WILDCARD_DOMAIN_NAME}
+
+class DiscoACMTests(TestCase):
+    '''Test disco_acm.py'''
+
+    def setUp(self):
+        self._acm = MagicMock()
+        self.disco_acm = DiscoACM(self._acm)
+
+    def test_get_certificate_arn_exact_match(self):
+        """exact match between the host and cert work"""
+        self._acm.list_certificates.return_value = [TEST_CERT]
+        self.assertTrue(self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME))
+
+    def test_get_certificate_arn_exact_match_wildcard(self):
+        """exact match between the host and wildcard cert do not work"""
+        self._acm.list_certificates.return_value = [TEST_WILDCARD_CERT]
+        self.assertFalse(self.disco_acm.get_certificate_arn(TEST_WILDCARD_DOMAIN_NAME))

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -30,41 +30,66 @@ class DiscoACMTests(TestCase):
         self.disco_acm = DiscoACM(self._acm)
 
     def test_get_certificate_arn_exact_match(self):
-        """exact match between the host and cert work"""
+        """
+        exact match between the host and cert work
+        e.g. a.b.c matches a.b.c
+        """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT]}
         self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Exact matching of host domain name to cert domain needs to be fixed.')
 
     def test_get_certificate_arn_wildcard_match(self):
-        """wildcard match between the host and cert work"""
+        """
+        wildcard match between the host and cert work
+        e.g. a.b.c matches *.b.c
+        """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_WILDCARD_CERT]}
         self.assertEqual(TEST_CERTIFICATE_ARN_ACM_WILDCARD,
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Exact matching of host domain name to cert domain needs to be fixed.')
 
     def test_get_certificate_arn_empty(self):
-        """empty string should not should NOT return a cert"""
+        """
+        empty string should not should NOT return a cert
+        e.g. '' does not match a.b.c or *.b.c
+        """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertFalse(self.disco_acm.get_certificate_arn(''),
                          'An empty string should not match certs.')
 
     def test_get_certificate_arn_no_hostname(self):
-        """dns names beginning with . should NOT return a cert"""
+        """
+        dns names beginning with . should NOT return a cert
+        e.g. .b.c does not match a.b.c or *.b.c
+        """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertFalse(self.disco_acm.get_certificate_arn('.example.com'),
                          'A missing host name should not match cert domains.')
 
     def test_get_certificate_arn_no_match(self):
-        """host that does not match cert domains should NOT return a cert"""
+        """
+        host that does not match cert domains should NOT return a cert
+        e.f.g.h does not match a.b.c or *.b.c
+        """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertFalse(self.disco_acm.get_certificate_arn('non.existent.cert.domain'),
                          'Matching of host domain name to cert domain is generating false positives.')
+
+    def test_get_certificate_arn_substring(self):
+        """
+        host that is a only a substring of a domain should NOT return a cert
+        a.b does not match a.b.c or *.b.c
+        """
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertFalse(self.disco_acm.get_certificate_arn('test.example'),
+                         'a.b should not match a.b.c or *.b.c.')
 
     def test_get_cert_arn_match_most_specific(self):
         """
         test both orderings of exact and wildcard matching cert domains
         to ensure the host domain matches the most specific cert domain in both cases
+        a.b.c will match a.b.c in preference to *.b.c
         """
         self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -43,12 +43,17 @@ class DiscoACMTests(TestCase):
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Exact matching of host domain name to cert domain needs to be fixed.')
 
-    def test_get_certificate_arn_deep_match(self):
-        """a host that matches a wildcard cert domain more than one level down should return a cert"""
-        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_WILDCARD_CERT]}
-        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_WILDCARD,
-                         self.disco_acm.get_certificate_arn(TEST_DEEP_DOMAIN_NAME),
-                         'Matching of host domain name to a nested cert subdomain needs to be fixed.')
+    def test_get_certificate_arn_empty(self):
+        """empty string should not should NOT return a cert"""
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertFalse(self.disco_acm.get_certificate_arn(''),
+                         'An empty string should not match certs.')
+
+    def test_get_certificate_arn_no_hostname(self):
+        """dns names beginning with . should NOT return a cert"""
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertFalse(self.disco_acm.get_certificate_arn('.example.com'),
+                         'A missing host name should not match cert domains.')
 
     def test_get_certificate_arn_no_match(self):
         """host that does not match cert domains should NOT return a cert"""

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -17,7 +17,9 @@ TEST_CERTIFICATE_ARN_ACM_EXACT = "arn:aws:acm::123:exact"
 TEST_CERTIFICATE_ARN_ACM_WILDCARD = "arn:aws:acm::123:wildcard"
 
 TEST_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM_EXACT, DOMAIN_NAME_KEY: TEST_DOMAIN_NAME}
-TEST_WILDCARD_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM_WILDCARD, DOMAIN_NAME_KEY: TEST_WILDCARD_DOMAIN_NAME}
+TEST_WILDCARD_CERT = {CERT_ARN_KEY: TEST_CERTIFICATE_ARN_ACM_WILDCARD,
+                      DOMAIN_NAME_KEY: TEST_WILDCARD_DOMAIN_NAME}
+
 
 class DiscoACMTests(TestCase):
     '''Test disco_acm.py'''
@@ -42,23 +44,20 @@ class DiscoACMTests(TestCase):
 
     def test_get_certificate_arn_no_match(self):
         """host that does not match cert domains should NOT return a cert"""
-        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
-                                                        [TEST_CERT, TEST_WILDCARD_CERT]}
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertFalse(self.disco_acm.get_certificate_arn('non.existent.cert.domain'),
                          'Matching of host domain name to cert domain is generating false positives.')
 
-    def test_get_certificate_arn_match_most_specific(self):
+    def test_get_cert_arn_match_most_specific(self):
         """
         test both orderings of exact and wildcard matching cert domains
         to ensure the host domain matches the most specific cert domain in both cases
         """
-        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
-                                                        [TEST_CERT, TEST_WILDCARD_CERT]}
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
         self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Failed to match most specific cert domain.')
-        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY:
-                                                        [TEST_WILDCARD_CERT, TEST_CERT]}
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_WILDCARD_CERT, TEST_CERT]}
         self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Failed to match most specific cert domain.')

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -49,6 +49,15 @@ class DiscoACMTests(TestCase):
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Exact matching of host domain name to cert domain needs to be fixed.')
 
+    def test_get_certificate_arn_bad_left_label(self):
+        """
+        host name starting with *. is invalid and should not return a cert match
+        e.g. *.b.c does not match a.b.c or *.b.c
+        """
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT, TEST_WILDCARD_CERT]}
+        self.assertFalse(self.disco_acm.get_certificate_arn(TEST_WILDCARD_DOMAIN_NAME),
+                         'An FQDN with an invalid left-most label should not match.')
+
     def test_get_certificate_arn_empty(self):
         """
         empty string should not should NOT return a cert

--- a/test/unit/test_disco_acm.py
+++ b/test/unit/test_disco_acm.py
@@ -12,6 +12,7 @@ from disco_aws_automation.disco_acm import (
 )
 
 TEST_DOMAIN_NAME = 'test.example.com'
+TEST_DEEP_DOMAIN_NAME = 'a.deeper.test.example.com'
 TEST_WILDCARD_DOMAIN_NAME = '*.example.com'
 TEST_CERTIFICATE_ARN_ACM_EXACT = "arn:aws:acm::123:exact"
 TEST_CERTIFICATE_ARN_ACM_WILDCARD = "arn:aws:acm::123:wildcard"
@@ -37,10 +38,17 @@ class DiscoACMTests(TestCase):
 
     def test_get_certificate_arn_wildcard_match(self):
         """wildcard match between the host and cert work"""
-        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_CERT]}
-        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_EXACT,
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_WILDCARD_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_WILDCARD,
                          self.disco_acm.get_certificate_arn(TEST_DOMAIN_NAME),
                          'Exact matching of host domain name to cert domain needs to be fixed.')
+
+    def test_get_certificate_arn_deep_match(self):
+        """a host that matches a wildcard cert domain more than one level down should return a cert"""
+        self._acm.list_certificates.return_value = {CERT_SUMMARY_LIST_KEY: [TEST_WILDCARD_CERT]}
+        self.assertEqual(TEST_CERTIFICATE_ARN_ACM_WILDCARD,
+                         self.disco_acm.get_certificate_arn(TEST_DEEP_DOMAIN_NAME),
+                         'Matching of host domain name to a nested cert subdomain needs to be fixed.')
 
     def test_get_certificate_arn_no_match(self):
         """host that does not match cert domains should NOT return a cert"""


### PR DESCRIPTION
- [x] unit tests

Note this only works for new elbs.  There is an existing bug that causes elb updates to not work properly in all cases.