### PR TITLE
Add tags to ELBs

### DIFF
--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -20,7 +20,6 @@ Options:
 
 from __future__ import print_function
 import sys
-import getpass
 from docopt import docopt
 
 from disco_aws_automation import DiscoELB, DiscoVPC
@@ -50,7 +49,7 @@ def run():
             print(format_string.format(elb_info['elb_name'], elb_info['availability_zones'],
                                        elb_info["elb_id"]))
     elif args['update']:
-        DiscoAWS(config, env).update_elb(args['--hostclass'], owner=getpass.getuser())
+        DiscoAWS(config, env).update_elb(args['--hostclass'])
 
 if __name__ == "__main__":
     run_gracefully(run)

--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -20,6 +20,7 @@ Options:
 
 from __future__ import print_function
 import sys
+import getpass
 from docopt import docopt
 
 from disco_aws_automation import DiscoELB, DiscoVPC
@@ -49,7 +50,7 @@ def run():
             print(format_string.format(elb_info['elb_name'], elb_info['availability_zones'],
                                        elb_info["elb_id"]))
     elif args['update']:
-        DiscoAWS(config, env).update_elb(args['--hostclass'])
+        DiscoAWS(config, env).update_elb(args['--hostclass'], owner=getpass.getuser())
 
 if __name__ == "__main__":
     run_gracefully(run)

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -324,7 +324,7 @@ class DiscoAWS(object):
                 testing=testing,
                 tags={
                     "hostclass": hostclass,
-                    "testing": "1" if testing else "0",
+                    "is_testing": "1" if testing else "0",
                     "environment": self.environment_name
                 })
 

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -283,7 +283,7 @@ class DiscoAWS(object):
 
     # Pylint thinks that we have too many local variables, but we needs them.
     # pylint:  disable=too-many-locals
-    def update_elb(self, hostclass, update_autoscaling=True, testing=False, owner=''):
+    def update_elb(self, hostclass, update_autoscaling=True, testing=False):
         '''Creates, Updates and Delete an ELB for a hostclass depending on current configuration'''
         if not is_truthy(self.hostclass_option_default(hostclass, "elb", "False")):
             if self.elb.get_elb(hostclass):
@@ -322,12 +322,11 @@ class DiscoAWS(object):
                                                                               "elb_connection_draining",
                                                                               300)),
                 testing=testing,
-                tags={"hostclass": hostclass,
-                      "testing": "1" if testing else "0",
-                      "owner": owner,
-                      "environment": self.environment_name,
-                      "productline": self.hostclass_option_default(hostclass, "product_line", "")}
-            )
+                tags={
+                    "hostclass": hostclass,
+                    "testing": "1" if testing else "0",
+                    "environment": self.environment_name
+                })
 
         if update_autoscaling:
             self.autoscale.update_elb([elb['LoadBalancerName']] if elb else [], hostclass=hostclass)
@@ -401,7 +400,7 @@ class DiscoAWS(object):
 
         self.create_floating_interfaces(meta_network, hostclass)
 
-        elb = self.update_elb(hostclass, update_autoscaling=False, testing=testing, owner=user_data["owner"])
+        elb = self.update_elb(hostclass, update_autoscaling=False, testing=testing)
 
         chaos = is_truthy(chaos or self.hostclass_option_default(hostclass, "chaos", "True"))
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.138"
+__version__ = "1.0.139"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/helpers/matchers.py
+++ b/test/helpers/matchers.py
@@ -1,0 +1,9 @@
+"""
+Some helpers for matching values in unit tests
+"""
+
+
+class MatchAnything(object):
+    """Helper class to use with assertions that can match any value"""
+    def __eq__(self, other):
+        return True

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -324,8 +324,7 @@ class DiscoAWSTests(TestCase):
             "eip": None,
             "domain_name": "example.com",
             "elb": "yes",
-            "elb_health_check_url": "/foo",
-            'product_line': 'unittest'
+            "elb_health_check_url": "/foo"
         }
         return get_mock_config(config)
 

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -11,6 +11,8 @@ from moto import mock_elb
 
 from disco_aws_automation import DiscoAWS
 from disco_aws_automation.exceptions import TimeoutError, SmokeTestError
+
+from test.helpers.matchers import MatchAnything
 from test.helpers.patch_disco_aws import (patch_disco_aws,
                                           get_default_config_dict,
                                           get_mock_config,
@@ -323,7 +325,8 @@ class DiscoAWSTests(TestCase):
             "eip": None,
             "domain_name": "example.com",
             "elb": "yes",
-            "elb_health_check_url": "/foo"
+            "elb_health_check_url": "/foo",
+            'product_line': 'unittest'
         }
         return get_mock_config(config)
 
@@ -345,7 +348,15 @@ class DiscoAWSTests(TestCase):
             elb_protocols='HTTP', instance_protocol='HTTP',
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
-            connection_draining_timeout=300, idle_timeout=300, testing=False)
+            connection_draining_timeout=300, idle_timeout=300, testing=False,
+            tags={
+                'owner': MatchAnything(),
+                'environment': 'unittestenv',
+                'productline': 'unittest',
+                'hostclass': 'mhcelb',
+                'testing': '0'
+            }
+        )
 
     @patch_disco_aws
     def test_create_userdata_with_eip(self, **kwargs):

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -12,7 +12,6 @@ from moto import mock_elb
 from disco_aws_automation import DiscoAWS
 from disco_aws_automation.exceptions import TimeoutError, SmokeTestError
 
