### PR TITLE
Minor logging enhancement for disco_autoscale.

### DIFF
--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -138,6 +138,7 @@ class DiscoAutoscale(object):
 
     def clean_configs(self):
         '''Delete unused Launch Configurations in current environment'''
+        logging.info("Cleaning up unused launch configurations in %s", self.environment_name)
         for config in self._get_config_generator():
             try:
                 self.delete_config(config.name)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.93"
+__version__ = "1.0.94"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
We log at the info level when we delete something, but we do not log that we are about to delete things, which is disconcerting for people who were launching some unrelated hostclass.