### PR TITLE
Snapshot an attached volume

### DIFF
--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -101,7 +101,7 @@ def run():
     elif args.mode == "capture":
         if args.volume_id:
             snapshot_id = aws.disco_storage.take_snapshot(args.volume_id)
-            print(snapshot_id)
+            logging.info("Successfully created snapshot: %s", snapshot_id)
         else:
             instances = instances_from_args(aws, args)
             if not instances:

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -57,6 +57,7 @@ def get_parser():
     parser_take_group.add_argument('--hostname', dest='hostnames', default=[], action='append', type=str)
     parser_take_group.add_argument('--hostclass', dest='hostclasses', default=[], action='append', type=str)
     parser_take_group.add_argument('--ami', dest='amis', default=[], action='append', type=str)
+    parser_take_group.add_argument('--volume-id', dest='volume_id', type=str)
 
     parser_update = subparsers.add_parser(
         'update', help='Update snapshot used by new instances in a hostclass')
@@ -98,15 +99,19 @@ def run():
     elif args.mode == "cleanup":
         aws.disco_storage.cleanup_ebs_snapshots(args.keep)
     elif args.mode == "capture":
-        instances = instances_from_args(aws, args)
-        if not instances:
-            logging.warning("No instances found")
-        for instance in instances:
-            return_code, output = aws.remotecmd(
-                instance, ["sudo /opt/wgen/bin/take_snapshot.sh"], user="snapshot")
-            if return_code:
-                raise Exception("Failed to snapshot instance {0}:\n {1}\n".format(instance, output))
-            logging.info("Successfully snapshotted %s", instance)
+        if args.volume_id:
+            snapshot_id = aws.disco_storage.take_snapshot(args.volume_id)
+            print(snapshot_id)
+        else:
+            instances = instances_from_args(aws, args)
+            if not instances:
+                logging.warning("No instances found")
+            for instance in instances:
+                return_code, output = aws.remotecmd(
+                    instance, ["sudo /opt/wgen/bin/take_snapshot.sh"], user="snapshot")
+                if return_code:
+                    raise Exception("Failed to snapshot instance {0}:\n {1}\n".format(instance, output))
+                logging.info("Successfully snapshotted %s", instance)
     elif args.mode == "delete":
         for snapshot_id in args.snapshots:
             aws.disco_storage.delete_snapshot(snapshot_id)

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -325,14 +325,13 @@ class DiscoStorage(object):
             instance = self.connection.get_all_instances(
                 instance_ids=[volume.attach_data.instance_id])[0].instances[0]
 
-            hostclass = instance.tags['hostclass']
-            environment = instance.tags['environment']
+            tags = {'hostclass': instance.tags['hostclass'],
+                    'env': instance.tags['environment']}
         else:
             raise RuntimeError("The volume specified is not attched to an instance. "
                                "Snapshotting that is not supported.")
 
         snapshot = throttled_call(volume.create_snapshot)
-        throttled_call(snapshot.add_tag, key='hostclass', value=hostclass)
-        throttled_call(snapshot.add_tag, key='env', value=environment)
+        throttled_call(snapshot.add_tags, tags=tags)
 
         return snapshot.id

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -318,7 +318,7 @@ class DiscoStorage(object):
                     self.delete_snapshot(snapshot.id)
 
     def take_snapshot(self, volume_id):
-        """Takes a snapshot of an existing volume"""
+        """Takes a snapshot of an attached volume"""
         volume = self.connection.get_all_volumes(volume_ids=[volume_id])[0]
 
         if volume.attach_data and volume.attach_data.instance_id:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.139"
+__version__ = "1.0.140"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_storage.py
+++ b/test/unit/test_disco_storage.py
@@ -128,7 +128,8 @@ class DiscoStorageTests(TestCase):
             Size=100,
             AvailabilityZone='fake-zone-1'
         )
-        client.attach_volume(VolumeId=volume['VolumeId'],
+        client.attach_volume(
+            VolumeId=volume['VolumeId'],
             InstanceId=instance.instance_id,
             Device='/dev/sdb'
         )
@@ -138,4 +139,5 @@ class DiscoStorageTests(TestCase):
         snapshots = self.storage.get_snapshots('mhcmock')
         self.assertEquals(len(snapshots), 1)
         self.assertEquals(snapshots[0].id, snapshot_id)
+        self.assertEquals(snapshots[0].volume_size, 100)
         self.assertEquals(snapshots[0].tags, {'env': 'unittestenv', 'hostclass': 'mhcmock'})

--- a/test/unit/test_disco_storage.py
+++ b/test/unit/test_disco_storage.py
@@ -112,7 +112,7 @@ class DiscoStorageTests(TestCase):
 
     @mock_ec2
     def test_take_snapshot(self):
-        """Test taking a snapshot of an existing volume"""
+        """Test taking a snapshot of an attached volume"""
         client = boto3.client('ec2')
         ec2 = boto3.resource('ec2')
         instance = ec2.create_instances(ImageId='mock_image_id',

--- a/test/unit/test_purge_snapshots.py
+++ b/test/unit/test_purge_snapshots.py
@@ -49,9 +49,9 @@ class DiscoPurgeSnapshotsTest(TestCase):
             mock.tags['env'] = env
         return mock
 
-    def _create_ami_mock(self, id):
+    def _create_ami_mock(self, ami_id):
         mock = MagicMock()
-        mock.id = id
+        mock.id = ami_id
 
         return mock
 


### PR DESCRIPTION
Add logic to the `disco_snapshot.py capture` command to allow for taking a snapshot of an attached volume.