### PR TITLE
Fail fast if smoketests fail during deploy

### DIFF
--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -441,7 +441,12 @@ class DiscoDeploy(object):
 
         try:
             smoke_tests = self.wait_for_smoketests(ami.id, new_group_config["desired_size"] or 1)
-            integration_tests = not run_tests or self.run_integration_tests(ami, wait_for_elb=uses_elb)
+            if smoke_tests and run_tests:
+                # If smoke tests passed and we should run integration tests, run them
+                integration_tests = self.run_integration_tests(ami, wait_for_elb=uses_elb)
+            elif not run_tests:
+                # Otherwise, if the tests should not be run, simply default them to passed
+                integration_tests = True
             if smoke_tests and integration_tests:
                 # If testing passed, mark AMI as tested
                 self._promote_ami(ami, "tested")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.125"
+__version__ = "1.0.126"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Previously, if smoke tests did not pass successfully integration tests
would still be run. Instead, we should fail out of the deploy if smoke
tests do not pass.