### PR TITLE
Removed proxy IP from ES access policy

### DIFF
--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -194,7 +194,7 @@ class DiscoElasticsearch(object):
         """
         nat_eips = self._get_nat_eips()
         if nat_eips:
-            allowed_source_ips.append(nat_eips.split(','))
+            allowed_source_ips += nat_eips.split(',')
 
         resource = "arn:aws:es:{region}:{account}:domain/{domain_name}/*".format(region=self.region,
                                                                                  account=self.account_id,

--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -189,15 +189,12 @@ class DiscoElasticsearch(object):
     def _access_policy(self, domain_name, allowed_source_ips):
         """
         Construct an access policy for the new Elasticsearch cluster. Needs to be dynamically created because
-        it will use the environment's proxy hostclass to forward requests to the elasticsearch cluster and the
-        IP of the proxy hostclass could be different at run time.
+        it will use the environment's NAT Gateway to forward requests to the elasticsearch cluster and the
+        IP addresses of the NAT Gateway would be read from disco_vpc.ini.
         """
-        proxy_hostclass = self.get_aws_option('http_proxy_hostclass')
-        proxy_ip = self.get_hostclass_option('eip', proxy_hostclass)
-        allowed_source_ips.append(proxy_ip)
         nat_eips = self._get_nat_eips()
         if nat_eips:
-            allowed_source_ips += nat_eips.split(',')
+            allowed_source_ips.append(nat_eips.split(','))
 
         resource = "arn:aws:es:{region}:{account}:domain/{domain_name}/*".format(region=self.region,
                                                                                  account=self.account_id,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.97"
+__version__ = "1.0.98"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elasticsearch.py
+++ b/test/unit/test_disco_elasticsearch.py
@@ -13,10 +13,6 @@ from test.helpers.patch_disco_aws import get_mock_config
 MOCK_AWS_CONFIG_DEFINITION = {
     "disco_aws": {
         "default_domain_name": "aws.example.com",
-        "http_proxy_hostclass": "mhcproxy"
-    },
-    "mhcproxy": {
-        "eip": "192.0.2.0"
     }
 }
 
@@ -225,7 +221,6 @@ class DiscoElastiSearchTests(TestCase):
         self.assertEquals(domain_config["SnapshotOptions"]["AutomatedSnapshotStartHour"],
                           int(MOCK_ES_CONFIG_DEFINITION[config_section]["snapshot_start_hour"]))
         expected_source_ips = MOCK_ES_CONFIG_DEFINITION[config_section]["allowed_source_ips"].split()
-        expected_source_ips.append(MOCK_AWS_CONFIG_DEFINITION["mhcproxy"]["eip"])
         expected_nat_gateways = MOCK_VPC_CONFIG_DEFINITION['envtype:foo']["tunnel_nat_gateways"].split(',')
         expected_source_ips += expected_nat_gateways
         access_policy = json.loads(domain_config["AccessPolicies"])


### PR DESCRIPTION
Staging and Production environments to not have EIP for mhcs3proxy configured, so **disco_elasticsearch --env staging update** fails. Also, we will be using NAT and not s3proxy to send logs to ES.