### PR TITLE
Parallel RDS Spinup

### DIFF
--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -101,7 +101,7 @@ def run():
         if args.cluster:
             rds.update_cluster_by_id(args.cluster)
         else:
-            rds.update_all_clusters_in_vpc(parallell=args.parallel)
+            rds.update_all_clusters_in_vpc(parallel=args.parallel)
     elif args.mode == "delete":
         rds.delete_db_instance(args.cluster, skip_final_snapshot=args.skip_final_snapshot)
     elif args.mode == "cleanup_snapshots":

--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -33,7 +33,7 @@ def get_parser():
     parser_update_group.add_argument('--cluster', dest='cluster',
                                      help='Cluster name (RDS Database Instance Identifier)')
     parser_update_group.add_argument('--parallel', dest='parallel', action='store_const', const=True,
-                                     default=False,  help='Update clusters in parallel')
+                                     default=False, help='Update clusters in parallel')
 
     # List Mode
     parser_list = subparsers.add_parser("list", help="List RDS clusters in an environment")

--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -29,8 +29,11 @@ def get_parser():
     parser_update.set_defaults(mode="update")
     parser_update.add_argument('--env', dest='env', required=False, default=None,
                                help='The environment containing the RDS cluster(s)')
-    parser_update.add_argument('--cluster', dest='cluster',
-                               help='Cluster name (RDS Database Instance Identifier)')
+    parser_update_group = parser_update.add_mutually_exclusive_group()
+    parser_update_group.add_argument('--cluster', dest='cluster',
+                                     help='Cluster name (RDS Database Instance Identifier)')
+    parser_update_group.add_argument('--parallel', dest='parallel', action='store_const', const=True,
+                                     default=False,  help='Update clusters in parallel')
 
     # List Mode
     parser_list = subparsers.add_parser("list", help="List RDS clusters in an environment")
@@ -98,7 +101,7 @@ def run():
         if args.cluster:
             rds.update_cluster_by_id(args.cluster)
         else:
-            rds.update_all_clusters_in_vpc()
+            rds.update_all_clusters_in_vpc(parallell=args.parallel)
     elif args.mode == "delete":
         rds.delete_db_instance(args.cluster, skip_final_snapshot=args.skip_final_snapshot)
     elif args.mode == "cleanup_snapshots":

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -8,7 +8,8 @@ import datetime
 import logging
 import time
 import sys
-from ConfigParser import ConfigParser, NoOptionError
+import threading
+from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 import boto3
 import botocore
@@ -39,134 +40,27 @@ DEFAULT_PORT = {
 }
 
 
-class DiscoRDS(object):
-    """Class for doing RDS operations on a given environment"""
+class RDS(threading.Thread):
+    """Class for spinning up a single rds instance"""
 
-    def __init__(self, vpc):
+    def __init__(self, env_name, database_name, rds_security_group_id, subnets_ids, domain_name):
         """Initialize class"""
+        threading.Thread.__init__(self)
+        self.threadID = database_name
+        self.vpc_name = env_name
+        self.database_name = database_name
         self.config_aws = read_config()
         self.config_rds = read_config(config_file=DEFAULT_CONFIG_FILE_RDS)
-        self.client = boto3.client('rds')
-        self.vpc = vpc
-        self.disco_vpc_sg_rules = DiscoVPCSecurityGroupRules(vpc, vpc.boto3_ec2)
-        self.vpc_name = vpc.environment_name
-        if self.vpc_name not in ['staging', 'production']:
-            self.domain_name = self.config_aws.get('disco_aws', 'default_domain_name')
-        else:
-            self.domain_name = self.config_aws.get('disco_aws',
-                                                   'default_domain_name@{0}'.format(self.vpc_name))
+        self.rds_security_group_id = rds_security_group_id
+        self.subnets_ids = subnets_ids
+        self.domain_name = domain_name
 
-    def config_with_default(self, section, param, default=None):
-        """Read the RDS config file and extract the parameter value, or return default if missing"""
-        try:
-            return self.config_rds.get(section, param)
-        except NoOptionError:
-            return default
-
-    def config_integer(self, section, param, default=None):
+    def spinup_alarms(self, database_name):
         """
-        Read the RDS config file and extract an integer value. If the value is not found and no
-        default is provided, raise NoOptionError.
+        Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
         """
-        try:
-            return int(self.config_rds.get(section, param))
-        except NoOptionError:
-            if default is not None:
-                return int(default)
-            else:
-                raise
-
-    def config_truthy(self, section, param, default='True'):
-        """Read the RDS config file and extract the boolean value, or return default if missing"""
-        return is_truthy(self.config_with_default(section, param, default))
-
-    def get_master_password(self, env_name, database_name):
-        """
-        Get the Master Password for instance stored in the S3 bucket
-        """
-        bucket_name = self.vpc.get_credential_buckets_from_env_name(self.config_aws, self.vpc_name)[0]
-        bucket = DiscoS3Bucket(bucket_name)
-
-        # for backwards compatibility check the old style keys containing the env name
-        instance_identifier = self._get_instance_identifier(env_name, database_name)
-        s3_password_old_key = 'rds/{0}/master_user_password'.format(instance_identifier)
-        if bucket.key_exists(s3_password_old_key):
-            return bucket.get_key(s3_password_old_key)
-
-        s3_password_new_key = 'rds/{0}/master_user_password'.format(database_name)
-        return bucket.get_key(s3_password_new_key)
-
-    def get_instance_parameters(self, env_name, database_name):
-        """Read the config file and extract the Instance related parameters"""
-        section = instance_identifier = self._get_instance_identifier(env_name, database_name)
-        db_engine = self.config_rds.get(section, 'engine')
-        engine_family = db_engine.split('-')[0]
-        default_license = DEFAULT_LICENSE.get(engine_family)
-        default_port = DEFAULT_PORT.get(engine_family)
-
-        instance_params = {
-            'AllocatedStorage': self.config_integer(section, 'allocated_storage'),
-            'AutoMinorVersionUpgrade': self.config_truthy(section, 'auto_minor_version_upgrade'),
-            'CharacterSetName': self.config_with_default(section, 'character_set_name'),
-            'DBInstanceClass': self.config_rds.get(section, 'db_instance_class'),
-            'DBInstanceIdentifier': instance_identifier,
-            'DBParameterGroupName': section,
-            'DBSubnetGroupName': section,
-            'Engine': db_engine,
-            'EngineVersion': self.config_rds.get(section, 'engine_version'),
-            'Iops': self.config_integer(section, 'iops', 0),
-            'LicenseModel': self.config_with_default(section, 'license_model', default_license),
-            'MasterUserPassword': self.get_master_password(env_name, database_name),
-            'MasterUsername': self.config_rds.get(section, 'master_username'),
-            'MultiAZ': self.config_truthy(section, 'multi_az'),
-            'Port': self.config_integer(section, 'port', default_port),
-            'PubliclyAccessible': self.config_truthy(section, 'publicly_accessible', 'False'),
-            'VpcSecurityGroupIds': [self.get_rds_security_group_id()],
-            'StorageEncrypted': self.config_truthy(section, 'storage_encrypted')}
-
-        return instance_params
-
-    def get_rds_security_group_id(self):
-        """
-        Returns the intranet security group id for the VPC for the current environment
-        """
-        security_groups = self.disco_vpc_sg_rules.get_all_security_groups_for_vpc()
-        for security_group in security_groups:
-            if security_group.get('Tags'):
-                tags = tag2dict(security_group['Tags'])
-                if tags.get("meta_network") == "intranet":
-                    return security_group['GroupId']
-
-        raise RuntimeError('Security group for intranet meta network is missing.')
-
-    def update_cluster_by_id(self, database_identifier):
-        """Update a RDS cluster by its database identifier"""
-        self.update_cluster(self._get_database_name(self.vpc_name, database_identifier))
-
-    def update_cluster(self, database_name):
-        """
-        Run the RDS Cluster update
-        """
-        instance_identifier = self._get_instance_identifier(self.vpc_name, database_name)
-        instance_params = self.get_instance_parameters(self.vpc_name, database_name)
-
-        if self._get_db_instance(instance_identifier):
-            self.modify_db_instance(instance_params)
-        else:
-            self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
-            # Process the Engine-specific Parameters for the Instance
-            group_name = instance_params["DBParameterGroupName"]
-            group_family = self.get_db_parameter_group_family(
-                instance_params["Engine"], instance_params["EngineVersion"])
-            logging.debug("creating parameter group %s with family %s", group_name, group_family)
-            self.recreate_db_parameter_group(self.vpc_name, database_name, group_name, group_family)
-            self.create_db_instance(instance_params)
-
-        # Create/Update CloudWatch Alarms for this instance
-        self.spinup_alarms(database_name)
-
-        # Create a DNS record for this instance
-        self.setup_dns(instance_identifier)
+        logging.debug("Configuring Cloudwatch alarms ")
+        DiscoAlarm(self.vpc_name).create_alarms(database_name)
 
     def _get_instance_address(self, instance_identifier):
         """
@@ -189,25 +83,128 @@ class DiscoRDS(object):
         disco_route53.delete_record(self.domain_name, instance_record_name, 'CNAME')
         disco_route53.create_record(self.domain_name, instance_record_name, 'CNAME', instance_endpoint)
 
-    def spinup_alarms(self, database_name):
-        """
-        Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
-        """
-        logging.debug("Configuring Cloudwatch alarms ")
-        DiscoAlarm(self.vpc_name).create_alarms(database_name)
+    @staticmethod
+    def delete_keys(dictionary, keys):
+        """Returns a copy of the given dict, with the given keys deleted"""
+        copy = dictionary.copy()
+        for key in keys:
+            del copy[key]
+        return copy
 
-    def update_all_clusters_in_vpc(self):
+    @staticmethod
+    def config_with_default(config, section, param, default=None):
+        """Read the RDS config file and extract the parameter value, or return default if missing"""
+        try:
+            return config.get(section, param)
+        except NoOptionError:
+            return default
+
+    @staticmethod
+    def config_integer(config, section, param, default=None):
+        try:
+            return int(config.get(section, param))
+        except NoOptionError:
+            if default is not None:
+                return int(default)
+            else:
+                raise
+
+    @staticmethod
+    def config_truthy(config, section, param, default='True'):
+        """Read the RDS config file and extract the boolean value, or return default if missing"""
+        return is_truthy(RDS.config_with_default(config, section, param, default))
+
+    @staticmethod
+    def get_instance_identifier(env_name, database_name):
+        return env_name + '-' + database_name
+
+    @staticmethod
+    def get_db_parameter_group_family(engine, engine_version):
         """
