### PR TITLE
Don't supply bogus Subnet when creating ELB in testing.

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.127"
+__version__ = "1.0.128"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,5 +8,5 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-moto>=0.4.23
+moto>=0.4.25
 six>=1.7.3

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,5 +8,5 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-moto>=0.4.25
+moto>=0.4.23
 six>=1.7.3

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,6 +8,5 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-# moto 0.4.24 is breaking our unit tests
-moto>=0.4.10,<=0.4.23
+moto>=0.4.25
 six>=1.7.3

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -57,7 +57,7 @@ class DiscoELBTests(TestCase):
         return self.disco_elb.get_or_create_elb(
             hostclass=hostclass or TEST_HOSTCLASS,
             security_groups=['sec-1'],
-            subnets=['sub-1'],
+            subnets=[],
             hosted_zone_name=TEST_DOMAIN_NAME,
             health_check_url="/" if instance_protocol.upper() in ('HTTP', 'HTTPS') else "",
             instance_protocol=instance_protocol,
@@ -115,7 +115,7 @@ class DiscoELBTests(TestCase):
                 'InstanceProtocol': 'HTTP',
                 'InstancePort': 80
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Scheme='internal',
             Tags=[{
@@ -139,7 +139,7 @@ class DiscoELBTests(TestCase):
                 'InstanceProtocol': 'HTTP',
                 'InstancePort': 80
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Scheme='internal',
             Tags=[{
@@ -161,7 +161,7 @@ class DiscoELBTests(TestCase):
                 'InstanceProtocol': 'HTTP',
                 'InstancePort': 80
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Tags=[{
                 "Key": "elb_name",
@@ -183,7 +183,7 @@ class DiscoELBTests(TestCase):
                 'InstancePort': 80,
                 'SSLCertificateId': TEST_CERTIFICATE_ARN_ACM
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Scheme='internal',
             Tags=[{
@@ -206,7 +206,7 @@ class DiscoELBTests(TestCase):
                 'InstanceProtocol': 'TCP',
                 'InstancePort': 25
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Scheme='internal',
             Tags=[{
@@ -235,7 +235,7 @@ class DiscoELBTests(TestCase):
                 'InstancePort': 80,
                 'SSLCertificateId': TEST_CERTIFICATE_ARN_ACM
             }],
-            Subnets=['sub-1'],
+            Subnets=[],
             SecurityGroups=['sec-1'],
             Scheme='internal',
             Tags=[{


### PR DESCRIPTION
We supply empty list anyway, this way moto does not try
to look up the bogus VPC. Ideally we'd create the subnet first,
but don't think that adds much to our tests.