### PR TITLE
Fix bug caused by upgrading to botocore 1.4.29

### DIFF
--- a/disco_aws_automation/resource_helper.py
+++ b/disco_aws_automation/resource_helper.py
@@ -1,7 +1,6 @@
 """
 This module has a bunch of functions about waiting for an AWS resource to become available
 """
-import json
 import logging
 import time
 
@@ -34,20 +33,6 @@ def create_filters(filter_dict):
 def tag2dict(tags):
     """ Converts a list of AWS tag dicts to a single dict with corresponding keys and values """
     return {tag.get('Key'): tag.get('Value') for tag in tags or {}}
-
-
-def handle_date_format(obj):
-    """
-    Helper function that properly handles date object returned from AWS.
-    Only used with boto3
-    """
-    def date_handler(item):
-        """
-        The actual date handling logic is here
-        """
-        return item.isoformat() if hasattr(item, 'isoformat') else item
-
-    return json.loads(json.dumps(obj, default=date_handler))
 
 
 def find_or_create(find, create):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.114"
+__version__ = "1.0.115"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_subnet.py
+++ b/test/unit/test_disco_subnet.py
@@ -59,7 +59,7 @@ def _get_ec2_conn_mock(test_disco_subnet):
 
     def _mock_describe_route_tables(*_, **__):
         if test_disco_subnet.route_table:
-            return {'RouteTables': [test_disco_subnet.route_table]}
+            return {'RouteTables': [copy.deepcopy(test_disco_subnet.route_table)]}
         else:
             return {'RouteTables': []}
 


### PR DESCRIPTION
Remove the handle_date_format() helper function because there is really no need to convert boto3 objects to JSON, and it is causing errors when botocore is upgraded to version 1.4.29

The new version of botocore returns objects of type `botocore.vendored.requests.structures.CaseInsensitiveDict`, which is not JSON serializable.