-        Updates every RDS instance in the current VPC to match the configuration
+        Extract the DB Parameter Group Family from Engine and Engine Version
+
+        Valid parameter group families are set based on the engine name (in lower case, if
+        applicable) and the major and minor versions of the DB (patchlevel and further
+        subdivisions of release version are ignored).
+        The rules here are heuristic, and may need to be tweaked.
+
+        Rules:
+          * oracle/sqlserver (engines that contain dashes): {engine}-{major}.{minor}
+          * others (no dashes): {engine}{major}.{minor}
         """
-        vpc_prefix = self.vpc_name + '-'
-        sections = [section for section in self.config_rds.sections()
-                    if section.startswith(vpc_prefix)]
-        logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
-        for section in sections:
-            # the section names are database identifiers
-            database_identifier = section
-            self.update_cluster(self._get_database_name(self.vpc_name, database_identifier))
+        engine_version_list = engine_version.split('.', 2)
+        format_string = "{0}-{1}.{2}" if "-" in engine else "{0}{1}.{2}"
+        return format_string.format(engine.lower(), engine_version_list[0], engine_version_list[1])
+
+    def get_master_password(self, env_name, database_name):
+        """
+        Get the Master Password for instance stored in the S3 bucket
+        """
+        from .disco_vpc import DiscoVPC
+        bucket_name = DiscoVPC.get_credential_buckets_from_env_name(self.config_aws, self.vpc_name)[0]
+        bucket = DiscoS3Bucket(bucket_name)
+
+        # for backwards compatibility check the old style keys containing the env name
+        instance_identifier = RDS.get_instance_identifier(env_name, database_name)
+        s3_password_old_key = 'rds/{0}/master_user_password'.format(instance_identifier)
+        if bucket.key_exists(s3_password_old_key):
+            return bucket.get_key(s3_password_old_key)
+
+        s3_password_new_key = 'rds/{0}/master_user_password'.format(database_name)
+        return bucket.get_key(s3_password_new_key)
+
+    def get_final_snapshot(self, db_instance_identifier):
+        """
+        Returns the information on the Final DB Snapshot. This can be used to restore a deleted DB instance
+        """
+        db_snapshot_identifier = '{}-final-snapshot'.format(db_instance_identifier)
+        try:
+            result_dict = self.client.describe_db_snapshots(DBSnapshotIdentifier=db_snapshot_identifier)
+            snapshots = result_dict["DBSnapshots"]
+            return snapshots[0] if snapshots else None
+        except botocore.exceptions.ClientError:
+            return None
+
+    def create_db_instance(self, instance_params, custom_snapshot=None):
+        """Creates the Relational database instance
+        If a snapshot is provided then we restore that snapshot
+        If a final snapshot exists for the given DB Instance ID, We restore from the final snapshot
+        If one doesn't exist, we create a new DB Instance
+        """
+        instance_identifier = instance_params['DBInstanceIdentifier']
+        snapshot = custom_snapshot or self.get_final_snapshot(instance_identifier)
+
+        if not snapshot:
+            # For Postgres, We dont need this parameter at creation
+            if instance_params['Engine'] == 'postgres':
+                instance_params = RDS.delete_keys(instance_params, ["CharacterSetName"])
+
+            logging.info("Creating new RDS cluster %s", instance_identifier)
+            self.client.create_db_instance(**instance_params)
+        else:
+            logging.info("Restoring RDS cluster from snapshot: %s", snapshot["DBSnapshotIdentifier"])
+            params = RDS.delete_keys(instance_params, [
+                "AllocatedStorage", "CharacterSetName", "DBParameterGroupName", "StorageEncrypted",
+                "EngineVersion", "MasterUsername", "MasterUserPassword", "VpcSecurityGroupIds"])
+            params["DBSnapshotIdentifier"] = snapshot["DBSnapshotIdentifier"]
+            self.client.restore_db_instance_from_db_snapshot(**params)
+            keep_trying(RDS_RESTORE_TIMEOUT, self.modify_db_instance, instance_params)
+
+    def modify_db_instance(self, instance_params, apply_immediately=True):
+        """
+        Modify settings for a DB instance. You can change one or more database configuration parameters
+        by specifying these parameters and the new values in the request.
+        """
+        logging.info("Updating RDS cluster %s", instance_params["DBInstanceIdentifier"])
+        params = RDS.delete_keys(instance_params, [
+            "Engine", "LicenseModel", "DBSubnetGroupName", "PubliclyAccessible",
+            "MasterUsername", "Port", "CharacterSetName", "StorageEncrypted"])
+        self.client.modify_db_instance(ApplyImmediately=apply_immediately, **params)
+        logging.info("Rebooting cluster to apply Param group %s", instance_params["DBInstanceIdentifier"])
+        keep_trying(RDS_STATE_POLL_INTERVAL,
+                    self.client.reboot_db_instance,
+                    DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
+                    ForceFailover=False)
 
     def recreate_db_subnet_group(self, db_subnet_group_name):
         """
@@ -223,17 +220,421 @@ class DiscoRDS(object):
             logging.debug("Not deleting subnet group '%s': %s", db_subnet_group_name, repr(err))
 
         db_subnet_group_description = 'Subnet Group for VPC {0}'.format(self.vpc_name)
