### PR TITLE
Fix a bug in get_rds_security_group_id() method of disco_rds.py

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -132,10 +132,10 @@ class DiscoRDS(object):
         Returns the intranet security group id for the VPC for the current environment
         """
         security_groups = self.disco_vpc_sg_rules.get_all_security_groups_for_vpc()
-        for sg in security_groups:
-            tags = tag2dict(sg['Tags'])
+        for security_group in security_groups:
+            tags = tag2dict(security_group['Tags'])
             if tags.get("meta_network") == "intranet":
-                return sg['GroupId']
+                return security_group['GroupId']
 
         raise RuntimeError('Security group for intranet meta network is missing.')
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.103"
+__version__ = "1.0.104"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tasks/lint/pep8rc_merged
+++ b/tasks/lint/pep8rc_merged
@@ -1,0 +1,3 @@
+[pep8]
+max_line_length=110
+ignore=E402

--- a/tasks/lint/pep8rc_merged
+++ b/tasks/lint/pep8rc_merged
@@ -1,3 +1,0 @@
-[pep8]
-max_line_length=110
-ignore=E402

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -12,6 +12,8 @@ from test.helpers.patch_disco_aws import get_mock_config
 TEST_ENV_NAME = 'unittestenv'
 TEST_VPC_ID = 'vpc-56e10e3d'  # the hard coded VPC Id that moto will always return
 
+MOCK_SG_GROUP_ID = 'mock_sg_group_id'
+
 
 def _get_vpc_mock():
     """Nastily copied from test_disco_elb"""
@@ -41,24 +43,34 @@ def _get_bucket_mock():
     return bucket
 
 
+def _get_vpc_sg_rules_mock():
+    vpc_sg_rules_mock = MagicMock()
+    vpc_sg_rules_mock.get_all_security_groups_for_vpc.return_value = [{
+        'GroupId': MOCK_SG_GROUP_ID,
+        'Tags': [{'Key': 'meta_network', 'Value': 'intranet'}]}]
+
+    return vpc_sg_rules_mock
+
 class DiscoRDSTests(unittest.TestCase):
     """Test DiscoRDS class"""
 
     def setUp(self):
-        self.rds = DiscoRDS(_get_vpc_mock())
-        self.rds.client = MagicMock()
-        self.rds.get_rds_security_group_id = MagicMock(return_value='fake_security_id')
-        self.rds.config_rds = get_mock_config({
-            'some-env-db-name': {
-                'engine': 'oracle',
-                'allocated_storage': '100',
-                'db_instance_class': 'db.m4.2xlarge',
-                'engine_version': '12.1.0.2.v2',
-                'master_username': 'foo'
+        with patch('disco_aws_automation.disco_rds.DiscoVPCSecurityGroupRules',
+                   return_value=_get_vpc_sg_rules_mock()):
 
-            }
-        })
-        self.rds.domain_name = 'example.com'
+            self.rds = DiscoRDS(_get_vpc_mock())
+            self.rds.client = MagicMock()
+            self.rds.config_rds = get_mock_config({
+                'some-env-db-name': {
+                    'engine': 'oracle',
+                    'allocated_storage': '100',
+                    'db_instance_class': 'db.m4.2xlarge',
+                    'engine_version': '12.1.0.2.v2',
+                    'master_username': 'foo'
+
+                }
+            })
+            self.rds.domain_name = 'example.com'
 
     def test_get_db_parameter_group_family(self):
         """Tests that get_db_parameter_group_family handles all the expected cases"""
@@ -130,3 +142,9 @@ class DiscoRDSTests(unittest.TestCase):
                                                                     'unittestenv-db-name.example.com.',
                                                                     'CNAME',
                                                                     'foo.example.com')
+
+    def test_get_rds_security_group_id(self):
+        """ Verify security group ID is retrieved correctly """
+        sg_group_id = self.rds.get_rds_security_group_id()
+
+        self.assertEqual(MOCK_SG_GROUP_ID, sg_group_id)

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -51,6 +51,7 @@ def _get_vpc_sg_rules_mock():
 
     return vpc_sg_rules_mock
 
+
 class DiscoRDSTests(unittest.TestCase):
     """Test DiscoRDS class"""
 


### PR DESCRIPTION
The get_all_security_groups_for_vpc() method of DiscoVPCSecurityGroupRules is now returning dicts instead of objects.