### PR TITLE
Eliminate race condition in bake_all_phase1.sh

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.142"
+__version__ = "1.0.143"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.139"
+__version__ = "1.0.140"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/jenkins/bake_all_phase1.sh
+++ b/jenkins/bake_all_phase1.sh
@@ -3,48 +3,8 @@
 source "$(dirname $0)/bake_common.sh"  > /dev/null 2>&1
 
 phase1_images=$(python -c 'from ConfigParser import ConfigParser; c = ConfigParser(); c.read(["disco_aws.ini"]); print " ".join([s for s in c.sections() if c.has_option(s, "phase") and c.get(s,"phase") == "1"])')
-exit_status=0
 RETRY_DELAY=30
-
-function all_testable {
-    local images=$1
-
-    for image_name in $phase1_images; do
-        ami=$(disco_deploy.py list --testable --hostclass "$image_name" | awk '{print $1}')
-        if [[ "$ami" == "" ]]; then
-            echo "$image_name is not testable" 1>&2
-            echo "0"
-            return
-        fi
-    done
-    echo "1"
-}
+BAKE_TO_STAGE=tested
 
 echo "Baking phase 1 AMIs"
 bake_hostclasses $phase1_images
-
-echo "Waiting for newly baked AMIs to become testable"
-for I in 0 1 2 3 4 5 6 7 8 9 10 ; do
-    if [[ "$(all_testable $phase1_images)" == "0" ]] ; then
-        echo "Not all phase 1 images are testable, sleeping $RETRY_DELAY seconds"
-        sleep $RETRY_DELAY
-    else
-        break
-    fi
-done
-
-echo "Promoting phase 1 AMIs"
-for image_name in $phase1_images; do
-    ami=$(disco_deploy.py list --testable --hostclass "$image_name" | awk '{print $1}')
-    if [[ "$ami" != "" ]]; then
-        if ! disco_bake.py promote --ami "$ami" --stage tested; then
-            echo "$image_name phase 1 promote failed"
-            exit_status=1
-        fi
-    else
-        echo "$image_name phase 1 bake failed"
-        exit_status=1
-    fi
-done
-
-exit $exit_status

--- a/jenkins/bake_common.sh
+++ b/jenkins/bake_common.sh
@@ -24,11 +24,14 @@ function bake {
     local hostclass=$1
     local attempt=0
     local exit_code=1
+    if [ "${BAKE_TO_STAGE}" != "" ]; then
+        stage_arg="--stage=$BAKE_TO_STAGE"
+    fi
 
     while [ "$exit_code" != "0" -a "$attempt" -lt "$MAX_ATTEMPTS" ]; do
         local log_file="$LOG_DIR/$hostclass.$attempt.log"
         echo "Baking $hostclass -- log at $log_file"
-        disco_bake.py --debug bake --hostclass $hostclass --use-local-ip &> $log_file
+        disco_bake.py --debug bake --hostclass $hostclass --use-local-ip $stage_arg &> $log_file
         exit_code="$?"
         attempt=$((attempt+1))
     done


### PR DESCRIPTION
Eliminated the somewhat brittle (and racey) logic of baking, listing testable AMIs, and then promoting them, in favor of simply detecting when we want baked AMIs to end up with a certain stage, and making disco_bake.py do it.