+
+        self.client.create_db_subnet_group(DBSubnetGroupName=db_subnet_group_name,
+                                           DBSubnetGroupDescription=db_subnet_group_description,
+                                           SubnetIds=self.subnets_ids)
+
+    def get_instance_parameters(self, env_name, database_name):
+        """Read the config file and extract the Instance related parameters"""
+        self.client = boto3.client('rds')
+        section = instance_identifier = RDS.get_instance_identifier(env_name, database_name)
+        db_engine = self.config_rds.get(section, 'engine')
+        engine_family = db_engine.split('-')[0]
+        default_license = DEFAULT_LICENSE.get(engine_family)
+        default_port = DEFAULT_PORT.get(engine_family)
+
+        instance_params = {
+            'AllocatedStorage': self.config_integer(self.config_rds, section, 'allocated_storage'),
+            'AutoMinorVersionUpgrade': self.config_truthy(self.config_rds, section, 'auto_minor_version_upgrade'),
+            'CharacterSetName': self.config_with_default(self.config_rds, section, 'character_set_name'),
+            'DBInstanceClass': self.config_rds.get(section, 'db_instance_class'),
+            'DBInstanceIdentifier': instance_identifier,
+            'DBParameterGroupName': section,
+            'DBSubnetGroupName': section,
+            'Engine': db_engine,
+            'EngineVersion': self.config_rds.get(section, 'engine_version'),
+            'Iops': self.config_integer(self.config_rds, section, 'iops', 0),
+            'LicenseModel': self.config_with_default(self.config_rds, section, 'license_model', default_license),
+            'MasterUserPassword': self.get_master_password(env_name, database_name),
+            'MasterUsername': self.config_rds.get(section, 'master_username'),
+            'MultiAZ': self.config_truthy(self.config_rds, section, 'multi_az'),
+            'Port': self.config_integer(self.config_rds, section, 'port', default_port),
+            'PubliclyAccessible': self.config_truthy(self.config_rds, section, 'publicly_accessible', 'False'),
+            'VpcSecurityGroupIds': [self.rds_security_group_id],
+            'StorageEncrypted': self.config_truthy(self.config_rds, section, 'storage_encrypted')}
+
+        return instance_params
+
+    def _get_db_instance(self, instance_identifier):
+        try:
+            return self.client.describe_db_instances(DBInstanceIdentifier=instance_identifier)
+        except botocore.exceptions.ClientError:
+            return None
+
+    def create_db_parameter_group(self, db_parameter_group_name, db_parameter_group_family):
+        """
+        Creates a new DB parameter group. Used to set customized parameters.
+
+        A DB parameter group is initially created with the default parameters for the
+        database engine used by the DB instance.
+        To provide custom values for any of the parameters, you must modify the group after creating it.
+        """
+        self.client.create_db_parameter_group(
+            DBParameterGroupName=db_parameter_group_name,
+            DBParameterGroupFamily=db_parameter_group_family,
+            Description='Custom params-{0}'.format(db_parameter_group_name))
+
+    def modify_db_parameter_group(self, db_parameter_group_name, parameters):
+        """
+        Modifies the parameters of a DB parameter group.
+
+        Submit a list of the following:
+        ('ParameterName', 'ParameterValue', 'Description', 'Source',
+         'ApplyType', 'DataType', 'AllowedValues', 'IsModifiable',
+         'MinimumEngineVersion', 'ApplyMethod')
+        """
+        for parameter in parameters:
+            keep_trying(RDS_STATE_POLL_INTERVAL,
+                        self.client.modify_db_parameter_group,
+                        DBParameterGroupName=db_parameter_group_name,
+                        Parameters=[{'ParameterName': parameter[0],
+                                     'ParameterValue': parameter[1],
+                                     'Description': 'Description',
+                                     'Source': 'engine-default',
+                                     'ApplyType': 'static',
+                                     'DataType': 'string',
+                                     'AllowedValues': 'somevalues',
+                                     'IsModifiable': True,
+                                     'MinimumEngineVersion': 'someversion',
+                                     'ApplyMethod': 'pending-reboot'}])
+
+    def recreate_db_parameter_group(self, env_name, database_name, db_parameter_group_name,
+                                    db_parameter_group_family):
+        """
+        Check if there are any custom parameters for this instance
+        Custom Parameters are set in ./rds/engine_specific/{instance_identifier}.ini
+        If this file doesn't exist, we'll use default RDS parameters
+        Args:
+            env_name (str): The environment name to use when reading the config file.
+                            This is only used in the section name of the config file.
+                            The parameter group is always created for the current environment
+            database_name (str): The database name such as 'txdb'
+            db_parameter_group_name (str): Usually the same as the database identifier such as 'ci-txdb'
+            db_parameter_group_family (str): Parameter group family such as 'oracle-se2-12.1'
+        """
+        try:
+            self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)
+        except Exception as err:
+            logging.debug("Not deleting DB parameter group '%s': %s", db_parameter_group_name, repr(err))
+
+        # DB Parameter Group Name must be created first, using RDS defaults
+        self.create_db_parameter_group(db_parameter_group_name, db_parameter_group_family)
+
+        # Extract the Custom Values from the config file
+        custom_param_file = os.path.join(ASIAQ_CONFIG,
+                                         'rds', 'engine_specific',
+                                         '{0}.ini'.format(database_name))
+
+        if os.path.isfile(custom_param_file):
+            custom_config = ConfigParser()
+            custom_config.read(custom_param_file)
+            try:
+                custom_db_params = custom_config.items(env_name)
+                logging.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
+                             db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
+                self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
+            except NoSectionError:
+                logging.info("Using Default RDS param")
+
+    def update_cluster(self):
+        """
+        Run the RDS Cluster update
+        """
+        instance_identifier = RDS.get_instance_identifier(self.vpc_name, self.database_name)
+        instance_params = self.get_instance_parameters(self.vpc_name, self.database_name)
+
+        if self._get_db_instance(instance_identifier):
+            self.modify_db_instance(instance_params)
+        else:
+            self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
+            # Process the Engine-specific Parameters for the Instance
+            group_name = instance_params["DBParameterGroupName"]
+            group_family = self.get_db_parameter_group_family(
+                instance_params["Engine"], instance_params["EngineVersion"])
+            logging.debug("creating parameter group %s with family %s", group_name, group_family)
+            self.recreate_db_parameter_group(self.vpc_name, self.database_name, group_name, group_family)
+            self.create_db_instance(instance_params)
+
+        # Create/Update CloudWatch Alarms for this instance
+        self.spinup_alarms(self.database_name)
+
+        # Create a DNS record for this instance
+        self.setup_dns(instance_identifier)
+
+    def clone(self, source_vpc, source_db):
+        source_db_identifier = RDS.get_instance_identifier(source_vpc, source_db)
+        clone_db_identifier = RDS.get_instance_identifier(self.vpc_name, source_db)
+
+        instance_params = self.get_instance_parameters(source_vpc, source_db)
+
+        if self._get_db_instance(clone_db_identifier):
+            raise RDSEnvironmentError(
+                'Cannot create clone instance {0} because a database already exists with that name'
+                .format(clone_db_identifier)
+            )
+
+        # override some parameters to use the new instance id
+        instance_params['DBInstanceIdentifier'] = clone_db_identifier
+        instance_params['DBSubnetGroupName'] = clone_db_identifier
+        instance_params['DBParameterGroupName'] = clone_db_identifier
+
+        self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
+
+        group_name = instance_params["DBParameterGroupName"]
+        group_family = RDS.get_db_parameter_group_family(
+            instance_params["Engine"], instance_params["EngineVersion"])
+        logging.debug("creating parameter group %s with family %s", group_name, group_family)
+
+        # create a parameter group using the parameters of the source db
+        self.recreate_db_parameter_group(source_vpc, source_db, group_name, group_family)
+
+        self.create_db_instance(instance_params,
+                                custom_snapshot=self.get_final_snapshot(source_db_identifier))
+
+        # Create/Update CloudWatch Alarms for this instance
+        self.spinup_alarms(source_db)
+
+        # Create a DNS record for this instance
+        self.setup_dns(clone_db_identifier)
+
+    def run(self):
+        self.update_cluster()
+
+
+class DiscoRDS(object):
+    """Class for doing RDS operations on a given environment"""
+
+    def __init__(self, vpc):
+        """Initialize class"""
+        self.config_aws = read_config()
+        self.config_rds = read_config(config_file=DEFAULT_CONFIG_FILE_RDS)
+        self.client = boto3.client('rds')
+        self.vpc = vpc
+        self.disco_vpc_sg_rules = DiscoVPCSecurityGroupRules(vpc, vpc.boto3_ec2)
+        self.vpc_name = vpc.environment_name
+        if self.vpc_name not in ['staging', 'production']:
+            self.domain_name = self.config_aws.get('disco_aws', 'default_domain_name')
+        else:
+            self.domain_name = self.config_aws.get('disco_aws',
+                                                   'default_domain_name@{0}'.format(self.vpc_name))
+
+#    def config_with_default(self, section, param, default=None):
+#        """Read the RDS config file and extract the parameter value, or return default if missing"""
+#        try:
+#            return self.config_rds.get(section, param)
+#        except NoOptionError:
+#            return default
+#
+#    def config_integer(self, section, param, default=None):
+#        """
+#        Read the RDS config file and extract an integer value. If the value is not found and no
+#        default is provided, raise NoOptionError.
+#        """
+#        try:
+#            return int(self.config_rds.get(section, param))
+#        except NoOptionError:
+#            if default is not None:
+#                return int(default)
+#            else:
+#                raise
+#
+#    def config_truthy(self, section, param, default='True'):
+#        """Read the RDS config file and extract the boolean value, or return default if missing"""
+#        return is_truthy(self.config_with_default(section, param, default))
+#
+#    def get_master_password(self, env_name, database_name):
+#        """
+#        Get the Master Password for instance stored in the S3 bucket
+#        """
+#        bucket_name = self.vpc.get_credential_buckets_from_env_name(self.config_aws, self.vpc_name)[0]
+#        bucket = DiscoS3Bucket(bucket_name)
+#
+#        # for backwards compatibility check the old style keys containing the env name
+#        instance_identifier = self._get_instance_identifier(env_name, database_name)
+#        s3_password_old_key = 'rds/{0}/master_user_password'.format(instance_identifier)
+#        if bucket.key_exists(s3_password_old_key):
+#            return bucket.get_key(s3_password_old_key)
+#
+#        s3_password_new_key = 'rds/{0}/master_user_password'.format(database_name)
+#        return bucket.get_key(s3_password_new_key)
+#
+#    def get_instance_parameters(self, env_name, database_name):
+#        """Read the config file and extract the Instance related parameters"""
+#        section = instance_identifier = self._get_instance_identifier(env_name, database_name)
+#        db_engine = self.config_rds.get(section, 'engine')
+#        engine_family = db_engine.split('-')[0]
+#        default_license = DEFAULT_LICENSE.get(engine_family)
+#        default_port = DEFAULT_PORT.get(engine_family)
+#
+#        instance_params = {
+#            'AllocatedStorage': self.config_integer(section, 'allocated_storage'),
+#            'AutoMinorVersionUpgrade': self.config_truthy(section, 'auto_minor_version_upgrade'),
+#            'CharacterSetName': self.config_with_default(section, 'character_set_name'),
+#            'DBInstanceClass': self.config_rds.get(section, 'db_instance_class'),
+#            'DBInstanceIdentifier': instance_identifier,
+#            'DBParameterGroupName': section,
+#            'DBSubnetGroupName': section,
+#            'Engine': db_engine,
+#            'EngineVersion': self.config_rds.get(section, 'engine_version'),
+#            'Iops': self.config_integer(section, 'iops', 0),
+#            'LicenseModel': self.config_with_default(section, 'license_model', default_license),
+#            'MasterUserPassword': self.get_master_password(env_name, database_name),
+#            'MasterUsername': self.config_rds.get(section, 'master_username'),
+#            'MultiAZ': self.config_truthy(section, 'multi_az'),
+#            'Port': self.config_integer(section, 'port', default_port),
+#            'PubliclyAccessible': self.config_truthy(section, 'publicly_accessible', 'False'),
+#            'VpcSecurityGroupIds': [self.get_rds_security_group_id()],
+#            'StorageEncrypted': self.config_truthy(section, 'storage_encrypted')}
+#
+#        return instance_params
+
+    def get_rds_security_group_id(self):
+        """
+        Returns the intranet security group id for the VPC for the current environment
+        """
+        security_groups = self.disco_vpc_sg_rules.get_all_security_groups_for_vpc()
+        for security_group in security_groups:
+            if security_group.get('Tags'):
+                tags = tag2dict(security_group['Tags'])
+                if tags.get("meta_network") == "intranet":
+                    return security_group['GroupId']
+
+        raise RuntimeError('Security group for intranet meta network is missing.')
+
+    def update_cluster_by_id(self, database_identifier):
+        """Update a RDS cluster by its database identifier"""
+        self.update_cluster(RDS.get_database_name(self.vpc_name, database_identifier))
+
+#    def update_cluster(self, database_name):
+#        """
+#        Run the RDS Cluster update
+#        """
+#        instance_identifier = self._get_instance_identifier(self.vpc_name, database_name)
+#        instance_params = self.get_instance_parameters(self.vpc_name, database_name)
+#
+#        if self._get_db_instance(instance_identifier):
+#            self.modify_db_instance(instance_params)
+#        else:
+#            self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
+#            # Process the Engine-specific Parameters for the Instance
+#            group_name = instance_params["DBParameterGroupName"]
+#            group_family = self.get_db_parameter_group_family(
+#                instance_params["Engine"], instance_params["EngineVersion"])
+#            logging.debug("creating parameter group %s with family %s", group_name, group_family)
+#            self.recreate_db_parameter_group(self.vpc_name, database_name, group_name, group_family)
+#            self.create_db_instance(instance_params)
+#
+#        # Create/Update CloudWatch Alarms for this instance
+#        self.spinup_alarms(database_name)
+#
+#        # Create a DNS record for this instance
+#        self.setup_dns(instance_identifier)
+#
+    def _get_instance_address(self, instance_identifier):
+        """
+        Obtains the instance end point for the given RDS instance
+        """
+        instance_info = self.client.describe_db_instances(DBInstanceIdentifier=instance_identifier)
+        return instance_info['DBInstances'][0]['Endpoint']['Address']
+
+#    def setup_dns(self, instance_identifier):
+#        """
+#        Setup Domain Name Lookup using Route 53
+#        """
+#        start_time = time.time()
+#        instance_endpoint = keep_trying(RDS_STARTUP_TIMEOUT, self._get_instance_address, instance_identifier)
+#        logging.info("Waited %s seconds for RDS to get an address", time.time() - start_time)
+#        disco_route53 = DiscoRoute53()
+#        instance_record_name = '{0}.{1}.'.format(instance_identifier, self.domain_name)
+#
+#        # Delete and recreate DNS record for this Instance
+#        disco_route53.delete_record(self.domain_name, instance_record_name, 'CNAME')
+#        disco_route53.create_record(self.domain_name, instance_record_name, 'CNAME', instance_endpoint)
+#
+#    def spinup_alarms(self, database_name):
+#        """
+#        Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
+#        """
+#        logging.debug("Configuring Cloudwatch alarms ")
+#        DiscoAlarm(self.vpc_name).create_alarms(database_name)
+
+    def update_all_clusters_in_vpc(self):
+        """
+        Updates every RDS instance in the current VPC to match the configuration
+        """
+        vpc_prefix = self.vpc_name + '-'
+        sections = [section for section in self.config_rds.sections()
+                    if section.startswith(vpc_prefix)]
+        logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
+        for section in sections:
+            # the section names are database identifiers
+            database_identifier = section
+            self.update_cluster(RDS.get_database_name(self.vpc_name, database_identifier))
+
+    def get_subnet_ids(self):
+        """ Get a list of subnet ids for the vpc"""
         subnets = self.vpc.get_all_subnets()
         subnet_ids = []
         for subnet in subnets:
             tags = tag2dict(subnet['Tags'])
             if tags['meta_network'] == 'intranet':
                 subnet_ids.append(str(subnet['SubnetId']))
