### PR TITLE
Bug fix: boto3.client.describe_subnets() takes a 'Filters' parameter, not 'filters'

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -226,8 +226,7 @@ class DiscoRDS(object):
             logging.debug("Not deleting subnet group '%s': %s", db_subnet_group_name, repr(err))
 
         db_subnet_group_description = 'Subnet Group for VPC {0}'.format(self.vpc_name)
-        # TODO: Move the logic of querying subnets inside DiscoVPC
-        subnets = self.vpc.boto3_ec2.describe_subnets(filters=self.vpc.vpc_filters())['Subnets']
+        subnets = self.vpc.get_all_subnets()
         subnet_ids = []
         for subnet in subnets:
             tags = tag2dict(subnet['Tags'])

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -411,6 +411,10 @@ class DiscoVPC(object):
         self._destroy_routes()
         self._destroy_vpc()
 
+    def get_all_subnets(self):
+        """ Returns a list of all the subnets in the current VPC """
+        return self.boto3_ec2.describe_subnets(Filters=self.vpc_filters())['Subnets']
+
     def _destroy_instances(self):
         """ Find all instances in vpc and terminate them """
         autoscale = DiscoAutoscale(environment_name=self.environment_name)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.105"
+__version__ = "1.0.106"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -19,20 +19,14 @@ def _get_vpc_mock():
     """Nastily copied from test_disco_elb"""
     vpc_mock = MagicMock()
     vpc_mock.environment_name = TEST_ENV_NAME
-    vpc_mock.vpc = MagicMock()
-    vpc_mock.vpc.id = TEST_VPC_ID
-    mock_boto3_ec2 = MagicMock()
-    mock_boto3_ec2.describe_subnets.return_value = {
-        'Subnets': [
-            {
-                'SubnetId': 'mock_subnet_id',
-                'Tags': [
-                    {'Key': 'meta_network', 'Value': 'intranet'}
-                ]
-            }
-        ]
-    }
-    vpc_mock.boto3_ec2 = mock_boto3_ec2
+    vpc_mock.get_all_subnets.return_value = [
+        {
+            'SubnetId': 'mock_subnet_id',
+            'Tags': [
+                {'Key': 'meta_network', 'Value': 'intranet'}
+            ]
+        }
+    ]
     return vpc_mock
 
 


### PR DESCRIPTION
Also moved the logic that queries subnets into DiscoVPC
