### PR TITLE
Snapshots should be environment specific

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -81,7 +81,7 @@ class DiscoAWS(object):
     def disco_storage(self):
         """Lazily creates disco storage object"""
         if not self._disco_storage:
-            self._disco_storage = DiscoStorage(self.connection, environment_name=self.environment_name)
+            self._disco_storage = DiscoStorage(self.environment_name, self.connection)
         return self._disco_storage
 
     @property

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -81,7 +81,7 @@ class DiscoAWS(object):
     def disco_storage(self):
         """Lazily creates disco storage object"""
         if not self._disco_storage:
-            self._disco_storage = DiscoStorage(self.connection)
+            self._disco_storage = DiscoStorage(self.connection, environment_name=self.environment_name)
         return self._disco_storage
 
     @property

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -285,10 +285,9 @@ class DiscoStorage(object):
     def delete_snapshot(self, snapshot_id):
         """Delete a snapshot by snapshot_id"""
 
-        snapshots = self.get_snapshots()
-        snapshot_ids = [snapshot.id for snapshot in snapshots]
-
-        if snapshot_id not in snapshot_ids:
+        snapshots = self.connection.get_all_snapshots(snapshot_ids=[snapshot_id],
+                                                      filters={'tag:env': self.environment_name})
+        if not snapshots:
             logging.error("Snapshot ID %s does not exist in environment %s",
                           snapshot_id, self.environment_name)
             return

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -121,7 +121,7 @@ class DiscoStorage(object):
     Wrapper class to handle all DiscoAWS storage functions
     """
 
-    def __init__(self, connection=None, environment_name=None):
+    def __init__(self, environment_name, connection=None):
         self.connection = connection if connection else boto.connect_ec2()
         self.environment_name = environment_name
 

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -285,8 +285,9 @@ class DiscoStorage(object):
     def delete_snapshot(self, snapshot_id):
         """Delete a snapshot by snapshot_id"""
 
-        snapshots = self.connection.get_all_snapshots(snapshot_ids=[snapshot_id],
-                                                      filters={'tag:env': self.environment_name})
+        snapshots = throttled_call(self.connection.get_all_snapshots,
+                                   snapshot_ids=[snapshot_id],
+                                   filters={'tag:env': self.environment_name})
         if not snapshots:
             logging.error("Snapshot ID %s does not exist in environment %s",
                           snapshot_id, self.environment_name)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.124"
+__version__ = "1.0.125"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/helpers/aws.config
+++ b/test/helpers/aws.config
@@ -1,3 +1,18 @@
+[default]
+region=ap-southeast-1
+
+[Boto]
+ec2_region_endpoint = ec2.ap-southeast-1.amazonaws.com
+autoscale_endpoint = autoscaling.ap-southeast-1.amazonaws.com
+cloudwatch_region_endpoint = monitoring.ap-southeast-1.amazonaws.com
+sns_region_endpoint = sns.ap-southeast-1.amazonaws.com
+elb_region_endpoint = elasticloadbalancing.ap-southeast-1.amazonaws.com
+autoscale_region_name = ap-southeast-1
+ec2_region_name = ap-southeast-1
+elb_region_name = ap-southeast-1
+cloudwatch_region_name = ap-southeast-1
+sns_region_name = ap-southeast-1
+
 [profile unit_tests]
 aws_access_key_id = AKIAJNFLNOYPTRIIYBMA
 aws_secret_access_key = INVALID

--- a/test/unit/test_disco_storage.py
+++ b/test/unit/test_disco_storage.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import random
 
 import dateutil.parser as dateparser
+import boto3
 from mock import MagicMock
 from moto import mock_ec2
 
@@ -12,24 +13,38 @@ from disco_aws_automation import DiscoStorage
 
 
 class DiscoStorageTests(TestCase):
-    '''Test DiscoStorage class'''
+    """Test DiscoStorage class"""
 
-    @mock_ec2
     def setUp(self):
-        self.storage = DiscoStorage()
+        self.storage = DiscoStorage(environment_name='unittestenv')
+
+    def _create_snapshot(self, hostclass, env):
+        client = boto3.client('ec2')
+        volume = client.create_volume(
+            Size=100,
+            AvailabilityZone='fake-zone-1'
+        )
+
+        snapshot = client.create_snapshot(VolumeId=volume['VolumeId'])
+
+        client.create_tags(Resources=[snapshot['SnapshotId']],
+                           Tags=[{'Key': 'hostclass', 'Value': hostclass},
+                                 {'Key': 'env', 'Value': env}])
+
+        return snapshot
 
     def test_is_ebs_optimized(self):
-        '''is_ebs_optimized works'''
+        """is_ebs_optimized works"""
         self.assertTrue(self.storage.is_ebs_optimized("m4.xlarge"))
         self.assertFalse(self.storage.is_ebs_optimized("t2.micro"))
 
     @mock_ec2
     def test_get_latest_snapshot_no_snap(self):
-        '''get_latest_snapshot() returns None if no snapshots exist for hostclass'''
+        """get_latest_snapshot() returns None if no snapshots exist for hostclass"""
         self.assertIsNone(self.storage.get_latest_snapshot("mhcfoo"))
 
     def mock_snap(self, hostclass, when=None):
-        '''Creates MagicMock for a snapshot'''
+        """Creates MagicMock for a snapshot"""
         ret = MagicMock()
         ret.tags = {"hostclass": hostclass}
         ret.start_time = when if when else dateparser.parse("2016-01-19 16:38:48+00:00")
@@ -38,7 +53,7 @@ class DiscoStorageTests(TestCase):
         return ret
 
     def test_get_latest_snapshot_with_snaps(self):
-        '''get_latest_snapshot() returns correct snapshot if many exist'''
+        """get_latest_snapshot() returns correct snapshot if many exist"""
         snap_list = [
             self.mock_snap("mhcfoo", dateparser.parse("2016-01-15 16:38:48+00:00")),
             self.mock_snap("mhcfoo", dateparser.parse("2016-01-19 16:38:48+00:00")),
@@ -47,6 +62,50 @@ class DiscoStorageTests(TestCase):
         self.assertEqual(self.storage.get_latest_snapshot("mhcfoo"), snap_list[1])
 
     def test_create_snapshot_bdm_syntax(self):
-        '''create_snapshot_bdm() calls functions with correct syntax'''
+        """create_snapshot_bdm() calls functions with correct syntax"""
         dev = self.storage.create_snapshot_bdm(self.mock_snap("mhcbar"), 5)
         self.assertEqual(dev.iops, 5)
+
+    @mock_ec2
+    def test_get_all_snapshots(self):
+        """Test getting all of the snapshots for an environment"""
+        self._create_snapshot('foo', 'unittestenv')
+        self._create_snapshot('foo', 'otherenv')
+
+        self.assertEquals(1, len(self.storage.get_snapshots()))
+
+    @mock_ec2
+    def test_delete_snapshot(self):
+        """Test deleting a snapshot"""
+        snapshot = self._create_snapshot('foo', 'unittestenv')
+        self.storage.delete_snapshot(snapshot['SnapshotId'])
+
+        self.assertEquals(0, len(self.storage.get_snapshots()))
+
+        snapshot = self._create_snapshot('foo', 'otherenv')
+        self.storage.delete_snapshot(snapshot['SnapshotId'])
+        self.assertEquals(1, len(DiscoStorage(environment_name='otherenv').get_snapshots()))
+
+    @mock_ec2
+    def test_cleanup_ebs_snapshots(self):
+        """Test deleting old snapshots"""
+        self._create_snapshot('foo', 'unittestenv')
+        self._create_snapshot('foo', 'unittestenv')
+        self._create_snapshot('foo', 'unittestenv')
+        self._create_snapshot('foo', 'otherenv')
+        self._create_snapshot('foo', 'otherenv')
+        self._create_snapshot('foo', 'otherenv')
+
+        self.storage.cleanup_ebs_snapshots(keep_last_n=2)
+
+        self.assertEquals(2, len(self.storage.get_snapshots()))
+        self.assertEquals(3, len(DiscoStorage(environment_name='otherenv').get_snapshots()))
+
+    @mock_ec2
+    def test_create_ebs_snapshot(self):
+        """Test creating a snapshot"""
+        self.storage.create_ebs_snapshot('mhcfoo', 250)
+
+        snapshots = self.storage.get_snapshots('mhcfoo')
+
+        self.assertEquals(250, snapshots[0].volume_size)


### PR DESCRIPTION
DiscoStorage now uses the environment name as a parameter for all of its calls. 

- Listing snapshots now returns only snapshots for the current environment. 
- Deleting snapshots checks if the snapshot exists in the environment
- Cleanup snapshots only deletes snapshots for the environment

**Other Fixes**
- DiscoStorage calls are now throttled
- Added boto2 style default region config to `tests/helpers/aws.config`. The new unit tests are making calls with Boto3 + Moto to create mock data but DiscoStorage uses Boto2. We were missing config to set the default region in Boto2 for unit tests but did have it for Boto3 which was causing the tests to fail when the Boto2 and Boto3 used different regions.