### PR TITLE
Added alarms support for ElasticSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1558,11 +1558,14 @@ spun up. By appending the section with hostclass name (eg:
 one specific hostclass. This can also be used to 'override' any of the
 options on specific hostclass.
 
-Section name breaks down into 2-3 period separated fields:
+Section name breaks down into 3-4 period separated fields:
 
-1.  Namespace
-2.  MetricName
-3.  Hostclass (Optional)
+1.  Team
+2.  Namespace
+3.  MetricName
+4.  Hostclass (Optional)
+
+NOTE: For the `AWS/ES` namespace, the hostclass field is required and refers to the internal name of the Elasticsearch domain. IE: `logs`.
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -1501,7 +1501,7 @@ workflow is:
 -   metrics and alarms are manually configured in disco_alarms.ini
 -   on VPC creation, SNS topics are created and subscribed to first
     responders
--   on hostclass provisioning, Clouwatch metrics and alarms are created,
+-   on hostclass provisioning, Cloudwatch metrics and alarms are created,
     and configured to push to appropriate SNS topic
 -   on hostclass termination, Cloudwatch metrics and alarms are deleted,
     but SNS topics are left intact
@@ -1578,6 +1578,15 @@ Options:
 
 For more information on the options refer to [CloudWatch' PutMetricAlarm
 API](CloudWatch'%20PutMetricAlarm%20API)
+
+##### Supported AWS Namespaces
+
+Currently, `disco_alarms.py` supports the following namespaces:
+
+-   AWS/EC2
+-   AWS/ELB
+-   AWS/RDS
+-   AWS/ES
 
 ##### Alarm Config for Custom Metrics
 

--- a/bin/disco_alarms.py
+++ b/bin/disco_alarms.py
@@ -35,7 +35,7 @@ from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
 from disco_aws_automation.disco_alarm_config import DiscoAlarmsConfig
 from disco_aws_automation.disco_alarm import DiscoAlarm
-
+from disco_aws_automation.disco_elasticsearch import DiscoElasticsearch
 
 def run():
     """Parses command line and dispatches the commands"""
@@ -49,8 +49,9 @@ def run():
     delete = args.get("--delete")
     hostclass = args.get("--hostclass")
     env = args.get("--env") or config.get("disco_aws", "default_environment")
-    alarms_config = DiscoAlarmsConfig(env)
-    disco_alarm = DiscoAlarm(env)
+    disco_elasticsearch = DiscoElasticsearch(env)
+    alarms_config = DiscoAlarmsConfig(env, elasticsearch=disco_elasticsearch)
+    disco_alarm = DiscoAlarm(env, alarm_configs=alarms_config)
 
     if args["update_notifications"]:
         notifications = alarms_config.get_notifications()

--- a/bin/disco_alarms.py
+++ b/bin/disco_alarms.py
@@ -37,6 +37,7 @@ from disco_aws_automation.disco_alarm_config import DiscoAlarmsConfig
 from disco_aws_automation.disco_alarm import DiscoAlarm
 from disco_aws_automation.disco_elasticsearch import DiscoElasticsearch
 
+
 def run():
     """Parses command line and dispatches the commands"""
     args = docopt(__doc__)

--- a/disco_aws_automation/disco_constants.py
+++ b/disco_aws_automation/disco_constants.py
@@ -19,3 +19,5 @@ NETWORKS = {"intranet": "Inter host",
             "dmz": "Client facing",
             "tunnel": "internet http proxy",
             "maintenance": "Admin jump box"}
+
+VPC_CONFIG_FILE = "disco_vpc.ini"

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -21,7 +21,7 @@ from . import normalize_path
 from .disco_alarm import DiscoAlarm
 from .disco_alarm_config import DiscoAlarmsConfig
 from .disco_autoscale import DiscoAutoscale
-from .disco_constants import CREDENTIAL_BUCKET_TEMPLATE, NETWORKS
+from .disco_constants import CREDENTIAL_BUCKET_TEMPLATE, NETWORKS, VPC_CONFIG_FILE
 from .disco_elasticache import DiscoElastiCache
 from .disco_elb import DiscoELB
 from .disco_log_metrics import DiscoLogMetrics
@@ -38,9 +38,6 @@ from .exceptions import (
     VPCNameNotFound)
 
 
-CONFIG_FILE = "disco_vpc.ini"
-
-
 # FIXME: pylint thinks the file has too many instance arguments
 # pylint: disable=R0902
 class DiscoVPC(object):
@@ -49,7 +46,7 @@ class DiscoVPC(object):
     """
 
     def __init__(self, environment_name, environment_type, vpc=None, config_file=None, boto3_ec2=None):
-        self.config_file = config_file or CONFIG_FILE
+        self.config_file = config_file or VPC_CONFIG_FILE
 
         self.environment_name = environment_name
         self.environment_type = environment_type

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -14,6 +14,7 @@ from .exceptions import VPCPeeringSyntaxError
 # way that works for unit tests.
 # pylint: disable=W0403
 import disco_vpc
+from .disco_constants import VPC_CONFIG_FILE
 
 LIVE_PEERING_STATES = ["pending-acceptance", "provisioning", "active"]
 
@@ -171,8 +172,8 @@ class DiscoVPCPeerings(object):
 
     @staticmethod
     def _get_peering_lines():
-        logging.debug("Parsing peerings configuration specified in %s", disco_vpc.CONFIG_FILE)
-        config = read_config(disco_vpc.CONFIG_FILE)
+        logging.debug("Parsing peerings configuration specified in %s", VPC_CONFIG_FILE)
+        config = read_config(VPC_CONFIG_FILE)
 
         if 'peerings' not in config.sections():
             logging.info("No VPC peering configuration defined.")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.118"
+__version__ = "1.0.119"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
`disco_alarms.py` will now support setting alarms for ElasticSearch domains. Additionally, when creating, updating, or deleting ElasticSearch domains, alarms will now be created/updated/deleted, respectively.

There was also a change made to the parsing logic for alarm metrics to support metrics with periods in them because some import ElasticSearch metrics have spaces in them.