### PR TITLE
Fix call to adduser in acfg1.py to work in centos5

### DIFF
--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -160,7 +160,7 @@ def get_or_create_ids(username, groupname):
     except KeyError:
         logging.info("Creating user %s", username)
         subprocess.call(['/usr/sbin/adduser',
-                         '--system',
+                         '-r',
                          '--gid', str(gid),
                          '--shell', '/sbin/nologin',
                          username])

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.143"
+__version__ = "1.0.144"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.145"
+__version__ = "1.0.146"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The version of adduser in Centos 5 does not support the --system option, however it supports -r which does the same thing.  acfg1.py calls adduser with --system, causing it to break when baking mhcpreamp.  This change should allow acfg1.py to work on Centos 5 without any change in behavior in other versions.