### PR TITLE
Add support for multiple elb ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1730,8 +1730,8 @@ Options:
 -   `elb_health_check_url` [Default /] The heartbeat end-point to test instance health
 -   `elb_instance_port` [Default=80] The port number that your services are running on
 -   `elb_instance_protocol` [Default inferred from port] HTTP | HTTPS | SSL | TCP
--   `elb_port` [Default=80] The port number to expose in the ELB
--   `elb_protocol` [Default inferred from port] HTTP | HTTPS | SSL | TCP
+-   `elb_port` [Default=80] List of port numbers to expose in the ELB
+-   `elb_protocol` [Default inferred from port] List of protocols to expose from ELB. HTTP | HTTPS | SSL | TCP
 -   `elb_public` [Default no] yes | no Should the ELB have a publicly routable IP
 -   `elb_sticky_app_cookie` [Optional] Enable sticky sessions by setting the session cookie of your application
 -   `elb_idle_timeout` [Default=300] Timeout before ELB kills idle connections

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -289,7 +289,7 @@ class DiscoAWS(object):
                 elb_subnets = self.get_subnets(elb_meta_network, hostclass)
                 subnet_ids = [subnet['SubnetId'] for subnet in elb_subnets]
 
-            elb_port = int(self.hostclass_option_default(hostclass, "elb_port", 80))
+            elb_port = self.hostclass_option_default(hostclass, "elb_port", 80)
             elb_protocol = self.hostclass_option_default(hostclass, "elb_protocol", None) or \
                 self._default_protocol_for_port(elb_port)
             instance_port = int(self.hostclass_option_default(hostclass, "elb_instance_port", 80))
@@ -303,7 +303,7 @@ class DiscoAWS(object):
                 hosted_zone_name=self.hostclass_option_default(hostclass, "domain_name"),
                 health_check_url=self.hostclass_option_default(hostclass, "elb_health_check_url"),
                 instance_protocol=instance_protocol, instance_port=instance_port,
-                elb_protocol=elb_protocol, elb_port=elb_port,
+                elb_protocols=elb_protocol, elb_ports=elb_port,
                 elb_public=is_truthy(self.hostclass_option_default(hostclass, "elb_public", "no")),
                 sticky_app_cookie=self.hostclass_option_default(hostclass, "elb_sticky_app_cookie", None),
                 idle_timeout=int(self.hostclass_option_default(hostclass, "elb_idle_timeout", 300)),

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -121,24 +121,26 @@ class DiscoELB(object):
                            'UnhealthyThreshold': 2,
                            'HealthyThreshold': 2})
 
-    def _setup_sticky_cookies(self, elb_id, elb_port, sticky_app_cookie, elb_name):
+    def _setup_sticky_cookies(self, elb_id, elb_ports, sticky_app_cookie, elb_name):
         if sticky_app_cookie:
             logging.warning("Using sticky sessions for ELB %s", elb_name)
             throttled_call(self.elb_client.create_app_cookie_stickiness_policy,
                            LoadBalancerName=elb_id,
                            PolicyName=STICKY_POLICY_NAME,
                            CookieName=sticky_app_cookie)
