### PR TITLE
Bug fix: Make sure all current routes all have valid CIDR block

### DIFF
--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -412,7 +412,8 @@ class DiscoMetaNetwork(object):
         current_route_tuples = set()
         if self.centralized_route_table:
             for route in self.centralized_route_table.routes:
-                if route.gateway_id and route.gateway_id != 'local':
+                if route.destination_cidr_block and \
+                        route.gateway_id and route.gateway_id != 'local':
                     current_route_tuples.add((route.destination_cidr_block, route.gateway_id))
         else:
             # Only need to get from one subnet since they are the same

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.122"
+__version__ = "1.0.123"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Because S3 endpoint routes do not use destination CIDR block. Those routes should be ignored by Asiaq.

@kelibezhani This will fix the error you saw.