### PR TITLE
ES archival: allow it to be run with iam-role

### DIFF
--- a/disco_aws_automation/disco_elasticsearch_archive.py
+++ b/disco_aws_automation/disco_elasticsearch_archive.py
@@ -111,7 +111,8 @@ class DiscoESArchive(object):
                 credentials.access_key,
                 credentials.secret_key,
                 self.region,
-                'es'
+                'es',
+                session_token=credentials.token
             )
 
             self._es_client = Elasticsearch(

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.132"
+__version__ = "1.0.133"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Jenkinses use iam-role to execute AWS commands. The session token needs to be added to the credentials object in order to allow Jenkinses access the ES api.