### PR TITLE
Update reference to get_all_security_groups_for_vpc() method

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -20,6 +20,7 @@ from .disco_alarm import DiscoAlarm
 from .disco_aws_util import is_truthy
 from .disco_creds import DiscoS3Bucket
 from .disco_route53 import DiscoRoute53
+from .disco_vpc_sg_rules import DiscoVPCSecurityGroupRules
 from .exceptions import TimeoutError, RDSEnvironmentError
 from .resource_helper import keep_trying
 
@@ -48,6 +49,7 @@ class DiscoRDS(object):
         self.config_rds = read_config(config_file=DEFAULT_CONFIG_FILE_RDS)
         self.client = boto3.client('rds')
         self.vpc = vpc
+        self.disco_vpc_sg_rules = DiscoVPCSecurityGroupRules(vpc, vpc.boto3_ec2)
         self.vpc_name = vpc.environment_name
         if self.vpc_name not in ['staging', 'production']:
             self.domain_name = self.config_aws.get('disco_aws', 'default_domain_name')
@@ -129,7 +131,7 @@ class DiscoRDS(object):
         """
         Returns the intranet security group id for the VPC for the current environment
         """
-        security_groups = self.vpc.get_all_security_groups_for_vpc()
+        security_groups = self.disco_vpc_sg_rules.get_all_security_groups_for_vpc()
         intranet = [sg for sg in security_groups if sg.tags and sg.tags.get("meta_network") == "intranet"][0]
         return intranet.id
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.101"
+__version__ = "1.0.102"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Because the `get_all_security_groups_for_vpc()` method in `disco_vpc.py` has been moved to `disco_vpc_sg_rules.py`.