### PR TITLE
Made acfg1 take hostclass as a command-line option.

### DIFF
--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -55,7 +55,6 @@ def _copy_files(source, destination, hostclasses, dryrun=False):
     # TODO Break this into smaller functions
     # pylint: disable=R0914
 
-
     for path, dirnames, filenames in os.walk(source):
         destpath = os.path.join(destination, os.path.relpath(path, source))
 
@@ -89,7 +88,7 @@ def _copy_files(source, destination, hostclasses, dryrun=False):
 
         # Add the host specific files first
         for destname, srcname in src_for_file.items():
-            src = os.path.join(path, filename)
+            src = os.path.join(path, srcname)
             dst = os.path.join(destpath, destname)
             sources.add(src)
             destinations.add(dst)

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -74,16 +74,16 @@ def _copy_files(source, destination, hostclasses, dryrun=False):
 
         src_for_file = {}
         for filename in filenames:
-            (realfile, _, hostclass) = filename.partition("~")
+            (realname, _, hostclass) = filename.partition("~")
             if hostclass and hostclass not in hostclasses:
                 # this file is not relevant
                 continue
-            if realfile not in src_for_file:
-                src_for_file[realfile] = filename
+            if realname not in src_for_file:
+                src_for_file[realname] = filename
             else:
-                (_, _, previous_hostclass) = src_for_file[realfile].partition("~")
+                (_, _, previous_hostclass) = src_for_file[realname].partition("~")
                 if _higher_priority(hostclass, previous_hostclass, hostclasses):
-                    src_for_file[realfile] = filename
+                    src_for_file[realname] = filename
 
         # Add the host specific files first
         for destname, srcname in src_for_file.items():

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -207,9 +207,11 @@ def get_or_create_ids(username, groupname):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="""
     Tool for copying trees of files. Files that contain '~' are only copied if
-    string after ~ matches hostclass. The files will also be renamed,
-    stripping ~ and hostclass string after it. Permissions and file ownership
-    are applied from /metadata.txt at the root of the tree.
+    the string after ~ matches the hostclass (taken from command line options,
+    or from /opt/wgen/etc/hostclass if no option is supplied). The files will
+    also be renamed, stripping the "~somehostclass" suffix if present.
+    Permissions and file ownership are applied from the acfg.metadata file at
+    the root of the source tree.
     """)
     parser.add_argument("source", help="Source location overlay directory")
     parser.add_argument("destination", help="Destination of where to overlay source directory over")

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -74,6 +74,8 @@ def _copy_files(source, destination, hostclasses, dryrun=False):
 
         src_for_file = {}
         for filename in filenames:
+            if filename == METADATA_FILE_NAME:
+                continue
             (realname, _, hostclass) = filename.partition("~")
             if hostclass and hostclass not in hostclasses:
                 # this file is not relevant

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -17,7 +17,7 @@ HOSTCLASS_FILE_PATH = "/opt/wgen/etc/hostclass"
 METADATA_FILE_NAME = "acfg.metadata"
 
 
-def copy_tree(source, destination, dryrun=False):
+def copy_tree(source, destination, hostclasses=[], dryrun=False):
     """Copies a file tree rooted at source to destination.
     Files that contain '~' are only copied if string after ~ matches hostclass and files
     not containing '~' are only copied if a hostclass specific version does not exist.
@@ -27,24 +27,34 @@ def copy_tree(source, destination, dryrun=False):
     and hostclass string after it. Permissions and file ownership are applied from
     source/METADATA_FILE_NAME, if it exists.
 
+    For special cases (e.g. operating-system specific phase1 files), hostclasses may instead
+    be passed as a list in the `hostclassses` argument.  If this argument is present, the content
+    of the hostclass file is ignored, and the passed-in list is used as a priority-ordered list of
+    virtual hostclasses to find the files for (so if the list is ['centos6_phase1', 'mhcgeneric'],
+    files and permissions marked with either of those hostclasses will be included, but in case of
+    conflict, 'centos6_phase1' will trump 'mhcgeneric').
+
     :param source:  the source tree root
     :param destination:  The destination tree root
+    :param hostclasses:  A priority-ordered list of hostclasses to use instead the one in HOSTCLASS_FILE_PATH
     :param dryrun:  If this is true copy_tree() will log as normal but not actually copy anything.
     :raise HostclassFileNotFound: if no hostclass file was found
     """
-    if os.path.exists(HOSTCLASS_FILE_PATH):
-        with open(HOSTCLASS_FILE_PATH) as hostclass_file:
-            hostclass = hostclass_file.readline().strip()
-            _copy_files(source, destination, hostclass, dryrun)
-            _apply_metadata(source, hostclass, dryrun)
-    else:
-        raise HostclassFileNotFound()
+    if not hostclasses:
+        if os.path.exists(HOSTCLASS_FILE_PATH):
+            with open(HOSTCLASS_FILE_PATH) as hostclass_file:
+                hostclasses = [hostclass_file.readline().strip()]
+        else:
+            raise HostclassFileNotFound()
+
+    _copy_files(source, destination, hostclasses, dryrun)
+    _apply_metadata(source, hostclasses, dryrun)
 
 
-def _copy_files(source, destination, hostclass, dryrun=False):
+def _copy_files(source, destination, hostclasses, dryrun=False):
     # TODO Break this into smaller functions
     # pylint: disable=R0914
-    magicsuffix = "~{0}".format(hostclass)
+
 
     for path, dirnames, filenames in os.walk(source):
         destpath = os.path.join(destination, os.path.relpath(path, source))