+        return subnet_ids
 
-        self.client.create_db_subnet_group(DBSubnetGroupName=db_subnet_group_name,
-                                           DBSubnetGroupDescription=db_subnet_group_description,
-                                           SubnetIds=subnet_ids)
+    def update_all_clusters_in_vpc_parallel(self):
+        """
+        Updates every RDS instance in the current VPC to match the configuration
+        """
+        vpc_prefix = self.vpc_name + '-'
+        sections = [section for section in self.config_rds.sections()
+                    if section.startswith(vpc_prefix)]
+        logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
+        rds_security_group_id = self.get_rds_security_group_id()
+        subnets_ids = self.get_subnet_ids()
+        rds_list = []
 
+        for section in sections:
+            # the section names are database identifiers
+            database_identifier = section
+            rds = RDS(self.vpc_name,
+                      RDS.get_database_name(self.vpc_name, database_identifier),
+                      rds_security_group_id,
+                      subnets_ids,
+                      self.domain_name)
+            rds_list.append(rds)
+
+        for rds in rds_list:
+            rds.start()
+
+        for rds in rds_list:
+            rds.join()
+
+#    def recreate_db_subnet_group(self, db_subnet_group_name):
+#        """
+#        Creates the DB Subnet Group. If it exists already, drops it and recreates it.
+#        DB subnet groups must contain at least one subnet in at least two AZs in the region.
+#
+#        @db_subnet_group_name: String. The name for the DB subnet group.
+#                               This value is stored as a lowercase string.
+#        """
+#        try:
+#            self.client.delete_db_subnet_group(DBSubnetGroupName=db_subnet_group_name)
+#        except Exception as err:
+#            logging.debug("Not deleting subnet group '%s': %s", db_subnet_group_name, repr(err))
+#
+#        db_subnet_group_description = 'Subnet Group for VPC {0}'.format(self.vpc_name)
+#        subnets = self.vpc.get_all_subnets()
+#        subnet_ids = []
+#        for subnet in subnets:
+#            tags = tag2dict(subnet['Tags'])
+#            if tags['meta_network'] == 'intranet':
+#                subnet_ids.append(str(subnet['SubnetId']))
+#
+#        self.client.create_db_subnet_group(DBSubnetGroupName=db_subnet_group_name,
+#                                           DBSubnetGroupDescription=db_subnet_group_description,
+#                                           SubnetIds=subnet_ids)
+#
     def get_final_snapshot(self, db_instance_identifier):
         """
         Returns the information on the Final DB Snapshot. This can be used to restore a deleted DB instance
@@ -246,54 +647,54 @@ class DiscoRDS(object):
         except botocore.exceptions.ClientError:
             return None
 
-    def delete_keys(self, dictionary, keys):
-        """Returns a copy of the given dict, with the given keys deleted"""
-        copy = dictionary.copy()
-        for key in keys:
-            del copy[key]
-        return copy
-
-    def create_db_instance(self, instance_params, custom_snapshot=None):
-        """Creates the Relational database instance
-        If a snapshot is provided then we restore that snapshot
-        If a final snapshot exists for the given DB Instance ID, We restore from the final snapshot
-        If one doesn't exist, we create a new DB Instance
-        """
-        instance_identifier = instance_params['DBInstanceIdentifier']
-        snapshot = custom_snapshot or self.get_final_snapshot(instance_identifier)
-
-        if not snapshot:
-            # For Postgres, We dont need this parameter at creation
-            if instance_params['Engine'] == 'postgres':
-                instance_params = self.delete_keys(instance_params, ["CharacterSetName"])
-
-            logging.info("Creating new RDS cluster %s", instance_identifier)
-            self.client.create_db_instance(**instance_params)
-        else:
-            logging.info("Restoring RDS cluster from snapshot: %s", snapshot["DBSnapshotIdentifier"])
-            params = self.delete_keys(instance_params, [
-                "AllocatedStorage", "CharacterSetName", "DBParameterGroupName", "StorageEncrypted",
-                "EngineVersion", "MasterUsername", "MasterUserPassword", "VpcSecurityGroupIds"])
-            params["DBSnapshotIdentifier"] = snapshot["DBSnapshotIdentifier"]
-            self.client.restore_db_instance_from_db_snapshot(**params)
-            keep_trying(RDS_RESTORE_TIMEOUT, self.modify_db_instance, instance_params)
-
-    def modify_db_instance(self, instance_params, apply_immediately=True):
-        """
-        Modify settings for a DB instance. You can change one or more database configuration parameters
-        by specifying these parameters and the new values in the request.
-        """
-        logging.info("Updating RDS cluster %s", instance_params["DBInstanceIdentifier"])
-        params = self.delete_keys(instance_params, [
-            "Engine", "LicenseModel", "DBSubnetGroupName", "PubliclyAccessible",
-            "MasterUsername", "Port", "CharacterSetName", "StorageEncrypted"])
-        self.client.modify_db_instance(ApplyImmediately=apply_immediately, **params)
-        logging.info("Rebooting cluster to apply Param group %s", instance_params["DBInstanceIdentifier"])
-        keep_trying(RDS_STATE_POLL_INTERVAL,
-                    self.client.reboot_db_instance,
-                    DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
-                    ForceFailover=False)
-
+#    def delete_keys(self, dictionary, keys):
+#        """Returns a copy of the given dict, with the given keys deleted"""
+#        copy = dictionary.copy()
+#        for key in keys:
+#            del copy[key]
+#        return copy
+#
+#    def create_db_instance(self, instance_params, custom_snapshot=None):
+#        """Creates the Relational database instance
+#        If a snapshot is provided then we restore that snapshot
+#        If a final snapshot exists for the given DB Instance ID, We restore from the final snapshot
+#        If one doesn't exist, we create a new DB Instance
+#        """
+#        instance_identifier = instance_params['DBInstanceIdentifier']
+#        snapshot = custom_snapshot or self.get_final_snapshot(instance_identifier)
+#
+#        if not snapshot:
+#            # For Postgres, We dont need this parameter at creation
+#            if instance_params['Engine'] == 'postgres':
+#                instance_params = self.delete_keys(instance_params, ["CharacterSetName"])
+#
+#            logging.info("Creating new RDS cluster %s", instance_identifier)
+#            self.client.create_db_instance(**instance_params)
+#        else:
+#            logging.info("Restoring RDS cluster from snapshot: %s", snapshot["DBSnapshotIdentifier"])
+#            params = self.delete_keys(instance_params, [
+#                "AllocatedStorage", "CharacterSetName", "DBParameterGroupName", "StorageEncrypted",
+#                "EngineVersion", "MasterUsername", "MasterUserPassword", "VpcSecurityGroupIds"])
+#            params["DBSnapshotIdentifier"] = snapshot["DBSnapshotIdentifier"]
+#            self.client.restore_db_instance_from_db_snapshot(**params)
+#            keep_trying(RDS_RESTORE_TIMEOUT, self.modify_db_instance, instance_params)
+#
+#    def modify_db_instance(self, instance_params, apply_immediately=True):
+#        """
+#        Modify settings for a DB instance. You can change one or more database configuration parameters
+#        by specifying these parameters and the new values in the request.
+#        """
+#        logging.info("Updating RDS cluster %s", instance_params["DBInstanceIdentifier"])
+#        params = self.delete_keys(instance_params, [
+#            "Engine", "LicenseModel", "DBSubnetGroupName", "PubliclyAccessible",
+#            "MasterUsername", "Port", "CharacterSetName", "StorageEncrypted"])
+#        self.client.modify_db_instance(ApplyImmediately=apply_immediately, **params)
+#        logging.info("Rebooting cluster to apply Param group %s", instance_params["DBInstanceIdentifier"])
+#        keep_trying(RDS_STATE_POLL_INTERVAL,
+#                    self.client.reboot_db_instance,
+#                    DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
+#                    ForceFailover=False)
+#
     def get_db_instances(self, status=None):
         """
         Get all RDS clusters/instances in the current VPC.
@@ -386,93 +787,98 @@ class DiscoRDS(object):
         if wait:
             self._wait_for_db_instance_deletions()
 
-    def create_db_parameter_group(self, db_parameter_group_name, db_parameter_group_family):
-        """
-        Creates a new DB parameter group. Used to set customized parameters.
-
-        A DB parameter group is initially created with the default parameters for the
-        database engine used by the DB instance.
-        To provide custom values for any of the parameters, you must modify the group after creating it.
-        """
-        self.client.create_db_parameter_group(
-            DBParameterGroupName=db_parameter_group_name,
-            DBParameterGroupFamily=db_parameter_group_family,
-            Description='Custom params-{0}'.format(db_parameter_group_name))
-
-    def modify_db_parameter_group(self, db_parameter_group_name, parameters):
-        """
-        Modifies the parameters of a DB parameter group.
-
-        Submit a list of the following:
-        ('ParameterName', 'ParameterValue', 'Description', 'Source',
-         'ApplyType', 'DataType', 'AllowedValues', 'IsModifiable',
-         'MinimumEngineVersion', 'ApplyMethod')
-        """
-        for parameter in parameters:
-            self.client.modify_db_parameter_group(DBParameterGroupName=db_parameter_group_name,
-                                                  Parameters=[{'ParameterName': parameter[0],
-                                                               'ParameterValue': parameter[1],
-                                                               'Description': 'Description',
-                                                               'Source': 'engine-default',
-                                                               'ApplyType': 'static',
-                                                               'DataType': 'string',
-                                                               'AllowedValues': 'somevalues',
-                                                               'IsModifiable': True,
-                                                               'MinimumEngineVersion': 'someversion',
-                                                               'ApplyMethod': 'pending-reboot'}])
-
-    def recreate_db_parameter_group(self, env_name, database_name, db_parameter_group_name,
-                                    db_parameter_group_family):
-        """
-        Check if there are any custom parameters for this instance
-        Custom Parameters are set in ./rds/engine_specific/{instance_identifier}.ini
-        If this file doesn't exist, we'll use default RDS parameters
-        Args:
-            env_name (str): The environment name to use when reading the config file.
-                            This is only used in the section name of the config file.
-                            The parameter group is always created for the current environment
-            database_name (str): The database name such as 'txdb'
-            db_parameter_group_name (str): Usually the same as the database identifier such as 'ci-txdb'
-            db_parameter_group_family (str): Parameter group family such as 'oracle-se2-12.1'
-        """
-        try:
-            self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)
-        except Exception as err:
-            logging.debug("Not deleting DB parameter group '%s': %s", db_parameter_group_name, repr(err))
-
-        # DB Parameter Group Name must be created first, using RDS defaults
-        self.create_db_parameter_group(db_parameter_group_name, db_parameter_group_family)
-
-        # Extract the Custom Values from the config file
-        custom_param_file = os.path.join(ASIAQ_CONFIG,
-                                         'rds', 'engine_specific',
-                                         '{0}.ini'.format(database_name))
-
-        if os.path.isfile(custom_param_file):
-            custom_config = ConfigParser()
-            custom_config.read(custom_param_file)
-            custom_db_params = custom_config.items(env_name)
-            logging.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
-                         db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
-            self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
-
-    def get_db_parameter_group_family(self, engine, engine_version):
-        """
-        Extract the DB Parameter Group Family from Engine and Engine Version
-
-        Valid parameter group families are set based on the engine name (in lower case, if
-        applicable) and the major and minor versions of the DB (patchlevel and further
-        subdivisions of release version are ignored).
-        The rules here are heuristic, and may need to be tweaked.
-
-        Rules:
-          * oracle/sqlserver (engines that contain dashes): {engine}-{major}.{minor}
-          * others (no dashes): {engine}{major}.{minor}
-        """
-        engine_version_list = engine_version.split('.', 2)
-        format_string = "{0}-{1}.{2}" if "-" in engine else "{0}{1}.{2}"
-        return format_string.format(engine.lower(), engine_version_list[0], engine_version_list[1])
-
+#    def create_db_parameter_group(self, db_parameter_group_name, db_parameter_group_family):
+#        """
+#        Creates a new DB parameter group. Used to set customized parameters.
+#
+#        A DB parameter group is initially created with the default parameters for the
+#        database engine used by the DB instance.
+#        To provide custom values for any of the parameters, you must modify the group after creating it.
+#        """
+#        self.client.create_db_parameter_group(
+#            DBParameterGroupName=db_parameter_group_name,
+#            DBParameterGroupFamily=db_parameter_group_family,
+#            Description='Custom params-{0}'.format(db_parameter_group_name))
+#
+#    def modify_db_parameter_group(self, db_parameter_group_name, parameters):
+#        """
+#        Modifies the parameters of a DB parameter group.
+#
+#        Submit a list of the following:
+#        ('ParameterName', 'ParameterValue', 'Description', 'Source',
+#         'ApplyType', 'DataType', 'AllowedValues', 'IsModifiable',
+#         'MinimumEngineVersion', 'ApplyMethod')
+#        """
+#        for parameter in parameters:
+#            keep_trying(RDS_STATE_POLL_INTERVAL,
+#                        self.client.modify_db_parameter_group,
+#                        DBParameterGroupName=db_parameter_group_name,
+#                        Parameters=[{'ParameterName': parameter[0],
+#                                     'ParameterValue': parameter[1],
+#                                     'Description': 'Description',
+#                                     'Source': 'engine-default',
+#                                     'ApplyType': 'static',
+#                                     'DataType': 'string',
+#                                     'AllowedValues': 'somevalues',
+#                                     'IsModifiable': True,
+#                                     'MinimumEngineVersion': 'someversion',
+#                                     'ApplyMethod': 'pending-reboot'}])
+#
+#    def recreate_db_parameter_group(self, env_name, database_name, db_parameter_group_name,
+#                                    db_parameter_group_family):
+#        """
+#        Check if there are any custom parameters for this instance
+#        Custom Parameters are set in ./rds/engine_specific/{instance_identifier}.ini
+#        If this file doesn't exist, we'll use default RDS parameters
+#        Args:
+#            env_name (str): The environment name to use when reading the config file.
+#                            This is only used in the section name of the config file.
+#                            The parameter group is always created for the current environment
+#            database_name (str): The database name such as 'txdb'
+#            db_parameter_group_name (str): Usually the same as the database identifier such as 'ci-txdb'
+#            db_parameter_group_family (str): Parameter group family such as 'oracle-se2-12.1'
+#        """
+#        try:
+#            self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)
+#        except Exception as err:
+#            logging.debug("Not deleting DB parameter group '%s': %s", db_parameter_group_name, repr(err))
+#
+#        # DB Parameter Group Name must be created first, using RDS defaults
+#        self.create_db_parameter_group(db_parameter_group_name, db_parameter_group_family)
+#
+#        # Extract the Custom Values from the config file
+#        custom_param_file = os.path.join(ASIAQ_CONFIG,
+#                                         'rds', 'engine_specific',
+#                                         '{0}.ini'.format(database_name))
+#
+#        if os.path.isfile(custom_param_file):
+#            custom_config = ConfigParser()
+#            custom_config.read(custom_param_file)
+#            try:
+#                custom_db_params = custom_config.items(env_name)
+#                logging.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
+#                             db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
+#                self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
+#            except NoSectionError:
+#                logging.info("Using Default RDS param")
+#
+#    def get_db_parameter_group_family(self, engine, engine_version):
+#        """
+#        Extract the DB Parameter Group Family from Engine and Engine Version
+#
+#        Valid parameter group families are set based on the engine name (in lower case, if
+#        applicable) and the major and minor versions of the DB (patchlevel and further
+#        subdivisions of release version are ignored).
+#        The rules here are heuristic, and may need to be tweaked.
+#
+#        Rules:
+#          * oracle/sqlserver (engines that contain dashes): {engine}-{major}.{minor}
+#          * others (no dashes): {engine}{major}.{minor}
+#        """
+#        engine_version_list = engine_version.split('.', 2)
+#        format_string = "{0}-{1}.{2}" if "-" in engine else "{0}{1}.{2}"
+#        return format_string.format(engine.lower(), engine_version_list[0], engine_version_list[1])
+#
     def cleanup_snapshots(self, days):
         """
         Cleanup all manual snapshots older than --age specified, by default its 30 days
@@ -489,13 +895,13 @@ class DiscoRDS(object):
                 logging.info("Deleting Snapshot %s since its older than %d", snapshot_id, days)
                 self.client.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
 
-    def _get_instance_identifier(self, env_name, database_name):
-        return env_name + '-' + database_name
-
-    def _get_database_name(self, env_name, instance_identifier):
-        identifier_prefix = len(env_name + '-')
-        return instance_identifier[identifier_prefix:]
-
+#    def _get_instance_identifier(self, env_name, database_name):
+#        return env_name + '-' + database_name
+#
+#    def _get_database_name(self, env_name, instance_identifier):
+#        identifier_prefix = len(env_name + '-')
+#        return instance_identifier[identifier_prefix:]
+#
     def _get_db_instance(self, instance_identifier):
         try:
             return self.client.describe_db_instances(DBInstanceIdentifier=instance_identifier)
@@ -510,10 +916,8 @@ class DiscoRDS(object):
             source_vpc (str): the VPC where the source database is located
             source_db (str): the source database name
         """