-from test.helpers.matchers import MatchAnything
 from test.helpers.patch_disco_aws import (patch_disco_aws,
                                           get_default_config_dict,
                                           get_mock_config,
@@ -350,9 +349,7 @@ class DiscoAWSTests(TestCase):
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
-                'owner': MatchAnything(),
                 'environment': 'unittestenv',
-                'productline': 'unittest',
                 'hostclass': 'mhcelb',
                 'testing': '0'
             }

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -351,7 +351,7 @@ class DiscoAWSTests(TestCase):
             tags={
                 'environment': 'unittestenv',
                 'hostclass': 'mhcelb',
-                'testing': '0'
+                'is_testing': '0'
             }
         )
 

--- a/test/unit/test_disco_elasticache.py
+++ b/test/unit/test_disco_elasticache.py
@@ -4,6 +4,7 @@ Tests of disco_elasticache
 from unittest import TestCase
 from mock import MagicMock, PropertyMock, call
 from disco_aws_automation import DiscoElastiCache
+from test.helpers.matchers import MatchAnything
 from test.helpers.patch_disco_aws import get_mock_config
 
 
@@ -39,13 +40,6 @@ def _get_mock_aws():
 def _get_mock_route53():
     route53 = MagicMock()
     return route53
-
-
-class MatchAnything(object):
-    """Helper class to use with assertions that can match any value"""
-
-    def __eq__(self, other):
-        return True
 
 
 class DiscoElastiCacheTests(TestCase):

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -119,11 +119,7 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=[],
             SecurityGroups=['sec-1'],
-            Scheme='internal',
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            Scheme='internal')
 
     @mock_elb
     def test_get_elb_internal_no_tls(self):
@@ -143,11 +139,7 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=[],
             SecurityGroups=['sec-1'],
-            Scheme='internal',
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            Scheme='internal')
 
     @mock_elb
     def test_get_elb_external(self):
@@ -164,11 +156,7 @@ class DiscoELBTests(TestCase):
                 'InstancePort': 80
             }],
             Subnets=[],
-            SecurityGroups=['sec-1'],
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            SecurityGroups=['sec-1'])
 
     @mock_elb
     def test_get_elb_with_tls(self):
@@ -187,11 +175,7 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=[],
             SecurityGroups=['sec-1'],
-            Scheme='internal',
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            Scheme='internal')
 
     @mock_elb
     def test_get_elb_with_tcp(self):
@@ -210,11 +194,7 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=[],
             SecurityGroups=['sec-1'],
-            Scheme='internal',
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            Scheme='internal')
 
     @mock_elb
     def test_get_elb_with_multiple_ports(self):
@@ -239,11 +219,7 @@ class DiscoELBTests(TestCase):
             }],
             Subnets=[],
             SecurityGroups=['sec-1'],
-            Scheme='internal',
-            Tags=[{
-                "Key": "elb_name",
-                "Value": DiscoELB.get_elb_name('unittestenv', 'mhcunit')
-            }])
+            Scheme='internal')
 
     @mock_elb
     def test_get_elb_mismatched_ports_protocols(self):

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -67,7 +67,9 @@ class DiscoELBTests(TestCase):
             elb_public=public,
             sticky_app_cookie=sticky_app_cookie,
             idle_timeout=idle_timeout,
-            connection_draining_timeout=connection_draining_timeout)
+            connection_draining_timeout=connection_draining_timeout,
+            tags={'tag_key': 'tag_value'}
+        )
 
     @mock_elb
     def test_get_certificate_arn_prefers_acm(self):
@@ -323,3 +325,16 @@ class DiscoELBTests(TestCase):
         self.disco_elb.elb_client.register_instances_with_load_balancer(LoadBalancerName=elb_id,
                                                                         Instances=instances)
         self.disco_elb.wait_for_instance_health_state(hostclass='mhcbar')
+
+    @mock_elb
+    def test_tagging_elb(self):
+        """Test tagging an ELB"""
+        client = self.disco_elb.elb_client
+        client.add_tags = MagicMock(wraps=client.add_tags)
+
+        self._create_elb()
+
+        client.add_tags.assert_called_once_with(
+            LoadBalancerNames=[DiscoELB.get_elb_id('unittestenv', 'mhcunit')],
+            Tags=[{'Value': 'tag_value', 'Key': 'tag_key'}]
+        )


### PR DESCRIPTION
This is a combination of #7 and #87, to add more tags to our ELBs for the purposes of making them more consistent with our other infrastructure and how we tag them.

#7 originally included productline and owner tags, but these were later removed because those tags might not provide as much utility as originally though. Instead, the intention is to remove the `elb_name` tag from ELBs and instead add `hostclass`, `environment`, and `is_testing` tags to ELBs to be consistent with our tagging for EC2 instances and ASGs.