-            throttled_call(self.elb_client.set_load_balancer_policies_of_listener,
-                           LoadBalancerName=elb_id,
-                           LoadBalancerPort=elb_port,
-                           PolicyNames=[STICKY_POLICY_NAME])
+            # add sticky sessions policy to every listener
+            for elb_port in elb_ports:
+                throttled_call(self.elb_client.set_load_balancer_policies_of_listener,
+                               LoadBalancerName=elb_id,
+                               LoadBalancerPort=int(elb_port),
+                               PolicyNames=[STICKY_POLICY_NAME])
         # TBD Remove stickiness policy if it exists
 
     # Pylint thinks this function has too many arguments
     # pylint: disable=R0913, R0914
     def get_or_create_elb(self, hostclass, security_groups, subnets, hosted_zone_name,
                           health_check_url, instance_protocol, instance_port,
-                          elb_protocol, elb_port, elb_public, sticky_app_cookie,
+                          elb_protocols, elb_ports, elb_public, sticky_app_cookie,
                           idle_timeout=None, connection_draining_timeout=None, testing=False):
         """
         Returns an elb.
@@ -153,8 +155,8 @@ class DiscoELB(object):
             health_check_url (str): The heartbeat url to use if protocol is HTTP or HTTPS
             instance_protocol (str): HTTP, HTTPS, SSL or TCP
             instance_port (int): The port that services on instances are running on
-            elb_protocol (str): HTTP, HTTPS, SSL or TCP
-            elb_port (int): The port to expose from the load balancer
+            elb_protocols (str): Comma separated list of protocols to expose. HTTP, HTTPS, SSL or TCP
+            elb_ports (str): Comma separated list of ports to expose from the load balancer
             elb_public (bool): True if the ELB should be internet routable
             sticky_app_cookie (str): The name of a cookie from your service to use for sticky sessions
             idle_timeout (int): time limit (in seconds) that ELB should wait before killing idle connections
@@ -166,23 +168,31 @@ class DiscoELB(object):
         elb_id = DiscoELB.get_elb_id(self.vpc.environment_name, hostclass, testing=testing)
         elb_name = DiscoELB.get_elb_name(self.vpc.environment_name, hostclass, testing=testing)
         elb = self.get_elb(hostclass, testing=testing)
+
+        elb_protocols = str(elb_protocols).split(',')
+        elb_ports = str(elb_ports).split(',')
+
         if not elb:
             logging.info("Creating ELB %s", elb_name)
 
-            listener = {
-                'Protocol': elb_protocol,
-                'LoadBalancerPort': elb_port,
-                'InstanceProtocol': instance_protocol,
-                'InstancePort': instance_port
-            }
+            if len(elb_protocols) != len(elb_ports):
+                raise CommandError('The number of ELB ports and protocols must match for ELB %s', elb_name)
 
-            # Only try to lookup a cert if we are using a secure protocol for the ELB
-            if elb_protocol.upper() in ["HTTPS", "SSL"]:
-                listener['SSLCertificateId'] = self.get_certificate_arn(cname) or ''
+            listeners = [{
+                'Protocol': listener_info[0].strip(),
+                'LoadBalancerPort': int(listener_info[1]),
+                'InstanceProtocol': instance_protocol,
+                'InstancePort': int(instance_port)
+            } for listener_info in zip(elb_protocols, elb_ports)]
+
+            for listener in listeners:
+                # Only try to lookup a cert if we are using a secure protocol for the ELB
+                if listener['Protocol'] in ["HTTPS", "SSL"]:
+                    listener['SSLCertificateId'] = self.get_certificate_arn(cname) or ''
 
             elb_args = {
                 'LoadBalancerName': elb_id,
-                'Listeners': [listener],
+                'Listeners': listeners,
                 'SecurityGroups': security_groups,
                 'Subnets': subnets,
                 'Tags': [
@@ -202,7 +212,7 @@ class DiscoELB(object):
         self.route53.create_record(hosted_zone_name, cname, 'CNAME', elb['DNSName'])
 
         self._setup_health_check(elb_id, health_check_url, instance_protocol, instance_port, elb_name)
-        self._setup_sticky_cookies(elb_id, elb_port, sticky_app_cookie, elb_name)
+        self._setup_sticky_cookies(elb_id, elb_ports, sticky_app_cookie, elb_name)
         self._update_elb_attributes(elb_id, idle_timeout, connection_draining_timeout)
 
         return elb

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -340,9 +340,9 @@ class DiscoAWSTests(TestCase):
 
         aws.elb.delete_elb.assert_not_called()
         aws.elb.get_or_create_elb.assert_called_once_with(
-            'mhcelb', elb_port=80, health_check_url='/foo',
+            'mhcelb', elb_ports=80, health_check_url='/foo',
             hosted_zone_name='example.com', instance_port=80,
-            elb_protocol='HTTP', instance_protocol='HTTP',
+            elb_protocols='HTTP', instance_protocol='HTTP',
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False)

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from mock import MagicMock
 from moto import mock_elb
-from disco_aws_automation import DiscoELB
+from disco_aws_automation import DiscoELB, CommandError
 
 TEST_ENV_NAME = 'unittestenv'
 TEST_HOSTCLASS = 'mhcunit'
@@ -34,7 +34,7 @@ class DiscoELBTests(TestCase):
     # pylint: disable=too-many-arguments
     def _create_elb(self, hostclass=None, public=False, tls=False,
                     instance_protocol='HTTP', instance_port=80,
-                    elb_protocol='HTTP', elb_port=80,
+                    elb_protocols='HTTP', elb_ports='80',
                     idle_timeout=None, connection_draining_timeout=None,
                     sticky_app_cookie=None):
         return self.disco_elb.get_or_create_elb(
@@ -45,8 +45,8 @@ class DiscoELBTests(TestCase):
             health_check_url="/" if instance_protocol.upper() in ('HTTP', 'HTTPS') else "",
             instance_protocol=instance_protocol,
             instance_port=instance_port,
-            elb_protocol="HTTPS" if tls else elb_protocol,
-            elb_port=443 if tls else elb_port,
+            elb_protocols="HTTPS" if tls else elb_protocols,
+            elb_ports='443' if tls else elb_ports,
             elb_public=public,
             sticky_app_cookie=sticky_app_cookie,
             idle_timeout=idle_timeout,
@@ -180,7 +180,7 @@ class DiscoELBTests(TestCase):
         elb_client = self.disco_elb.elb_client
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
         self._create_elb(instance_protocol='TCP', instance_port=25,
-                         elb_protocol='TCP', elb_port=25)
+                         elb_protocols='TCP', elb_ports=25)
         elb_client.create_load_balancer.assert_called_once_with(
             LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
             Listeners=[{
@@ -196,6 +196,43 @@ class DiscoELBTests(TestCase):
                 "Key": "elb_name",
                 "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
             }])
+
+    @mock_elb
+    def test_get_elb_with_multiple_ports(self):
+        """Test creating an ELB that listens on multiple ports"""
+        elb_client = self.disco_elb.elb_client
+        elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
+        self._create_elb(instance_protocol='HTTP', instance_port=80,
+                         elb_protocols='HTTP, HTTPS', elb_ports='80, 443')
+        elb_client.create_load_balancer.assert_called_once_with(
+            LoadBalancerName=DiscoELB.get_elb_id('unittestenv', 'mhcunit'),
+            Listeners=[{
+                'Protocol': 'HTTP',
+                'LoadBalancerPort': 80,
+                'InstanceProtocol': 'HTTP',
+                'InstancePort': 80
+            }, {
+                'Protocol': 'HTTPS',
+                'LoadBalancerPort': 443,
+                'InstanceProtocol': 'HTTP',
+                'InstancePort': 80,
+                'SSLCertificateId': TEST_CERTIFICATE_ARN_ACM
+            }],
+            Subnets=['sub-1'],
+            SecurityGroups=['sec-1'],
+            Scheme='internal',
+            Tags=[{
+                "Key": "elb_name",
+                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
+            }])
+
+    @mock_elb
+    def test_get_elb_mismatched_ports_protocols(self):
+        """Test that creating an ELB fails when using a different number of ELB ports and protocols"""
+        self.assertRaises(CommandError,
+                          self._create_elb,
+                          elb_protocols='HTTP, HTTPS',
+                          elb_ports='80')
 
     @mock_elb
     def test_get_elb_with_idle_timeout(self):


### PR DESCRIPTION
This adds support for exposing multiple ports and portocols from ELB. 
This does **not** add support for multiple instance ports in order to keep this PR small

The new config looks like:
```ini
[mhcfoo]
elb_protocol=HTTP,HTTPS
elb_port=80,443
```

The above config creates 2 listeners in the ELB. Once that lists on 80 and HTTP and another for 443 and HTTPS. An error is thrown if the number of elb_ports and elb_protocols doesn't match