-        source_db_identifier = self._get_instance_identifier(source_vpc, source_db)
-        clone_db_identifier = self._get_instance_identifier(self.vpc_name, source_db)
 
-        instance_params = self.get_instance_parameters(source_vpc, source_db)
+        clone_db_identifier = RDS.get_instance_identifier(self.vpc_name, source_db)
 
         if self._get_db_instance(clone_db_identifier):
             raise RDSEnvironmentError(
@@ -521,26 +925,11 @@ class DiscoRDS(object):
                 .format(clone_db_identifier)
             )
 
-        # override some parameters to use the new instance id
-        instance_params['DBInstanceIdentifier'] = clone_db_identifier
-        instance_params['DBSubnetGroupName'] = clone_db_identifier
-        instance_params['DBParameterGroupName'] = clone_db_identifier
+        rds_security_group_id = self.get_rds_security_group_id()
+        subnets_ids = self.get_subnet_ids()
+        rds = RDS(self.vpc_name,
+                  RDS.get_database_name(self.vpc_name, clone_db_identifier),
+                  rds_security_group_id,
+                  subnets_ids, self.domain_name)
 
-        self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
-
-        group_name = instance_params["DBParameterGroupName"]
-        group_family = self.get_db_parameter_group_family(
-            instance_params["Engine"], instance_params["EngineVersion"])
-        logging.debug("creating parameter group %s with family %s", group_name, group_family)
-
-        # create a parameter group using the parameters of the source db
-        self.recreate_db_parameter_group(source_vpc, source_db, group_name, group_family)
-
-        self.create_db_instance(instance_params,
-                                custom_snapshot=self.get_final_snapshot(source_db_identifier))
-
-        # Create/Update CloudWatch Alarms for this instance
-        self.spinup_alarms(source_db)
-
-        # Create a DNS record for this instance
-        self.setup_dns(clone_db_identifier)
+        rds.clone(source_vpc, source_db)

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -43,16 +43,16 @@ DEFAULT_PORT = {
 class RDS(threading.Thread):
     """Class for spinning up a single rds instance"""
 
-    def __init__(self, env_name, database_identifier, rds_security_group_id, subnets_ids, domain_name):
+    def __init__(self, env_name, database_identifier, rds_security_group_id, subnet_ids, domain_name):
         """Initialize class"""
-        threading.Thread.__init__(self)
-        self.threadID = database_identifier
+        threading.Thread.__init__(self, name=database_identifier)
+        self.client = boto3.client('rds')
         self.vpc_name = env_name
         self.database_name = RDS.get_database_name(env_name, database_identifier)
         self.config_aws = read_config()
         self.config_rds = read_config(config_file=DEFAULT_CONFIG_FILE_RDS)
         self.rds_security_group_id = rds_security_group_id
-        self.subnets_ids = subnets_ids
+        self.subnet_ids = subnet_ids
         self.domain_name = domain_name
 
     def spinup_alarms(self, database_name):
@@ -85,6 +85,7 @@ class RDS(threading.Thread):
 
     @staticmethod
     def get_database_name(env_name, instance_identifier):
+        """ Extract the database name from the instance_identifier """
         identifier_prefix = len(env_name + '-')
         return instance_identifier[identifier_prefix:]
 
@@ -107,6 +108,7 @@ class RDS(threading.Thread):
 
     @staticmethod
     def config_integer(config, section, param, default=None):
+        """Read the config file and return the integer value else return default"""
         try:
             return int(config.get(section, param))
         except NoOptionError:
@@ -122,6 +124,7 @@ class RDS(threading.Thread):
 
     @staticmethod
     def get_instance_identifier(env_name, database_name):
+        """Returns the database identifier. e.g. ci-testdb"""
         return env_name + '-' + database_name
 
     @staticmethod
@@ -230,24 +233,26 @@ class RDS(threading.Thread):
 
         self.client.create_db_subnet_group(DBSubnetGroupName=db_subnet_group_name,
                                            DBSubnetGroupDescription=db_subnet_group_description,
-                                           SubnetIds=self.subnets_ids)
+                                           SubnetIds=self.subnet_ids)
 
     def get_instance_parameters(self, env_name, database_name):
         """Read the config file and extract the Instance related parameters"""
