### PR TITLE
Update ELB Name Length Limit

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -293,8 +293,8 @@ class DiscoELB(object):
         # load balancers can only have letters, numbers or dashes in their names so strip everything else
         elb_name = re.sub(r'[^a-zA-Z0-9-]', '', name)
 
-        if len(elb_name) > 32:
-            raise CommandError('ELB name ' + elb_name + " is over 32 characters")
+        if len(elb_name) > 255:
+            raise CommandError('ELB name ' + elb_name + " is over 255 characters")
 
         return elb_name
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.111"
+__version__ = "1.0.112"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
This needed to be 32 character because that was the limit of an ELB's name. Now this exists as a tag, so the length can be up to 255 characters.