@@ -62,22 +72,26 @@ def _copy_files(source, destination, hostclass, dryrun=False):
         destinations = set()
         files = []
 
-        # Add the host specific files first
-        for filename in [f for f in filenames if f.endswith(magicsuffix)]:
-            src = os.path.join(path, filename)
-            dst = os.path.join(destpath, filename[0:-len(magicsuffix)])
-            sources |= set([src])
-            destinations |= set([dst])
-            files += [(src, dst)]
+        src_for_file = {}
+        for filename in filenames:
+            (realfile, _, hostclass) = filename.partition("~")
+            if hostclass and hostclass not in hostclasses:
+                # this file is not relevant
+                continue
+            if realfile not in src_for_file:
+                src_for_file[realfile] = filename
+            else:
+                (_, _, previous_hostclass) = src_for_file[realfile].partition("~")
+                if _higher_priority(hostclass, previous_hostclass, hostclasses):
+                    src_for_file[realfile] = filename
 
-        # Add generic files if they don't overwrite host specific files
-        for filename in [f for f in filenames if "~" not in f]:
+        # Add the host specific files first
+        for destname, srcname in src_for_file.items():
             src = os.path.join(path, filename)
-            dst = os.path.join(destpath, filename)
-            if dst not in destinations:
-                sources |= set([src])
-                destinations |= set([dst])
-                files += [(src, dst)]
+            dst = os.path.join(destpath, destname)
+            sources.add(src)
+            destinations.add(dst)
+            files += [(src, dst)]
 
         # Tell user what is being skipped
         for filename in filenames:
@@ -92,7 +106,7 @@ def _copy_files(source, destination, hostclass, dryrun=False):
                 shutil.copy(spath, dpath)
 
 
-def _apply_metadata(source, hostclass, dryrun=False):
+def _apply_metadata(source, hostclasses, dryrun=False):
     # Pylint thinks this function has too many local variables
     # pylint: disable=R0914
     metadata_file_path = os.path.join(source, METADATA_FILE_NAME)
@@ -100,30 +114,38 @@ def _apply_metadata(source, hostclass, dryrun=False):
         logging.warning("Metadata file not found: %s, no permissions to apply.", metadata_file_path)
         return
 
-    magicsuffix = "~{0}".format(hostclass)
-
+    hostclass_for_path = {}
     with open(metadata_file_path, 'r') as metadata_file:
         for line in metadata_file.readlines():
             file_metadata = line.partition('#')[0].strip()  # ignore comments and blank lines
             if not file_metadata:
                 continue
             try:
-                filename, permissions, owner, group = file_metadata.split()
+                file_entry, permissions, owner, group = file_metadata.split()
             except Exception:
                 raise ValueError("Not enough values to unpack on line: {0}".format(file_metadata))
 
-            if "~" in filename:
-                if filename.endswith(magicsuffix):
-                    filename = filename[0:-len(magicsuffix)]
-                else:
-                    logging.info("skipping permissions: %s", filename)
-                    continue
+            (filename, _, hostclass) = file_entry.partition("~")
+
+            if hostclass and hostclass not in hostclasses:
+                logging.info("skipping permissions: %s", file_entry)
+                continue
 
             if not os.path.exists(filename):
                 logging.warning("skipping permissions (file not found): %s", filename)
                 continue
 
-            logging.info("setting ownership of %s to %s:%s", filename, owner, group)
+            if filename not in hostclass_for_path:
+                hostclass_for_path[filename] = hostclass
+                logging.info("setting ownership of %s to %s:%s", filename, owner, group)
+            else:
+                if _higher_priority(hostclass, hostclass_for_path[filename], hostclasses):
+                    hostclass_for_path[filename] = hostclass
+                    logging.info("OVERRIDING ownership of %s to %s:%s", filename, owner, group)
+                else:
+                    logging.info("Skipping permissions from hostclass %s on %s", hostclass, filename)
+                    continue
+
             if not dryrun:
                 uid, gid = get_or_create_ids(owner, group)
                 os.chown(filename, uid, gid)
@@ -131,6 +153,16 @@ def _apply_metadata(source, hostclass, dryrun=False):
             logging.info("setting permissions of %s to %s", filename, permissions)
             if not dryrun:
                 os.chmod(filename, int(permissions, 8))
+
+
+def _higher_priority(new_hostclass, old_hostclass, all_hostclasses):
+    if new_hostclass:
+        if old_hostclass:
+            return all_hostclasses.index(new_hostclass) < all_hostclasses.index(old_hostclass)
+        else:
+            return True
+    else:
+        return False
 
 
 class HostclassFileNotFound(EnvironmentError):
@@ -178,9 +210,11 @@ if __name__ == "__main__":
     parser.add_argument("source", help="Source location overlay directory")
     parser.add_argument("destination", help="Destination of where to overlay source directory over")
     parser.add_argument('--dry', action='store_const', const=True, default=False, help='Dry run only')
+    parser.add_argument('--hostclass', action='append', dest='hostclasses', metavar='HOSTCLASS',
+                        help='A hostclass (possibly virtual) for which to select files. (Repeatable.)')
 
     logger = logging.getLogger('')
     logger.setLevel(logging.INFO)
 
     args = parser.parse_args()
-    copy_tree(args.source, args.destination, args.dry)
+    copy_tree(args.source, args.destination, args.hostclasses, args.dry)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.144"
+__version__ = "1.0.145"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Modified acfg1.py to support passing in multiple hostclasses as command-line options, instead of handling only one and requiring it to be in a specific file.

This would allow us to specify files to be included in a specific OS-version bake, which has at times seemed desirable.