-        self.client = boto3.client('rds')
         section = instance_identifier = RDS.get_instance_identifier(env_name, database_name)
         db_engine = self.config_rds.get(section, 'engine')
         engine_family = db_engine.split('-')[0]
         default_license = DEFAULT_LICENSE.get(engine_family)
         default_port = DEFAULT_PORT.get(engine_family)
-        preferred_backup_window = self.config_with_default(self.config_rds, section, 'preferred_backup_window', None)
+        preferred_backup_window = self.config_with_default(self.config_rds, section,
+                                                           'preferred_backup_window',
+                                                           None)
         preferred_maintenance_window = self.config_with_default(self.config_rds, section,
                                                                 'preferred_maintenance_window',
                                                                 None)
 
         instance_params = {
             'AllocatedStorage': self.config_integer(self.config_rds, section, 'allocated_storage'),
-            'AutoMinorVersionUpgrade': self.config_truthy(self.config_rds, section, 'auto_minor_version_upgrade'),
+            'AutoMinorVersionUpgrade': self.config_truthy(self.config_rds,
+                                                          section, 'auto_minor_version_upgrade'),
             'CharacterSetName': self.config_with_default(self.config_rds, section, 'character_set_name'),
             'DBInstanceClass': self.config_rds.get(section, 'db_instance_class'),
             'DBInstanceIdentifier': instance_identifier,
@@ -256,15 +261,18 @@ class RDS(threading.Thread):
             'Engine': db_engine,
             'EngineVersion': self.config_rds.get(section, 'engine_version'),
             'Iops': self.config_integer(self.config_rds, section, 'iops', 0),
-            'LicenseModel': self.config_with_default(self.config_rds, section, 'license_model', default_license),
+            'LicenseModel': self.config_with_default(self.config_rds, section,
+                                                     'license_model', default_license),
             'MasterUserPassword': self.get_master_password(env_name, database_name),
             'MasterUsername': self.config_rds.get(section, 'master_username'),
             'MultiAZ': self.config_truthy(self.config_rds, section, 'multi_az'),
             'Port': self.config_integer(self.config_rds, section, 'port', default_port),
-            'PubliclyAccessible': self.config_truthy(self.config_rds, section, 'publicly_accessible', 'False'),
+            'PubliclyAccessible': self.config_truthy(self.config_rds, section,
+                                                     'publicly_accessible', 'False'),
             'VpcSecurityGroupIds': [self.rds_security_group_id],
             'StorageEncrypted': self.config_truthy(self.config_rds, section, 'storage_encrypted'),
-            'BackupRetentionPeriod': self.config_integer(self.config_rds, section, 'backup_retention_period', 1)
+            'BackupRetentionPeriod': self.config_integer(self.config_rds, section,
+                                                         'backup_retention_period', 1)
         }
 
         # If custom windows were set, use them. If windows are not specified, we will use the AWS defaults
@@ -383,6 +391,10 @@ class RDS(threading.Thread):
         self.setup_dns(instance_identifier)
 
     def clone(self, source_vpc, source_db):
+        """
+        Clone the database in source_vpc into the current vpc. The vpc name of the current
+        database would be the same as the source database.
+        """
         source_db_identifier = RDS.get_instance_identifier(source_vpc, source_db)
         clone_db_identifier = RDS.get_instance_identifier(self.vpc_name, source_db)
 
@@ -439,76 +451,6 @@ class DiscoRDS(object):
             self.domain_name = self.config_aws.get('disco_aws',
                                                    'default_domain_name@{0}'.format(self.vpc_name))
 
