### PR TITLE
ignore case when checking elb protocol

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -202,7 +202,7 @@ class DiscoELB(object):
 
             for listener in listeners:
                 # Only try to lookup a cert if we are using a secure protocol for the ELB
-                if listener['Protocol'] in ["HTTPS", "SSL"]:
+                if listener['Protocol'].upper() in ["HTTPS", "SSL"]:
                     listener['SSLCertificateId'] = self.get_certificate_arn(cname) or ''
 
             elb_args = {

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.126"
+__version__ = "1.0.127"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
We currently get a slightly obscure error when using lower case to specify ELB protocol.

> An error occurred (ValidationError) when calling the CreateLoadBalancer operation: Secure Listeners need to specify a SSLCertificateId

So save future developer debug time and do a case insensitive check.