### PR TITLE
Fix `is_testing` tag interpretation for ELBs

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -10,7 +10,7 @@ import hashlib
 import boto3
 import botocore
 
-from .disco_aws_util import get_tag_value
+from .disco_aws_util import get_tag_value, is_truthy
 from .disco_route53 import DiscoRoute53
 from .disco_acm import DiscoACM
 from .disco_iam import DiscoIAM
@@ -83,8 +83,8 @@ class DiscoELB(object):
             hostclass = get_tag_value(tag_description["Tags"], "hostclass")
             environment = get_tag_value(tag_description["Tags"], "environment")
             testing = get_tag_value(tag_description["Tags"], "is_testing")
-            if hostclass and environment and testing:
-                elb_name = self.get_elb_name(environment, hostclass, testing)
+            if hostclass and environment and testing is not None:
+                elb_name = self.get_elb_name(environment, hostclass, is_truthy(testing))
             else:
                 # Otherwise, look for the elb_name tag or just use the name of the load balancer
                 elb_name = get_tag_value(tag_description["Tags"], "elb_name") or elb_id

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.140"
+__version__ = "1.0.141"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -45,11 +45,11 @@ class DiscoELBTests(TestCase):
         self.iam.get_certificate_arn.return_value = TEST_CERTIFICATE_ARN_IAM
 
     # pylint: disable=too-many-arguments
-    def _create_elb(self, hostclass=None, public=False, tls=False,
+    def _create_elb(self, hostclass=TEST_HOSTCLASS, public=False, tls=False,
                     instance_protocol='HTTP', instance_port=80,
                     elb_protocols='HTTP', elb_ports='80',
                     idle_timeout=None, connection_draining_timeout=None,
-                    sticky_app_cookie=None, existing_cookie_policy=None):
+                    sticky_app_cookie=None, existing_cookie_policy=None, testing=False):
         sticky_policies = [existing_cookie_policy] if existing_cookie_policy else []
         mock_describe = MagicMock(return_value={'PolicyDescriptions': sticky_policies})
         self.disco_elb.elb_client.describe_load_balancer_policies = mock_describe
@@ -68,7 +68,11 @@ class DiscoELBTests(TestCase):
             sticky_app_cookie=sticky_app_cookie,
             idle_timeout=idle_timeout,
             connection_draining_timeout=connection_draining_timeout,
-            tags={'tag_key': 'tag_value'}
+            tags={
+                'environment': TEST_ENV_NAME,
+                'hostclass': hostclass,
+                'is_testing': '1' if testing else '0'
+            }
         )
 
     @mock_elb
@@ -312,5 +316,21 @@ class DiscoELBTests(TestCase):
 
         client.add_tags.assert_called_once_with(
             LoadBalancerNames=[DiscoELB.get_elb_id('unittestenv', 'mhcunit')],
-            Tags=[{'Value': 'tag_value', 'Key': 'tag_key'}]
+            Tags=[
+                {'Key': 'environment', 'Value': TEST_ENV_NAME},
+                {'Key': 'is_testing', 'Value': '0'},
+                {'Key': 'hostclass', 'Value': TEST_HOSTCLASS},
+            ]
         )
+
+    @mock_elb
+    def test_display_listing(self):
+        """ Test that the tags for an ELB are correctly read for display """
+        self._create_elb(hostclass='mhcbar')
+        self._create_elb(hostclass='mhcfoo', testing=True)
+
+        listings = self.disco_elb.list_for_display()
+
+        elb_names = [listing['elb_name'] for listing in listings]
+
+        self.assertEquals(set(['unittestenv-mhcbar', 'unittestenv-mhcfoo-test']), set(elb_names))


### PR DESCRIPTION
Truthy-ness wonkiness. Using `is_truthy` to turn the value of the tag into a sensible boolean. Also added an unit test to catch this in the future.