-#    def config_with_default(self, section, param, default=None):
-#        """Read the RDS config file and extract the parameter value, or return default if missing"""
-#        try:
-#            return self.config_rds.get(section, param)
-#        except NoOptionError:
-#            return default
-#
-#    def config_integer(self, section, param, default=None):
-#        """
-#        Read the RDS config file and extract an integer value. If the value is not found and no
-#        default is provided, raise NoOptionError.
-#        """
-#        try:
-#            return int(self.config_rds.get(section, param))
-#        except NoOptionError:
-#            if default is not None:
-#                return int(default)
-#            else:
-#                raise
-#
-#    def config_truthy(self, section, param, default='True'):
-#        """Read the RDS config file and extract the boolean value, or return default if missing"""
-#        return is_truthy(self.config_with_default(section, param, default))
-#
-#    def get_master_password(self, env_name, database_name):
-#        """
-#        Get the Master Password for instance stored in the S3 bucket
-#        """
-#        bucket_name = self.vpc.get_credential_buckets_from_env_name(self.config_aws, self.vpc_name)[0]
-#        bucket = DiscoS3Bucket(bucket_name)
-#
-#        # for backwards compatibility check the old style keys containing the env name
-#        instance_identifier = self._get_instance_identifier(env_name, database_name)
-#        s3_password_old_key = 'rds/{0}/master_user_password'.format(instance_identifier)
-#        if bucket.key_exists(s3_password_old_key):
-#            return bucket.get_key(s3_password_old_key)
-#
-#        s3_password_new_key = 'rds/{0}/master_user_password'.format(database_name)
-#        return bucket.get_key(s3_password_new_key)
-#
-#    def get_instance_parameters(self, env_name, database_name):
-#        """Read the config file and extract the Instance related parameters"""
-#        section = instance_identifier = self._get_instance_identifier(env_name, database_name)
-#        db_engine = self.config_rds.get(section, 'engine')
-#        engine_family = db_engine.split('-')[0]
-#        default_license = DEFAULT_LICENSE.get(engine_family)
-#        default_port = DEFAULT_PORT.get(engine_family)
-#
-#        instance_params = {
-#            'AllocatedStorage': self.config_integer(section, 'allocated_storage'),
-#            'AutoMinorVersionUpgrade': self.config_truthy(section, 'auto_minor_version_upgrade'),
-#            'CharacterSetName': self.config_with_default(section, 'character_set_name'),
-#            'DBInstanceClass': self.config_rds.get(section, 'db_instance_class'),
-#            'DBInstanceIdentifier': instance_identifier,
-#            'DBParameterGroupName': section,
-#            'DBSubnetGroupName': section,
-#            'Engine': db_engine,
-#            'EngineVersion': self.config_rds.get(section, 'engine_version'),
-#            'Iops': self.config_integer(section, 'iops', 0),
-#            'LicenseModel': self.config_with_default(section, 'license_model', default_license),
-#            'MasterUserPassword': self.get_master_password(env_name, database_name),
-#            'MasterUsername': self.config_rds.get(section, 'master_username'),
-#            'MultiAZ': self.config_truthy(section, 'multi_az'),
-#            'Port': self.config_integer(section, 'port', default_port),
-#            'PubliclyAccessible': self.config_truthy(section, 'publicly_accessible', 'False'),
-#            'VpcSecurityGroupIds': [self.get_rds_security_group_id()],
-#            'StorageEncrypted': self.config_truthy(section, 'storage_encrypted')}
-#
-#        return instance_params
-
     def get_rds_security_group_id(self):
         """
         Returns the intranet security group id for the VPC for the current environment
@@ -524,73 +466,11 @@ class DiscoRDS(object):
 
     def update_cluster_by_id(self, database_identifier):
         """Update a RDS cluster by its database identifier"""
-        self.update_cluster(RDS.get_database_name(self.vpc_name, database_identifier))
-
-#    def update_cluster(self, database_name):
-#        """
-#        Run the RDS Cluster update
-#        """
-#        instance_identifier = self._get_instance_identifier(self.vpc_name, database_name)
-#        instance_params = self.get_instance_parameters(self.vpc_name, database_name)
-#
-#        if self._get_db_instance(instance_identifier):
-#            self.modify_db_instance(instance_params)
-#        else:
-#            self.recreate_db_subnet_group(instance_params["DBSubnetGroupName"])
-#            # Process the Engine-specific Parameters for the Instance
-#            group_name = instance_params["DBParameterGroupName"]
-#            group_family = self.get_db_parameter_group_family(
-#                instance_params["Engine"], instance_params["EngineVersion"])
-#            logging.debug("creating parameter group %s with family %s", group_name, group_family)
-#            self.recreate_db_parameter_group(self.vpc_name, database_name, group_name, group_family)
-#            self.create_db_instance(instance_params)
-#
-#        # Create/Update CloudWatch Alarms for this instance
-#        self.spinup_alarms(database_name)
-#
-#        # Create a DNS record for this instance
-#        self.setup_dns(instance_identifier)
-#
-    def _get_instance_address(self, instance_identifier):
-        """
-        Obtains the instance end point for the given RDS instance
-        """
-        instance_info = self.client.describe_db_instances(DBInstanceIdentifier=instance_identifier)
-        return instance_info['DBInstances'][0]['Endpoint']['Address']
-
-#    def setup_dns(self, instance_identifier):
-#        """
-#        Setup Domain Name Lookup using Route 53
-#        """
-#        start_time = time.time()
-#        instance_endpoint = keep_trying(RDS_STARTUP_TIMEOUT, self._get_instance_address, instance_identifier)
-#        logging.info("Waited %s seconds for RDS to get an address", time.time() - start_time)
-#        disco_route53 = DiscoRoute53()
-#        instance_record_name = '{0}.{1}.'.format(instance_identifier, self.domain_name)
-#
-#        # Delete and recreate DNS record for this Instance
-#        disco_route53.delete_record(self.domain_name, instance_record_name, 'CNAME')
-#        disco_route53.create_record(self.domain_name, instance_record_name, 'CNAME', instance_endpoint)
-#
-#    def spinup_alarms(self, database_name):
-#        """
-#        Configure alarms for this RDS instance. The alarms are configured in disco_alarms.ini
-#        """
-#        logging.debug("Configuring Cloudwatch alarms ")
-#        DiscoAlarm(self.vpc_name).create_alarms(database_name)
-
-    def update_all_clusters_in_vpc(self):
-        """
-        Updates every RDS instance in the current VPC to match the configuration
-        """
-        vpc_prefix = self.vpc_name + '-'
-        sections = [section for section in self.config_rds.sections()
-                    if section.startswith(vpc_prefix)]
-        logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
-        for section in sections:
-            # the section names are database identifiers
-            database_identifier = section
-            self.update_cluster(RDS.get_database_name(self.vpc_name, database_identifier))
+        rds_security_group_id = self.get_rds_security_group_id()
+        subnet_ids = self.get_subnet_ids()
+        rds = RDS(self.vpc_name, database_identifier,
+                  rds_security_group_id, subnet_ids, self.domain_name)
+        rds.update_cluster()
 
     def get_subnet_ids(self):
         """ Get a list of subnet ids for the vpc"""
@@ -602,7 +482,7 @@ class DiscoRDS(object):
                 subnet_ids.append(str(subnet['SubnetId']))
         return subnet_ids
 
-    def update_all_clusters_in_vpc_parallel(self):
+    def update_all_clusters_in_vpc(self, parallel=True):
         """
         Updates every RDS instance in the current VPC to match the configuration
         """
@@ -611,7 +491,7 @@ class DiscoRDS(object):
                     if section.startswith(vpc_prefix)]
         logging.debug("The following RDS clusters will be updated: %s", ", ".join(sections))
         rds_security_group_id = self.get_rds_security_group_id()
-        subnets_ids = self.get_subnet_ids()
+        subnet_ids = self.get_subnet_ids()
         rds_list = []
 
         for section in sections:
@@ -620,41 +500,24 @@ class DiscoRDS(object):
             rds = RDS(self.vpc_name,
                       database_identifier,
                       rds_security_group_id,
-                      subnets_ids,
+                      subnet_ids,
                       self.domain_name)
             rds_list.append(rds)
 
+        # For Sequential execution
+        if not parallel:
+            for rds in rds_list:
+                rds.update_cluster()
+            return
+
+        # Running in parallel
         for rds in rds_list:
             rds.start()
 
+        # Wait for all threads to finish
         for rds in rds_list:
             rds.join()
 
