### PR TITLE
Fix blue/green not respecting the pipeline

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.135"
+__version__ = "1.0.136"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -25,8 +25,8 @@ MOCK_PIPELINE_DEFINITION = [
     },
     {
         'hostclass': 'mhcbluegreen',
-        'min_size': 1,
-        'desired_size': 1,
+        'min_size': 2,
+        'desired_size': 2,
         'integration_test': 'blue_green_service',
         'deployable': 'yes'
     },
@@ -442,11 +442,11 @@ class DiscoDeployTests(TestCase):
         self.assertTrue(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
         self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'max_size': 1,
-                    'min_size': 1, 'integration_test': "blue_green_service", 'desired_size': 1,
+            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'max_size': 2,
+                    'min_size': 2, 'integration_test': "blue_green_service", 'desired_size': 2,
                     'smoke_test': 'no', 'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True),
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'min_size': 1, 'desired_size': 1, 'max_size': 1,
+                    'min_size': 2, 'desired_size': 2, 'max_size': 2,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
         self._disco_autoscale.delete_groups.assert_not_called()


### PR DESCRIPTION
In the case of there being no ASG, blue/green deployment would always
default to '1' for the sizing of the new ASG, even if there was an entry
in the pipeline file. This change should fix the broken if condition
that lead to this state and make sure that the pipeline entry is
respected. This wasn't noticed because the unit test was incidentally
using the same sizing as the default value. That has also been changed.