### PR TITLE
Add support for deleting snapshots older than a number of days

### DIFF
--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -42,6 +42,8 @@ def get_parser():
     parser_cleanup.set_defaults(mode='cleanup')
     parser_cleanup.add_argument('--keep', dest='keep', required=False, type=int, default=3,
                                 help='A non-zero number of snapshots to keep per hostclass')
+    parser_cleanup.add_argument('--keep-days', dest='keep_days', required=False, type=int,
+                                help='Do not delete snapshots that are less than this number of days old')
 
     parser_delete = subparsers.add_parser(
         'delete', help='Delete a set of snapshots')
@@ -96,7 +98,7 @@ def run():
                 snapshot.tags['hostclass'], snapshot.id, snapshot.status,
                 snapshot.start_time, snapshot.volume_size))
     elif args.mode == "cleanup":
-        aws.disco_storage.cleanup_ebs_snapshots(args.keep)
+        aws.disco_storage.cleanup_ebs_snapshots(args.keep, keep_last_days=args.keep_days)
     elif args.mode == "capture":
         instances = instances_from_args(aws, args)
         if not instances:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.133"
+__version__ = "1.0.134"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Its now possible to specify `keep_last_days` in addition to `keep_last_n` when cleaning snapshots.

The two options work together when deciding which snapshots to keep and delete.
Atleast `keep_last_n` snapshots will be kept per hostclass but if `keep_last_days` is specified
then other snapshots may be also kept if they are younger than given number of days