-#    def recreate_db_subnet_group(self, db_subnet_group_name):
-#        """
-#        Creates the DB Subnet Group. If it exists already, drops it and recreates it.
-#        DB subnet groups must contain at least one subnet in at least two AZs in the region.
-#
-#        @db_subnet_group_name: String. The name for the DB subnet group.
-#                               This value is stored as a lowercase string.
-#        """
-#        try:
-#            self.client.delete_db_subnet_group(DBSubnetGroupName=db_subnet_group_name)
-#        except Exception as err:
-#            logging.debug("Not deleting subnet group '%s': %s", db_subnet_group_name, repr(err))
-#
-#        db_subnet_group_description = 'Subnet Group for VPC {0}'.format(self.vpc_name)
-#        subnets = self.vpc.get_all_subnets()
-#        subnet_ids = []
-#        for subnet in subnets:
-#            tags = tag2dict(subnet['Tags'])
-#            if tags['meta_network'] == 'intranet':
-#                subnet_ids.append(str(subnet['SubnetId']))
-#
-#        self.client.create_db_subnet_group(DBSubnetGroupName=db_subnet_group_name,
-#                                           DBSubnetGroupDescription=db_subnet_group_description,
-#                                           SubnetIds=subnet_ids)
-#
     def get_final_snapshot(self, db_instance_identifier):
         """
         Returns the information on the Final DB Snapshot. This can be used to restore a deleted DB instance
@@ -667,54 +530,6 @@ class DiscoRDS(object):
         except botocore.exceptions.ClientError:
             return None
 
-#    def delete_keys(self, dictionary, keys):
-#        """Returns a copy of the given dict, with the given keys deleted"""
-#        copy = dictionary.copy()
-#        for key in keys:
-#            del copy[key]
-#        return copy
-#
-#    def create_db_instance(self, instance_params, custom_snapshot=None):
-#        """Creates the Relational database instance
-#        If a snapshot is provided then we restore that snapshot
-#        If a final snapshot exists for the given DB Instance ID, We restore from the final snapshot
-#        If one doesn't exist, we create a new DB Instance
-#        """
-#        instance_identifier = instance_params['DBInstanceIdentifier']
-#        snapshot = custom_snapshot or self.get_final_snapshot(instance_identifier)
-#
-#        if not snapshot:
-#            # For Postgres, We dont need this parameter at creation
-#            if instance_params['Engine'] == 'postgres':
-#                instance_params = self.delete_keys(instance_params, ["CharacterSetName"])
-#
-#            logging.info("Creating new RDS cluster %s", instance_identifier)
-#            self.client.create_db_instance(**instance_params)
-#        else:
-#            logging.info("Restoring RDS cluster from snapshot: %s", snapshot["DBSnapshotIdentifier"])
-#            params = self.delete_keys(instance_params, [
-#                "AllocatedStorage", "CharacterSetName", "DBParameterGroupName", "StorageEncrypted",
-#                "EngineVersion", "MasterUsername", "MasterUserPassword", "VpcSecurityGroupIds"])
-#            params["DBSnapshotIdentifier"] = snapshot["DBSnapshotIdentifier"]
-#            self.client.restore_db_instance_from_db_snapshot(**params)
-#            keep_trying(RDS_RESTORE_TIMEOUT, self.modify_db_instance, instance_params)
-#
-#    def modify_db_instance(self, instance_params, apply_immediately=True):
-#        """
-#        Modify settings for a DB instance. You can change one or more database configuration parameters
-#        by specifying these parameters and the new values in the request.
-#        """
-#        logging.info("Updating RDS cluster %s", instance_params["DBInstanceIdentifier"])
-#        params = self.delete_keys(instance_params, [
-#            "Engine", "LicenseModel", "DBSubnetGroupName", "PubliclyAccessible",
-#            "MasterUsername", "Port", "CharacterSetName", "StorageEncrypted"])
-#        self.client.modify_db_instance(ApplyImmediately=apply_immediately, **params)
-#        logging.info("Rebooting cluster to apply Param group %s", instance_params["DBInstanceIdentifier"])
-#        keep_trying(RDS_STATE_POLL_INTERVAL,
-#                    self.client.reboot_db_instance,
-#                    DBInstanceIdentifier=instance_params["DBInstanceIdentifier"],
-#                    ForceFailover=False)
-#
     def get_db_instances(self, status=None):
         """
         Get all RDS clusters/instances in the current VPC.
@@ -807,98 +622,6 @@ class DiscoRDS(object):
         if wait:
             self._wait_for_db_instance_deletions()
 
-#    def create_db_parameter_group(self, db_parameter_group_name, db_parameter_group_family):
-#        """
-#        Creates a new DB parameter group. Used to set customized parameters.
-#
-#        A DB parameter group is initially created with the default parameters for the
-#        database engine used by the DB instance.
-#        To provide custom values for any of the parameters, you must modify the group after creating it.
-#        """
-#        self.client.create_db_parameter_group(
-#            DBParameterGroupName=db_parameter_group_name,
-#            DBParameterGroupFamily=db_parameter_group_family,
-#            Description='Custom params-{0}'.format(db_parameter_group_name))
-#
-#    def modify_db_parameter_group(self, db_parameter_group_name, parameters):
-#        """
-#        Modifies the parameters of a DB parameter group.
-#
-#        Submit a list of the following:
-#        ('ParameterName', 'ParameterValue', 'Description', 'Source',
-#         'ApplyType', 'DataType', 'AllowedValues', 'IsModifiable',
-#         'MinimumEngineVersion', 'ApplyMethod')
-#        """
-#        for parameter in parameters:
-#            keep_trying(RDS_STATE_POLL_INTERVAL,
-#                        self.client.modify_db_parameter_group,
-#                        DBParameterGroupName=db_parameter_group_name,
-#                        Parameters=[{'ParameterName': parameter[0],
-#                                     'ParameterValue': parameter[1],
-#                                     'Description': 'Description',
-#                                     'Source': 'engine-default',
-#                                     'ApplyType': 'static',
-#                                     'DataType': 'string',
-#                                     'AllowedValues': 'somevalues',
-#                                     'IsModifiable': True,
-#                                     'MinimumEngineVersion': 'someversion',
-#                                     'ApplyMethod': 'pending-reboot'}])
-#
-#    def recreate_db_parameter_group(self, env_name, database_name, db_parameter_group_name,
-#                                    db_parameter_group_family):
-#        """
-#        Check if there are any custom parameters for this instance
-#        Custom Parameters are set in ./rds/engine_specific/{instance_identifier}.ini
-#        If this file doesn't exist, we'll use default RDS parameters
-#        Args:
-#            env_name (str): The environment name to use when reading the config file.
-#                            This is only used in the section name of the config file.
-#                            The parameter group is always created for the current environment
-#            database_name (str): The database name such as 'txdb'
-#            db_parameter_group_name (str): Usually the same as the database identifier such as 'ci-txdb'
-#            db_parameter_group_family (str): Parameter group family such as 'oracle-se2-12.1'
-#        """
-#        try:
-#            self.client.delete_db_parameter_group(DBParameterGroupName=db_parameter_group_name)
-#        except Exception as err:
-#            logging.debug("Not deleting DB parameter group '%s': %s", db_parameter_group_name, repr(err))
-#
-#        # DB Parameter Group Name must be created first, using RDS defaults
-#        self.create_db_parameter_group(db_parameter_group_name, db_parameter_group_family)
-#
-#        # Extract the Custom Values from the config file
-#        custom_param_file = os.path.join(ASIAQ_CONFIG,
-#                                         'rds', 'engine_specific',
-#                                         '{0}.ini'.format(database_name))
-#
-#        if os.path.isfile(custom_param_file):
-#            custom_config = ConfigParser()
-#            custom_config.read(custom_param_file)
-#            try:
-#                custom_db_params = custom_config.items(env_name)
-#                logging.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
-#                             db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
-#                self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
-#            except NoSectionError:
-#                logging.info("Using Default RDS param")
-#
-#    def get_db_parameter_group_family(self, engine, engine_version):
-#        """
-#        Extract the DB Parameter Group Family from Engine and Engine Version
-#
-#        Valid parameter group families are set based on the engine name (in lower case, if
-#        applicable) and the major and minor versions of the DB (patchlevel and further
-#        subdivisions of release version are ignored).
-#        The rules here are heuristic, and may need to be tweaked.
-#
-#        Rules:
-#          * oracle/sqlserver (engines that contain dashes): {engine}-{major}.{minor}
-#          * others (no dashes): {engine}{major}.{minor}
-#        """
-#        engine_version_list = engine_version.split('.', 2)
-#        format_string = "{0}-{1}.{2}" if "-" in engine else "{0}{1}.{2}"
-#        return format_string.format(engine.lower(), engine_version_list[0], engine_version_list[1])
-#
     def cleanup_snapshots(self, days):
         """
         Cleanup all manual snapshots older than --age specified, by default its 30 days
@@ -915,13 +638,6 @@ class DiscoRDS(object):
                 logging.info("Deleting Snapshot %s since its older than %d", snapshot_id, days)
                 self.client.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
 
-#    def _get_instance_identifier(self, env_name, database_name):
-#        return env_name + '-' + database_name
-#
-#    def _get_database_name(self, env_name, instance_identifier):
-#        identifier_prefix = len(env_name + '-')
-#        return instance_identifier[identifier_prefix:]
-#
     def _get_db_instance(self, instance_identifier):
         try:
             return self.client.describe_db_instances(DBInstanceIdentifier=instance_identifier)
@@ -946,10 +662,10 @@ class DiscoRDS(object):
             )
 
         rds_security_group_id = self.get_rds_security_group_id()
-        subnets_ids = self.get_subnet_ids()
+        subnet_ids = self.get_subnet_ids()
         rds = RDS(self.vpc_name,
                   clone_db_identifier,
                   rds_security_group_id,
-                  subnets_ids, self.domain_name)
+                  subnet_ids, self.domain_name)
 
         rds.clone(source_vpc, source_db)

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -341,7 +341,7 @@ class DiscoVPC(object):
         self.disco_vpc_endpoints.update()
         self.configure_notifications()
         self.disco_vpc_peerings.update_peering_connections()
-        self.rds.update_all_clusters_in_vpc_parallel()
+        self.rds.update_all_clusters_in_vpc(parallel=True)
 
     def configure_notifications(self, dry_run=False):
         """

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -341,7 +341,7 @@ class DiscoVPC(object):
         self.disco_vpc_endpoints.update()
         self.configure_notifications()
         self.disco_vpc_peerings.update_peering_connections()
-        self.rds.update_all_clusters_in_vpc()
+        self.rds.update_all_clusters_in_vpc_parallel()
 
     def configure_notifications(self, dry_run=False):
         """

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.142"
+__version__ = "1.0.143"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.143"
+__version__ = "1.0.144"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -105,6 +105,7 @@ class DiscoVPCTests(unittest.TestCase):
         self.assertItemsEqual(actual_ip_ranges, expected_ip_ranges)
 
     # pylint: disable=unused-argument
+    @patch('disco_aws_automation.disco_vpc.DiscoRDS')
     @patch('disco_aws_automation.disco_vpc.DiscoVPCEndpoints')
     @patch('disco_aws_automation.disco_vpc.DiscoSNS')
     @patch('disco_aws_automation.disco_vpc.DiscoVPCGateways')
@@ -115,7 +116,7 @@ class DiscoVPCTests(unittest.TestCase):
     @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork')
     def test_create_auto_vpc(self, meta_network_mock, boto3_resource_mock,
                              boto3_client_mock, config_mock,
-                             sleep_mock, gateways_mock, sns_mock, endpoints_mock):
+                             sleep_mock, gateways_mock, sns_mock, endpoints_mock, rds_mock):
         """Test creating a VPC with a dynamic ip range"""
         # FIXME This needs to mock way too many things. DiscoVPC needs to be refactored
 

--- a/test/unit/test_disco_vpc_sg_rules.py
+++ b/test/unit/test_disco_vpc_sg_rules.py
@@ -11,6 +11,7 @@ from test.helpers.patch_disco_aws import TEST_ENV_NAME, get_mock_config
 
 
 # pylint: disable=unused-argument
+@patch('disco_aws_automation.disco_vpc.DiscoRDS.update_all_clusters_in_vpc')
 @patch('disco_aws_automation.disco_vpc.DiscoVPCEndpoints')
 @patch('disco_aws_automation.disco_vpc.DiscoSNS')
 @patch('disco_aws_automation.disco_vpc.DiscoVPCGateways')
@@ -21,7 +22,7 @@ from test.helpers.patch_disco_aws import TEST_ENV_NAME, get_mock_config
 @patch('disco_aws_automation.disco_vpc.DiscoVPC.get_random_free_subnet')
 def _get_vpc_mock(random_subnet_mock=None, meta_network_mock=None, boto3_resource_mock=None,
                   boto3_client_mock=None, config_mock=None,
-                  gateways_mock=None, sns_mock=None, endpoints_mock=None):
+                  gateways_mock=None, sns_mock=None, endpoints_mock=None, rds_mock=None):
 
     config_mock.return_value = get_mock_config({
         'envtype:auto-vpc-type': {


### PR DESCRIPTION
This PR enables Parallel execution of RDS instances. The following changes have been made
- Use of python Threading library.
- A new class derived from Threading, that encapsulates the creation/update of a single RDS instance.
- Option to enable or disable parallel execution.
- Add `--parallel` option to `disco_rds.py update`.