### PR TITLE
Made no-destroy SSH command stop saving host keys.

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -426,7 +426,8 @@ class DiscoBake(object):
             if not no_destroy:
                 instance.terminate()
             else:
-                logging.info("Examine instance command: ssh root@%s",
+                logging.info("Examine instance command: "
+                             "ssh -o UserKnownHostsFile=/dev/null root@%s",
                              instance.ip_address or instance.private_ip_address)
 
         return image

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.123"
+__version__ = "1.0.124"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.124"
+__version__ = "1.0.125"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Modified the disco_bake output to include the necessary option to avoid saving the IP address and host key when connecting to a host baked with the --no-destroy option.