### PR TITLE
Fix VPC destruction error

### DIFF
--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -417,7 +417,8 @@ class DiscoMetaNetwork(object):
         else:
             # Only need to get from one subnet since they are the same
             for route in self.disco_subnets.values()[0].route_table['Routes']:
-                if route.get('GatewayId') and route.get('GatewayId') != 'local':
+                if route.get('DestinationCidrBlock') and \
+                        route.get('GatewayId') and route.get('GatewayId') != 'local':
                     current_route_tuples.add(
                         (route['DestinationCidrBlock'], route['GatewayId']))
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.106"
+__version__ = "1.0.107"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Changes summary:

- Reorder destruction of several resources during VPC destruction
- Repeat calls to delete network interfaces until successful
- Ensure gateway routes have the DestinationCidrBlock property