### PR TITLE
Add config directory init.d to update-creds script

### DIFF
--- a/sample_configuration/discoroot/etc/init.d/disco-update-creds
+++ b/sample_configuration/discoroot/etc/init.d/disco-update-creds
@@ -154,6 +154,9 @@ get_config_files() {
 
     files="$files\n$(find /opt/splunkforwarder/etc 2> /dev/null)"
 
+    # init.d scripts
+    files="$files\n$(find /etc/init.d 2> /dev/null)"
+
     echo -e "$files"
 }
 


### PR DESCRIPTION
This adds /etc/init.d direcotry to the disco-update-creds script so while provisioning asiaq substitutes credentials substitution string with passwords in any configs located in beforementioned directory or its subdirectories. This is necessary for story DS-12372 (Create and configure new hostclass for mhcqueuewebsync in aws) because the mhcqueuewebsync hostclass has configs with sensitive data in /etc/init.d directory.