### PR TITLE
Add a --keep option to disco_purge_snapshots.py

### DIFF
--- a/bin/disco_purge_snapshots.py
+++ b/bin/disco_purge_snapshots.py
@@ -15,13 +15,14 @@ Usage:
     disco_purge_snapshots.py [options]
 
 Options:
-    -h --help          Show this screen.
-    --debug            Log in debug level.
-    --stray-ami        Purge only snapshots created by CreateImage
-    --no-metadata      Purge only snapshots with no tags
-    --old              Purge only old snapshots (100 days)
-    --keep NUM_TO_KEEP Keep at least this number of snapshots per hostclass per environment
-    --dry-run          Only print what will be done
+    -h --help                 Show this screen.
+    --debug                   Log in debug level.
+    --stray-ami               Purge only snapshots created by CreateImage
+    --no-metadata             Purge only snapshots with no tags
+    --old                     Purge only old snapshots (100 days) [DEPRECATED: use --keep-days instead]
+    --keep-days DAYS          Delete snapshots older than this number of days
+    --keep-num NUM            Keep at least this number of snapshots per hostclass per env
+    --dry-run                 Only print what will be done
 """
 
 from __future__ import print_function
@@ -40,6 +41,8 @@ from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
 
 OLD_IMAGE_DAYS = 100
+DEFAULT_KEEP_LAST = 5
+NOW = datetime.now(pytz.UTC)
 
 
 def run():
@@ -51,10 +54,11 @@ def run():
     configure_logging(args["--debug"])
 
     # If no options are set, we assume user wants all of 'em.
-    arg_options = ["--stray-ami", "--no-metadata", "--old"]
+    arg_options = ["--stray-ami", "--no-metadata",
+                   "--keep-days", OLD_IMAGE_DAYS,
+                   "--keep-num", DEFAULT_KEEP_LAST]
     if not any([args[option] for option in arg_options if option in args]):
-        for option in arg_options:
-            args[option] = True
+        args = docopt(__doc__, argv=arg_options)
 
     _ignore, failed_to_purge = purge_snapshots(args)
     if failed_to_purge:
@@ -63,14 +67,13 @@ def run():
 
 def purge_snapshots(options):
     """
-    Purge snapshots we concider no longer worth keeping
+    Purge snapshots we consider no longer worth keeping
     """
     ec2_conn = boto.connect_ec2()
     snap_pattern = re.compile(
         r"Created by CreateImage\(i-[a-f0-9]+\) for ami-[a-f0-9]+"
     )
     ami_pattern = re.compile(r"ami-[a-f0-9]+")
-    now = datetime.now(pytz.UTC)
 
     images_by_id = {
         image.id: image for image in ec2_conn.get_all_images(owners=['self'])
@@ -96,25 +99,27 @@ def purge_snapshots(options):
             continue
 
         # build a dict of hostclass+environment to a list of snapshots
-        # use this dict for the --keep option to know how many snapshots are there for each hostclass
+        # use this dict for the --keep-num option to know how many snapshots are there for each hostclass
         if snap.tags and snap.tags.get('hostclass') and snap.tags.get('env'):
             key_name = snap.tags.get('hostclass') + '_' + snap.tags.get('env')
             hostclass_snapshots = snapshot_dict.setdefault(key_name, [])
             hostclass_snapshots.append(snap)
 
-        if options["--old"]:
+        if options["--old"] or options["--keep-days"]:
+            old_days = int(options.get('--keep-days') or OLD_IMAGE_DAYS)
+
             snap_date = iso8601.parse_date(snap.start_time)
-            snap_days_old = (now - snap_date).days
-            if snap_days_old > OLD_IMAGE_DAYS:
-                print("Deleting old ({1} days) snapshot: {0}".format(
-                    snap.id, snap_days_old))
+            snap_days_old = (NOW - snap_date).days
+            if snap_days_old > old_days:
+                print("Deleting old ({1} > {2} days) snapshot: {0}".format(
+                    snap.id, snap_days_old, old_days))
                 snaps_to_purge.append(snap)
                 continue
 
         logging.debug("skipping snapshot: %s description: %s tags: %s", snap.id, snap.description, snap.tags)
 
-    if options.get('--keep'):
-        snaps_to_purge = remove_kept_snapshots(snaps_to_purge, int(options.get('--keep')), snapshot_dict)
+    if options.get('--keep-num'):
+        snaps_to_purge = remove_kept_snapshots(snaps_to_purge, int(options.get('--keep-num')), snapshot_dict)
 
     if not options["--dry-run"]:
         for snap in snaps_to_purge:
@@ -133,7 +138,7 @@ def remove_kept_snapshots(snaps_to_purge, keep_count, snapshot_dict):
     snapshots are kept for each hostclass in each environment
     """
     if keep_count < 1:
-        raise ValueError("The number of snapshots to keep must be greater than 1 when specifying --keep")
+        raise ValueError("The number of snapshots to keep must be greater than 1 for --keep-num")
     snaps_to_keep = []
     for hostclass_snapshots in snapshot_dict.values():
         keep_for_hostclass = sorted(hostclass_snapshots,
@@ -144,9 +149,9 @@ def remove_kept_snapshots(snaps_to_purge, keep_count, snapshot_dict):
         hostclass = keep_for_hostclass[0].tags['hostclass']
         env = keep_for_hostclass[0].tags['env']
 
-        logging.debug(
-            "Keeping last %s snapshots (%s) for hostclass %s in environment %s",
-            keep_count, snap_ids, hostclass, env
+        print(
+            "Keeping last %s snapshots (%s) for hostclass %s in environment %s" %
+            (keep_count, snap_ids, hostclass, env)
         )
 
     # remove the snapshots we plan to keep from purge list

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.134"
+__version__ = "1.0.135"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_purge_snapshots.py
+++ b/test/unit/test_purge_snapshots.py
@@ -1,0 +1,74 @@
+"""Tests disco_purge_snapshots"""
+from unittest import TestCase
+
+import datetime
+import random
+import sys
+import pytz
+from mock import patch, MagicMock
+
+from bin.disco_purge_snapshots import run
+
+# the current date to use for tests
+NOW_MOCK = datetime.datetime(2016, 1, 14, 0, 0, 0, tzinfo=pytz.UTC)
+
+
+class DiscoPurgeSnapshotsTest(TestCase):
+    """Test disco_purge_snapshots"""
+    def setUp(self):
+        self.snapshots = [
+            self._create_mock_snap('2016-01-01T00:00:00.000Z', hostclass='mhcfoo', env='ci'),
+            self._create_mock_snap('2016-01-02T00:00:00.000Z', hostclass='mhcfoo', env='ci'),
+            self._create_mock_snap('2016-01-03T00:00:00.000Z', hostclass='mhcfoo', env='ci')
+        ]
+
+    def _get_mock_ec2_conn(self):
+        mock = MagicMock()
+        mock.get_all_snapshots.return_value = self.snapshots
+
+        return mock
+
+    def _create_mock_snap(self, create_time, image_id=None, hostclass=None, env=None):
+        mock = MagicMock()
+        mock.start_time = create_time
+        mock.tags = {}
+        mock.id = 'snap-' + str(random.randrange(0, 9999999))
+        if image_id:
+            mock.description = 'Created by CreateImage for %s' % image_id
+
+        if hostclass:
+            mock.tags['hostclass'] = hostclass
+
+        if env:
+            mock.tags['env'] = env
+        return mock
+
+    @patch('bin.disco_purge_snapshots.NOW', NOW_MOCK)
+    def test_purge_with_keep_days_and_old(self):
+        """Test that --keep-days overrides --old"""
+        with patch('boto.connect_ec2', return_value=self._get_mock_ec2_conn()):
+            sys.argv = ['disco_purge_snapshots.py', '--old', '--keep-days', '11']
+            run()
+            self.assertEquals(1, self.snapshots[0].delete.call_count)
+            self.assertEquals(1, self.snapshots[1].delete.call_count)
+            self.assertEquals(0, self.snapshots[2].delete.call_count)
+
+    @patch('bin.disco_purge_snapshots.NOW', NOW_MOCK)
+    def test_purge_with_keep_days(self):
+        """Test purging snapshots by date"""
+        with patch('boto.connect_ec2', return_value=self._get_mock_ec2_conn()):
+            sys.argv = ['disco_purge_snapshots.py', '--keep-days', '11']
+            run()
+            self.assertEquals(1, self.snapshots[0].delete.call_count)
+            self.assertEquals(1, self.snapshots[1].delete.call_count)
+            self.assertEquals(0, self.snapshots[2].delete.call_count)
+
+    @patch('bin.disco_purge_snapshots.NOW', NOW_MOCK)
+    def test_purge_with_keep_num(self):
+        """Test purging snapshots by date but keeping a set number of them"""
+        with patch('boto.connect_ec2', return_value=self._get_mock_ec2_conn()):
+            sys.argv = ['disco_purge_snapshots.py', '--keep-days', '11', '--keep-num', '2']
+            run()
+            self.assertEquals(1, self.snapshots[0].delete.call_count)
+            self.assertEquals(0, self.snapshots[1].delete.call_count)
+            self.assertEquals(0, self.snapshots[2].delete.call_count)


### PR DESCRIPTION
This option guarantees atleast a given number of snapshots are kept for each hostclass in each environment