### PR TITLE
Handle spinup errors in blue/green deployments

### DIFF
--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -14,6 +14,7 @@ from botocore.exceptions import WaiterError
 import boto3
 
 from .resource_helper import throttled_call
+from .exceptions import TooManyAutoscalingGroups
 
 
 DEFAULT_TERMINATION_POLICIES = ["OldestLaunchConfiguration"]
@@ -315,7 +316,7 @@ class DiscoAutoscale(object):
         elif len(groups) == 1 or (len(groups) == 2 and not throw_on_two_groups):
             return groups[0]
         else:
-            raise RuntimeError("There are too many autoscaling groups for {}.".format(hostclass))
+            raise TooManyAutoscalingGroups("There are too many autoscaling groups for {}.".format(hostclass))
 
     def terminate(self, instance_id, decrement_capacity=True):
         """

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -135,3 +135,8 @@ class EIPConfigError(RuntimeError):
 class RouteCreationError(RuntimeError):
     """Error trying to create a route"""
     pass
+
+
+class TooManyAutoscalingGroups(RuntimeError):
+    """Error trying to create more than the expected number of autoscaling groups"""
+    pass

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.141"
+__version__ = "1.0.142"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
As has been demonstrated, sometimes AWS cannot provide enough instances
for an ASG and this causes the spinup function to fail and throw an
exception. Now, we should catch any exceptions from the spinup command
and try to teardown the newly created testing ASG (and ELB if necessary)
so that the ASGs are not left in a bad state.

Added a number of unit tests to try to cover the different combinations
of already existing old ASGs and newly created ASGs to make sure that we
don't accidently destroy an ASG that is already in use can cause
downtime.