### PR TITLE
Make alarms work with dynamic ASG names

### DIFF
--- a/bin/disco_alarms.py
+++ b/bin/disco_alarms.py
@@ -50,7 +50,7 @@ def run():
     hostclass = args.get("--hostclass")
     env = args.get("--env") or config.get("disco_aws", "default_environment")
     alarms_config = DiscoAlarmsConfig(env)
-    disco_alarm = DiscoAlarm()
+    disco_alarm = DiscoAlarm(env)
 
     if args["update_notifications"]:
         notifications = alarms_config.get_notifications()
@@ -58,8 +58,7 @@ def run():
     elif args["update_metrics"]:
         if delete:
             disco_alarm.delete_hostclass_environment_alarms(env, hostclass)
-        alarms = alarms_config.get_alarms(hostclass)
-        disco_alarm.create_alarms(alarms)
+        disco_alarm.create_alarms(hostclass)
     elif args["list"]:
         alarms = disco_alarm.get_alarms(
             {"env": env, "hostclass": hostclass} if hostclass else {"env": env})

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -15,7 +15,6 @@ import botocore
 import pytz
 
 from . import read_config, ASIAQ_CONFIG
-from .disco_alarm_config import DiscoAlarmsConfig
 from .disco_alarm import DiscoAlarm
 from .disco_aws_util import is_truthy
 from .disco_creds import DiscoS3Bucket
@@ -195,10 +194,7 @@ class DiscoRDS(object):
         Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
         """
         logging.debug("Configuring Cloudwatch alarms ")
-        disco_alarm_config = DiscoAlarmsConfig(self.vpc_name)
-        disco_alarm = DiscoAlarm()
-        instance_alarms = disco_alarm_config.get_alarms(database_name)
-        disco_alarm.create_alarms(instance_alarms)
+        DiscoAlarm(self.vpc_name).create_alarms(database_name)
 
     def update_all_clusters_in_vpc(self):
         """

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -393,7 +393,7 @@ class DiscoVPC(object):
 
     def destroy(self):
         """ Delete all VPC resources in the right order and then delete the vpc itself """
-        DiscoAlarm().delete_environment_alarms(self.environment_name)
+        DiscoAlarm(self.environment_name).delete_environment_alarms(self.environment_name)
         self.log_metrics.delete_all_metrics()
         self.log_metrics.delete_all_log_groups()
         self._destroy_instances()

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.112"
+__version__ = "1.0.113"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_alarm.py
+++ b/test/unit/test_disco_alarm.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from random import randint
 import logging
 
+from mock import MagicMock
 from moto import mock_cloudwatch
 from boto.ec2.cloudwatch import CloudWatchConnection
 from disco_aws_automation import DiscoAlarm, DiscoAlarmsConfig
@@ -15,12 +16,15 @@ from test.helpers.patch_disco_aws import get_mock_config
 TOPIC_ARN = "arn:aws:sns:us-west-2:123456789012:ci"
 ENVIRONMENT = "testenv"
 ACCOUNT_ID = "123456789012"  # mock_sns uses account id 123456789012
+MOCK_GROUP_NAME = "ci_mhcfoo_123141231245123"
 
 
 class DiscoAlarmTests(TestCase):
     """Test disco_alarm"""
 
     def setUp(self):
+        self.autoscale = MagicMock()
+        self.autoscale.get_existing_group.return_value.name = MOCK_GROUP_NAME
         self.cloudwatch_mock = mock_cloudwatch()
         self.cloudwatch_mock.start()
         disco_sns = DiscoSNS(account_id=ACCOUNT_ID)
@@ -61,6 +65,7 @@ class DiscoAlarmTests(TestCase):
             "threshold_max": "90",
             "level": "critical",
             "team": "america",
+            "autoscaling_group_name": "{}_{}_{}".format(hostclass, ENVIRONMENT, randint(100000, 999999))
         }
         return DiscoAlarmConfig(options)
 
@@ -152,9 +157,9 @@ class DiscoAlarmTests(TestCase):
 
     def test_get_alarm_config(self):
         """Test DiscoAlarmsConfig get_alarms for regular metrics"""
-        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT)
+        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT, autoscale=self.autoscale)
         disco_alarms_config.config = get_mock_config({
-            'reporting.EC2.CPU.mhcrasberi': {
+            'reporting.AWS/EC2.CPU.mhcrasberi': {
                 'log_pattern_metric': 'false',
                 'threshold_max': '1',
                 'duration': '60',
@@ -167,12 +172,13 @@ class DiscoAlarmTests(TestCase):
 
         alarm_configs = disco_alarms_config.get_alarms('mhcrasberi')
         self.assertEqual(1, len(alarm_configs))
-        self.assertEquals('EC2', alarm_configs[0].namespace)
+        self.assertEquals('AWS/EC2', alarm_configs[0].namespace)
         self.assertEquals('CPU', alarm_configs[0].metric_name)
+        self.assertEquals(MOCK_GROUP_NAME, alarm_configs[0].autoscaling_group_name)
 
     def test_get_alarm_config_log_pattern_metric(self):
         """Test DiscoAlarmsConfig get_alarms for log pattern metrics"""
-        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT)
+        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT, autoscale=self.autoscale)
         disco_alarms_config.config = get_mock_config({
             'reporting.LogMetrics.ErrorCount.mhcrasberi': {
                 'log_pattern_metric': 'true',
@@ -192,7 +198,7 @@ class DiscoAlarmTests(TestCase):
 
     def test_get_alarm_config_elb_metric(self):
         """Test DiscoAlarmsConfig get_alarms for ELB metrics"""
-        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT)
+        disco_alarms_config = DiscoAlarmsConfig(ENVIRONMENT, autoscale=self.autoscale)
         disco_alarms_config.config = get_mock_config({
             'reporting.AWS/ELB.HealthyHostCount.mhcbanana': {
                 'threshold_min': '1',


### PR DESCRIPTION
DiscoAlarms was assuming that the names of autoscaling group was static,
but that is no longer true due to changes necessary for blue/green
deployment. Instead, when alarms are being configured for a hostclass,
the autoscaling group name can now be provided along with that call, or
the DiscoAlarmsConfig now has the capability to grab the autoscaling
group name if one was not provided and the namespace is 'AWS/EC2'.

Additionally, because autoscaling group names are not part of the
namespacing of the alarm names, there was a possible problem where
blue/green deployment might update alarms to point to the new autoscaling group, destroy that autoscaling group when tests fail, and then not repoint the alarms to the old autoscaling group. To resolve this, alarms are not created for
autoscaling groups that are marked with 'is_testing'. Instead, alarms
will be created for that autoscaling group after it passes tests,
similar to how we handle ELB switchover.

Also added some unit tests to ensure that we try to lookup the
autoscaling group name when it isn't provided.