### PR TITLE
VPC peerings: enhance error handling and a bug fix

### DIFF
--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -542,29 +542,24 @@ class DiscoMetaNetwork(object):
         If a centralized route table is used, add the route there. If not, add the route
         to all the subnets. """
         if self.centralized_route_table:
-            peering_routes_for_peering = [
+            peering_routes_for_cidr = [
                 _ for _ in self.centralized_route_table.routes
-                if _.vpc_peering_connection_id == peering_conn_id
+                if _.destination_cidr_block == cidr
             ]
-            if not peering_routes_for_peering:
-                peering_routes_for_cidr = [
-                    _ for _ in self.centralized_route_table.routes
-                    if _.destination_cidr_block == cidr
-                ]
-                if not peering_routes_for_cidr:
-                    logging.info(
-                        'Create routes for (route_table: %s, dest_cidr: %s, connection: %s)',
-                        self.centralized_route_table.id, cidr, peering_conn_id)
-                    self._connection.create_route(route_table_id=self.centralized_route_table.id,
-                                                  destination_cidr_block=cidr,
-                                                  vpc_peering_connection_id=peering_conn_id)
-                else:
-                    logging.info(
-                        'Update routes for (route_table: %s, dest_cidr: %s, connection: %s)',
-                        self.centralized_route_table.id, cidr, peering_conn_id)
-                    self._connection.replace_route(route_table_id=self.centralized_route_table.id,
-                                                   destination_cidr_block=cidr,
-                                                   vpc_peering_connection_id=peering_conn_id)
+            if not peering_routes_for_cidr:
+                logging.info(
+                    'Create routes for (route_table: %s, dest_cidr: %s, connection: %s)',
+                    self.centralized_route_table.id, cidr, peering_conn_id)
+                self._connection.create_route(route_table_id=self.centralized_route_table.id,
+                                              destination_cidr_block=cidr,
+                                              vpc_peering_connection_id=peering_conn_id)
+            else:
+                logging.info(
+                    'Update routes for (route_table: %s, dest_cidr: %s, connection: %s)',
+                    self.centralized_route_table.id, cidr, peering_conn_id)
+                self._connection.replace_route(route_table_id=self.centralized_route_table.id,
+                                               destination_cidr_block=cidr,
+                                               vpc_peering_connection_id=peering_conn_id)
         else:
             # No centralized route table here, so add a route to each subnet
             for disco_subnet in self.disco_subnets.values():

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.127"
+__version__ = "1.0.128"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.126"
+__version__ = "1.0.127"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_metanetwork.py
+++ b/test/unit/test_disco_metanetwork.py
@@ -158,14 +158,19 @@ class DiscoMetaNetworkTests(TestCase):
         self.meta_network.create()
 
         mock_peering_conn_id = 'peering_conn_id'
-        mock_cidr = '10.101.0.0/16'
+        mock_cidr1 = '10.101.0.0/16'
+        self.meta_network.create_peering_route(mock_peering_conn_id, mock_cidr1)
 
-        self.meta_network.create_peering_route(mock_peering_conn_id, mock_cidr)
+        mock_cidr2 = '10.102.0.0/16'
+        self.meta_network.create_peering_route(mock_peering_conn_id, mock_cidr2)
 
-        self.mock_vpc_conn.create_route.\
-            assert_called_once_with(destination_cidr_block=mock_cidr,
-                                    route_table_id=MOCK_ROUTE_TABLE.id,
-                                    vpc_peering_connection_id=mock_peering_conn_id)
+        expected_calls = [call(destination_cidr_block=mock_cidr1,
+                               route_table_id=MOCK_ROUTE_TABLE.id,
+                               vpc_peering_connection_id=mock_peering_conn_id),
+                          call(destination_cidr_block=mock_cidr2,
+                               route_table_id=MOCK_ROUTE_TABLE.id,
+                               vpc_peering_connection_id=mock_peering_conn_id)]
+        self.mock_vpc_conn.create_route.assert_has_calls(expected_calls)
 
     @patch('disco_aws_automation.disco_subnet.DiscoSubnet.__init__', return_value=None)
     def test_create_peering__with_existing_route(self, mock_subnet_init):


### PR DESCRIPTION
Two changes:

- We used to raise a runtime error if a VPC associated with a peering no longer exist. It could be due to it being deleted or it being in a different AWS account. Now Asiaq would just skip these peering and warn the user that he might want to delete the peering manually.
- Corrected a bug where we used to assume if a route table already has a rout to a peering connection, then we don't need to doing anything with the peering any more. However, a route with a different CIDR could still be added to the route table.
