### PR TITLE
Output message disco_deploy.test with no 'untested' amis

### DIFF
--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -675,6 +675,8 @@ class DiscoDeploy(object):
         amis = self.get_update_amis()
         if len(amis):
             self.update_ami(random.choice(amis), dry_run, deployment_strategy)
+        else:
+            logging.info("No updated AMIs found.")
 
     def hostclass_option(self, hostclass, key):
         '''

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -668,7 +668,7 @@ class DiscoDeploy(object):
         if len(amis):
             self.test_ami(random.choice(amis), dry_run, deployment_strategy)
         else:
-            logging.info("No 'untested' AMI found.")
+            logging.info("No 'untested' AMIs found.")
 
     def update(self, dry_run=False, deployment_strategy=None):
         '''Updates a single autoscaling group with a newer AMI'''

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -667,6 +667,8 @@ class DiscoDeploy(object):
         amis = self.get_test_amis()
         if len(amis):
             self.test_ami(random.choice(amis), dry_run, deployment_strategy)
+        else:
+            logging.info("No 'untested' AMI found.")
 
     def update(self, dry_run=False, deployment_strategy=None):
         '''Updates a single autoscaling group with a newer AMI'''

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -676,7 +676,7 @@ class DiscoDeploy(object):
         if len(amis):
             self.update_ami(random.choice(amis), dry_run, deployment_strategy)
         else:
-            logging.info("No updated AMIs found.")
+            logging.info("No new 'tested' AMIs found.")
 
     def hostclass_option(self, hostclass, key):
         '''

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.133"
+__version__ = "1.0.134"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Whenever I ran `disco_deploy.py --debug test --ami [ami id]` and it would stop after a couple seconds without any error, I would get really confused... until I realized (or someone told me) that I forgot to promote my AMI to "untested".  The output said nothing to indicate that was the issue. This simple change adds a message saying that no "untested" AMI was found.