### PR TITLE
Snapshot/Volume fix

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -247,7 +247,7 @@ class DiscoAWS(object):
         old_config = self.autoscale.get_launch_config(hostclass=hostclass)
         if not old_config or any([extra_space, extra_disk, iops]):
             block_device_mappings = [self.disco_storage.configure_storage(
-                hostclass=hostclass, ami_id=ami.id,
+                ami_id=ami.id,
                 extra_space=extra_space, extra_disk=extra_disk, iops=iops,
                 ephemeral_disk_count=self.disco_storage.get_ephemeral_disk_count(instance_type))]
         else:

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -369,7 +369,7 @@ class DiscoBake(object):
         reservation = self.connection.run_instances(
             source_ami_id,
             block_device_map=self.disco_storage.configure_storage(
-                hostclass, ami_id=source_ami_id),
+                ami_id=source_ami_id),
             instance_type=self.option("bakery_instance_type"),
             key_name=self.option("bake_key"),
             network_interfaces=interfaces)

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -369,7 +369,7 @@ class DiscoBake(object):
         reservation = self.connection.run_instances(
             source_ami_id,
             block_device_map=self.disco_storage.configure_storage(
-                hostclass, ami_id=source_ami_id, map_snapshot=False),
+                hostclass, ami_id=source_ami_id),
             instance_type=self.option("bakery_instance_type"),
             key_name=self.option("bake_key"),
             network_interfaces=interfaces)

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -175,7 +175,7 @@ class DiscoStorage(object):
         # to the right four characters, i.e /dev/sdb becomes /dev/sdf, /dev/sdc becomes /dev/sde
         # and so on.
         # TODO  Figure out how to stop this from happening
-        disk_names = ['/dev/sd' + chr(ord('a') + i) for i in range(0, 26)]
+        disk_names = ['/dev/sd' + chr(ord('a') + i) for i in range(0, 25)]
         if ami_id:
             ami = self.connection.get_image(ami_id)
             if not ami:
@@ -194,16 +194,6 @@ class DiscoStorage(object):
         bdm[disk_names[current_disk]] = sda
         logging.debug("mapped %s to root partition", disk_names[current_disk])
         current_disk += 1
-
-        # Map the latest snapshot for this hostclass
-        if map_snapshot:
-            latest = self.get_latest_snapshot(hostclass)
-            if latest:
-                self.wait_for_snapshot(latest)
-                current_name = disk_names[current_disk]
-                bdm[current_name] = self.create_snapshot_bdm(latest, iops)
-                logging.debug("mapped %s to snapshot %s", current_name, latest.id)
-                current_disk += 1
 
         # Map extra disk
         if extra_disk:

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -173,6 +173,7 @@ class DiscoStorage(object):
         # Pylint thinks this function has too many local variables
         # pylint: disable=R0914
 
+        # disk names only go up to /dev/sdy. /dev/sdz is reserved for EBS volume
         disk_names = ['/dev/sd' + chr(ord('a') + i) for i in range(0, 25)]
         if ami_id:
             ami = self.connection.get_image(ami_id)

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -165,8 +165,7 @@ class DiscoStorage(object):
                           extra_space=None,
                           extra_disk=None,
                           iops=None,
-                          ephemeral_disk_count=0,
-                          map_snapshot=True):
+                          ephemeral_disk_count=0):
         ''' Cofigures block device mapping for root partition, extra disk if it's used,
         and the ephemeral discks. Note that EBS volume mapping is no longer being created
         here. The logic for attaching EBS volume has been moved to /etc/asiaq/init/ebs-start.sh '''

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -167,7 +167,9 @@ class DiscoStorage(object):
                           iops=None,
                           ephemeral_disk_count=0,
                           map_snapshot=True):
-        '''Alter block device to destroy the volume on termination and add any extra space'''
+        ''' Cofigures block device mapping for root partition, extra disk if it's used,
+        and the ephemeral discks. Note that EBS volume mapping is no longer being created
+        here. The logic for attaching EBS volume has been moved to /etc/asiaq/init/ebs-start.sh '''
         # Pylint thinks this function has too many local variables
         # pylint: disable=R0914
 

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -160,14 +160,13 @@ class DiscoStorage(object):
         return device
 
     def configure_storage(self,
-                          hostclass,
                           ami_id=None,
                           extra_space=None,
                           extra_disk=None,
                           iops=None,
                           ephemeral_disk_count=0):
         ''' Cofigures block device mapping for root partition, extra disk if it's used,
-        and the ephemeral discks. Note that EBS volume mapping is no longer being created
+        and the ephemeral disks. Note that EBS volume mapping is no longer being created
         here. The logic for attaching EBS volume has been moved to /etc/asiaq/init/ebs-start.sh '''
         # Pylint thinks this function has too many local variables
         # pylint: disable=R0914

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -171,10 +171,6 @@ class DiscoStorage(object):
         # Pylint thinks this function has too many local variables
         # pylint: disable=R0914
 
-        # We map disk names starting at /dev/sda, but aws shifts everything after /dev/sda
-        # to the right four characters, i.e /dev/sdb becomes /dev/sdf, /dev/sdc becomes /dev/sde
-        # and so on.
-        # TODO  Figure out how to stop this from happening
         disk_names = ['/dev/sd' + chr(ord('a') + i) for i in range(0, 25)]
         if ami_id:
             ami = self.connection.get_image(ami_id)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.122"
+__version__ = "1.0.123"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
This PR removes the EBS volume config in the block device mapping of the launch configuration.

This is an accompanying PR for https://github.com/amplifylitco/asiaq_astro_config/pull/653