### PR TITLE
Add logging for disco_acm

### DIFF
--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -73,7 +73,9 @@ class DiscoACM(object):
             certs.sort(key=lambda cert: len(cert[DOMAIN_NAME_KEY]), reverse=True)
             if not certs:
                 logging.warning("No ACM certificates returned for %s", dns_name)
-            return certs[0][CERT_ARN_KEY] if certs else None
+                return None
+            else:
+                return certs[0][CERT_ARN_KEY]
         except (botocore.exceptions.EndpointConnectionError,
                 botocore.vendored.requests.exceptions.ConnectionError):
             # some versions of botocore(1.3.26) will try to connect to acm even if outside us-east-1

--- a/disco_aws_automation/disco_acm.py
+++ b/disco_aws_automation/disco_acm.py
@@ -71,8 +71,11 @@ class DiscoACM(object):
             certs = [cert for cert in cert_summary if self._in_domain(cert[DOMAIN_NAME_KEY], dns_name)]
             # determine the most specific domain match
             certs.sort(key=lambda cert: len(cert[DOMAIN_NAME_KEY]), reverse=True)
+            if not certs:
+                logging.warning("No ACM certificates returned for %s", dns_name)
             return certs[0][CERT_ARN_KEY] if certs else None
         except (botocore.exceptions.EndpointConnectionError,
                 botocore.vendored.requests.exceptions.ConnectionError):
             # some versions of botocore(1.3.26) will try to connect to acm even if outside us-east-1
+            logging.exception("Unable to get ACM certificate")
             return None

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.113"
+__version__ = "1.0.114"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
`DiscoACM` doesn't log anything when a certificate isn't found. Adding some logging statements to help debug why it can't find certs in staging/prod.