### PR TITLE
Updated bake_all_phase1 script to be smarter about phase1s.

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.116"
+__version__ = "1.0.117"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/jenkins/bake_all_phase1.sh
+++ b/jenkins/bake_all_phase1.sh
@@ -2,7 +2,7 @@
 
 source "$(dirname $0)/bake_common.sh"  > /dev/null 2>&1
 
-phase1_images="centos6_phase1 centos7_phase1 ubuntu1404_phase1"
+phase1_images=$(python -c 'from ConfigParser import ConfigParser; c = ConfigParser(); c.read(["disco_aws.ini"]); print " ".join([s for s in c.sections() if c.has_option(s, "phase") and c.get(s,"phase") == "1"])')
 exit_status=0
 RETRY_DELAY=30
 


### PR DESCRIPTION
Modified the bake_all_phase1.sh script to be able to find all hostclass definitions that are marked with phase=1, rather than having a hard-coded list.