### PR TITLE
Made disco_elb.py support ELB-managed sticky sessions.

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -121,10 +121,10 @@ class DiscoELB(object):
 
     def _setup_sticky_cookies(self, elb_id, elb_ports, sticky_app_cookie, elb_name):
         policies = throttled_call(self.elb_client.describe_load_balancer_policies,
-                                      LoadBalancerName=elb_id)
+                                  LoadBalancerName=elb_id)
         logging.debug("ELB policies found: %s", policies['PolicyDescriptions'])
 
-        def set_policies_for_elb_ports(policies):
+        def _set_policies_for_elb_ports(policies):
             for elb_port in elb_ports:
                 throttled_call(self.elb_client.set_load_balancer_policies_of_listener,
                                LoadBalancerName=elb_id,
@@ -133,7 +133,7 @@ class DiscoELB(object):
 
         if [desc for desc in policies['PolicyDescriptions'] if desc['PolicyName'] == STICKY_POLICY_NAME]:
             logging.warning("Deleting sticky session policy from ELB %s", elb_name)
-            set_policies_for_elb_ports([])
+            _set_policies_for_elb_ports([])
             throttled_call(self.elb_client.delete_load_balancer_policy,
                            LoadBalancerName=elb_id,
                            PolicyName=STICKY_POLICY_NAME)
@@ -149,8 +149,7 @@ class DiscoELB(object):
                 policy_creator = self.elb_client.create_app_cookie_stickiness_policy
             throttled_call(policy_creator, **policy_args)
             # add sticky sessions policy to every listener
-            set_policies_for_elb_ports([STICKY_POLICY_NAME])
-
+            _set_policies_for_elb_ports([STICKY_POLICY_NAME])
 
     # Pylint thinks this function has too many arguments
     # pylint: disable=R0913, R0914

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.119"
+__version__ = "1.0.121"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -10,6 +10,20 @@ TEST_VPC_ID = 'vpc-56e10e3d'  # the hard coded VPC Id that moto will always retu
 TEST_DOMAIN_NAME = 'test.example.com'
 TEST_CERTIFICATE_ARN_ACM = "arn:aws:acm::123:blah"
 TEST_CERTIFICATE_ARN_IAM = "arn:aws:acm::123:blah"
+# With these constants, you could do some significant testing of setting and clearing stickiness policies,
+# were it not for the fact that moto's ELB support is insufficient for the task.
+MOCK_POLICY_NAME = "mock-sticky-policy"
+MOCK_APP_STICKY_POLICY = {
+    u'PolicyAttributeDescriptions': [{u'AttributeName': 'CookieName', u'AttributeValue': 'JSESSIONID'}],
+    u'PolicyName': MOCK_POLICY_NAME,
+    u'PolicyTypeName': 'AppCookieStickinessPolicyType'
+}
+
+MOCK_ELB_STICKY_POLICY = {
+    u'PolicyAttributeDescriptions': [{u'AttributeName': 'CookieExpirationPeriod', u'AttributeValue': '0'}],
+    u'PolicyName': MOCK_POLICY_NAME,
+    u'PolicyTypeName': 'LBCookieStickinessPolicyType'
+}
 
 
 def _get_vpc_mock():
@@ -35,7 +49,11 @@ class DiscoELBTests(TestCase):
                     instance_protocol='HTTP', instance_port=80,
                     elb_protocols='HTTP', elb_ports='80',
                     idle_timeout=None, connection_draining_timeout=None,
-                    sticky_app_cookie=None):
+                    sticky_app_cookie=None, existing_cookie_policy=None):
+        sticky_policies = [existing_cookie_policy] if existing_cookie_policy else []
+        mock_describe = MagicMock(return_value={'PolicyDescriptions': sticky_policies})
+        self.disco_elb.elb_client.describe_load_balancer_policies = mock_describe
+
         return self.disco_elb.get_or_create_elb(
             hostclass=hostclass or TEST_HOSTCLASS,
             security_groups=['sec-1'],


### PR DESCRIPTION
Updated disco_elb.py to treat "ELB" or "AWSELB" as special cookie names indicating
that we should use the ELB-managed sticky session code instead of using app-managed
sticky sessions, and to support updating or deleting the stickiness policy of a given
ELB as well as adding it.