### PR TITLE
Fix blue/green handling of non-deploy hostclasses

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.90"
+__version__ = "1.0.91"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -603,8 +603,30 @@ class DiscoDeployTests(TestCase):
         self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
-    def test_bg_with_hostclass_not_in_pipeline(self):
-        '''Blue/green deploys as non-deployable if hostclass is not in pipeline'''
+    def test_bg_with_hc_not_in_pl_and_no_group(self):
+        '''Blue/green is non-deployable if hostclass is not in pipeline, and dies with no existing group'''
+        ami = MagicMock()
+        ami.name = "mhcfoo 2"
+        ami.id = "ami-12345678"
+        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
+        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
+        new_group = self.mock_group("mhcfoo")
+        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
+        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_aws.instances.return_value = instances
+        self._disco_aws.remotecmd.return_value = (1, "")
+        self.assertTrue(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
+        self._disco_elb.wait_for_instance_health_state.assert_not_called()
+        self._disco_aws.spinup.assert_called_once_with(
+            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
+              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
+              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+
+    def test_bg_with_hc_not_in_pl_and_group(self):
+        '''Blue/green is non-deployable if hostclass is not in pipeline, dies, and updates existing group'''
         ami = MagicMock()
         ami.name = "mhcfoo 2"
         ami.id = "ami-12345678"
@@ -620,10 +642,13 @@ class DiscoDeployTests(TestCase):
         self.assertTrue(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with([{
-            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 2,
-            'integration_test': None, 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
-            'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_has_calls(
+            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 2,
+                    'integration_test': None, 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
+                    'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True),
+             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 2,
+                    'integration_test': None, 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
+                    'hostclass': 'mhcfoo'}], group_name=old_group.name)])
         self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_integration_tests_with_elb(self):


### PR DESCRIPTION
When a non-deployable hostclass is tested via blue/green and that
hostclass already has an ASG present, the old ASG should be updated to
use the new AMI in the future. This helps maintain the plausible
workflow of using `disco_deploy.py update` to update the AMI used by the
autoscaling group if tests pass. Then the running instances can be
terminated later so that autoscaling brings up instances with the new AMI.