### PR TITLE
VPC Update bug fix

### DIFF
--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -313,7 +313,9 @@ class DiscoMetaNetwork(object):
         logging.info("Updating security rules for meta network %s", self.name)
         current_sg_rules = [
             self.create_sg_rule_tuple(
-                rule.ip_protocol, [int(rule.from_port), int(rule.to_port)],
+                rule.ip_protocol,
+                [int(rule.from_port) if rule.from_port else 0,
+                 int(rule.to_port) if rule.to_port else 65535],
                 grant.group_id, grant.cidr_ip)
             for rule in self.security_group.rules
             for grant in rule.grants]

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.99"
+__version__ = "1.0.100"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
When a rule is created with port range of 0:65535, the from_port and to_port of the rule returned from AWS during querying (boto2) are None. We need to default the ports to 0 and 65535, respectively, in that case.