### PR TITLE
Adding NAT EIPs in ES access policy (whitelist)

### DIFF
--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -15,6 +15,7 @@ from .disco_route53 import DiscoRoute53
 from .resource_helper import throttled_call
 from .disco_aws_util import is_truthy
 from .disco_constants import DEFAULT_CONFIG_SECTION
+from .disco_vpc import CONFIG_FILE as VPC_CONFIG_FILE
 
 CONFIG_FILE = "disco_elasticsearch.ini"
 
@@ -27,7 +28,7 @@ class DiscoElasticsearch(object):
     def __init__(self, environment_name, config_aws=None, config_es=None,
                  config_vpc=None, route53=None):
         self.config_aws = config_aws or read_config()
-        self.config_vpc = config_vpc or read_config('disco_vpc.ini')
+        self.config_vpc = config_vpc or read_config(VPC_CONFIG_FILE)
         self.config_es = config_es or read_config(CONFIG_FILE)
         self.route53 = route53 or DiscoRoute53()
 

--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -195,9 +195,9 @@ class DiscoElasticsearch(object):
         proxy_hostclass = self.get_aws_option('http_proxy_hostclass')
         proxy_ip = self.get_hostclass_option('eip', proxy_hostclass)
         allowed_source_ips.append(proxy_ip)
-        if self._get_nat_eips():
-            nat_eips = self._get_nat_eips().split(',')
-            allowed_source_ips += nat_eips
+        nat_eips = self._get_nat_eips()
+        if nat_eips:
+            allowed_source_ips += nat_eips.split(',')
 
         resource = "arn:aws:es:{region}:{account}:domain/{domain_name}/*".format(region=self.region,
                                                                                  account=self.account_id,

--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -194,10 +194,10 @@ class DiscoElasticsearch(object):
         """
         proxy_hostclass = self.get_aws_option('http_proxy_hostclass')
         proxy_ip = self.get_hostclass_option('eip', proxy_hostclass)
-        nat_eips = self._get_nat_eips().split(',')
-
         allowed_source_ips.append(proxy_ip)
-        allowed_source_ips += nat_eips
+        if self._get_nat_eips():
+            nat_eips = self._get_nat_eips().split(',')
+            allowed_source_ips += nat_eips
 
         resource = "arn:aws:es:{region}:{account}:domain/{domain_name}/*".format(region=self.region,
                                                                                  account=self.account_id,
@@ -423,4 +423,7 @@ class DiscoElasticsearch(object):
 
     def _get_nat_eips(self):
         env_option = 'envtype:{}'.format(self.environment_name)
-        return self.config_vpc.get(env_option, 'tunnel_nat_gateways')
+        if self.config_vpc.has_option(env_option, 'tunnel_nat_gateways'):
+            return self.config_vpc.get(env_option, 'tunnel_nat_gateways')
+        else:
+            return None

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.91"
+__version__ = "1.0.93"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.90"
+__version__ = "1.0.91"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
In order to send logs to Elasticsearch using NAT service, we have to *whitelist* NAT EIPs