### PR TITLE
Fix timed autoscaling for disco_deploy.py

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -262,9 +262,9 @@ class DiscoAWS(object):
             for subnet_ip in subnet_ips.split(' '):
                 meta_network.get_interface(subnet_ip)
 
-    def create_scaling_schedule(self, hostclass, min_size, desired_size, max_size):
+    def create_scaling_schedule(self, min_size, desired_size, max_size, hostclass=None, group_name=None):
         """Create autoscaling schedule"""
-        self.autoscale.delete_all_recurring_group_actions(hostclass=hostclass)
+        self.autoscale.delete_all_recurring_group_actions(hostclass=hostclass, group_name=group_name)
         maps = [
             size_as_recurrence_map(min_size, sentinel=None),
             size_as_recurrence_map(desired_size, sentinel=None),
@@ -275,7 +275,7 @@ class DiscoAWS(object):
                         for time in times if time is not None}
         for recurrence, sizes in combined_map.items():
             self.autoscale.create_recurring_group_action(
-                str(recurrence), hostclass=hostclass,
+                str(recurrence), hostclass=hostclass, group_name=group_name,
                 min_size=sizes[0], desired_capacity=sizes[1], max_size=sizes[2])
 
     def _default_protocol_for_port(self, port):
@@ -422,7 +422,7 @@ class DiscoAWS(object):
             group_name=group_name
         )
 
-        self.create_scaling_schedule(hostclass, min_size, desired_size, max_size)
+        self.create_scaling_schedule(min_size, desired_size, max_size, group_name=group.name)
 
         # Create alarms and custom metrics for the hostclass, if is not being used for testing
         if not testing:

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -83,7 +83,7 @@ def size_as_recurrence_map(size, sentinel=''):
              - size = timed interval(s), like "2@0 22 * * *:24@0 10 * * *", will return: {'0 10 * * *': 24,
                                                                                           '0 22 * * *': 2}
     """
-    if not size:
+    if not size and size != 0:
         return {sentinel: None}
     else:
         return {sentinel: int(size)} if str(size).isdigit() else {

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -59,17 +59,7 @@ class DiscoDeploy(object):
 
     def _get_hostclasses_from_pipeline_definition(self, pipeline_definition):
         ''' Return hostclasses from pipeline definitions, validating numeric input '''
-        hostclasses = {entry["hostclass"]: entry for entry in pipeline_definition}
-
-        for entry in hostclasses.itervalues():
-            if "min_size" in entry:
-                entry["min_size"] = int(size_as_minimum_int_or_none(entry["min_size"]))
-            if "desired_size" in entry:
-                entry["desired_size"] = int(size_as_maximum_int_or_none(entry["desired_size"]))
-            if "max_size" in entry:
-                entry["max_size"] = int(size_as_maximum_int_or_none(entry["max_size"]))
-
-        return hostclasses
+        return {entry["hostclass"]: entry for entry in pipeline_definition}
 
     def _filter_amis(self, amis):
         if self._restrict_amis:
@@ -235,7 +225,7 @@ class DiscoDeploy(object):
         except:
             logging.exception("promotion failed")
 
-    def handle_nodeploy_ami(self, old_hostclass_dict, ami, desired_size, dry_run):
+    def handle_nodeploy_ami(self, ami, pipeline_dict=None, dry_run=False, old_group=None):
         '''Promotes a non-deployable host and updates the autoscaling group to use it next time
 
         A host is launched in testing mode and if it passes smoketests it is promoted and
@@ -245,48 +235,46 @@ class DiscoDeploy(object):
         are not replaced by the new AMI.
 
         '''
-        if not old_hostclass_dict:
-            old_hostclass_dict = {"hostclass": DiscoBake.ami_hostclass(ami)}
+        hostclass = DiscoBake.ami_hostclass(ami)
+
+        if not pipeline_dict:
+            pipeline_dict = {"hostclass": hostclass}
 
         logging.info("Smoke testing non-deploy Hostclass %s AMI %s with %s deployment strategy",
-                     old_hostclass_dict["hostclass"], ami.id, DEPLOYMENT_STRATEGY_CLASSIC)
+                     hostclass, ami.id, DEPLOYMENT_STRATEGY_CLASSIC)
 
         if dry_run:
             return
 
-        new_size = desired_size * 2 if desired_size else 1
-        new_hostclass_dict = copy.deepcopy(old_hostclass_dict)
-        new_hostclass_dict["sequence"] = 1
-        new_hostclass_dict["max_size"] = new_size
-        new_hostclass_dict["min_size"] = new_size / 2
-        new_hostclass_dict["desired_size"] = new_size
-        new_hostclass_dict["smoke_test"] = "no"
-        new_hostclass_dict["ami"] = ami.id
-        rollback_hostclass_dict = copy.deepcopy(old_hostclass_dict)
+        new_hostclass_dict = self._generate_deploy_pipeline(
+            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC,
+            pipeline_dict=pipeline_dict,
+            old_group=old_group,
+            ami=ami
+        )
+
+        rollback_hostclass_dict = self._generate_final_pipeline(
+            pipeline_dict=pipeline_dict,
+            old_group=old_group,
+            ami=ami
+        )
+        rollback_hostclass_dict["smoke_test"] = "no"
 
         self._disco_aws.spinup([new_hostclass_dict], testing=True)
 
-        rollback_hostclass_dict["sequence"] = 1
-        rollback_hostclass_dict["smoke_test"] = "no"
-        rollback_hostclass_dict["max_size"] = old_hostclass_dict.get("max_size", desired_size)
-        rollback_hostclass_dict["min_size"] = old_hostclass_dict.get("min_size", desired_size)
-        rollback_hostclass_dict["desired_size"] = old_hostclass_dict.get("desired_size", desired_size)
-        rollback_hostclass_dict["desired_size"] = snap_to_range(
-            rollback_hostclass_dict["desired_size"],
-            rollback_hostclass_dict["min_size"], rollback_hostclass_dict["max_size"])
-
-        if self.wait_for_smoketests(ami.id, desired_size or 1):
+        if self.wait_for_smoketests(ami.id, new_hostclass_dict["desired_size"]):
             self._promote_ami(ami, "tested")
-            rollback_hostclass_dict["ami"] = ami.id
         else:
             self._promote_ami(ami, "failed")
             rollback_hostclass_dict.pop("ami", None)
 
-        if rollback_hostclass_dict["desired_size"]:
+        if old_group:
             self._disco_aws.terminate(self._get_new_instances(ami.id), use_autoscaling=True)
             self._disco_aws.spinup([rollback_hostclass_dict])
+            # Create scheduled actions on the ASG.
+            self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
         else:
-            self._disco_autoscale.delete_groups(hostclass=rollback_hostclass_dict["hostclass"], force=True)
+            self._disco_autoscale.delete_groups(hostclass=hostclass, force=True)
 
     def _get_old_instances(self, new_ami_id):
         '''Returns instances of the hostclass of new_ami_id that are not running new_ami_id'''
@@ -334,44 +322,54 @@ class DiscoDeploy(object):
             self._set_maintenance_mode(hostclass, self._get_old_instances(ami.id), False)
         return ret
 
-    def handle_tested_ami(self, old_hostclass_dict, ami, desired_size, run_tests=False, dry_run=False):
+    def handle_tested_ami(self, ami, pipeline_dict=None, run_tests=False, dry_run=False, old_group=None):
         '''
         Tests hostclasses which we can deploy normally.
 
         Deploys AMIs inside the same autoscaling group, and destroys old instances on successful passing,
         otherwise destroys the new instances and rolls back the ASG's configuration.
         '''
-        logging.info("testing deployable hostclass %s AMI %s with %s deployment strategy",
-                     old_hostclass_dict["hostclass"], ami.id, DEPLOYMENT_STRATEGY_CLASSIC)
+        hostclass = DiscoBake.ami_hostclass(ami)
+
+        logging.info(
+            "testing deployable hostclass %s AMI %s with %s deployment strategy",
+            hostclass,
+            ami.id,
+            DEPLOYMENT_STRATEGY_CLASSIC
+        )
 
         if dry_run:
             return
 
-        if desired_size and run_tests and not self.run_integration_tests(ami):
+        if not pipeline_dict:
+            pipeline_dict = {}
+
+        if old_group and run_tests and not self.run_integration_tests(ami):
             raise Exception("Failed pre-test -- not testing AMI {}".format(ami.id))
 
-        new_size = desired_size * 2 if desired_size else 1
-        new_hostclass_dict = copy.deepcopy(old_hostclass_dict)
-        new_hostclass_dict["sequence"] = 1
-        new_hostclass_dict["max_size"] = new_size
-        new_hostclass_dict["min_size"] = new_size / 2
-        new_hostclass_dict["desired_size"] = new_size
-        new_hostclass_dict["smoke_test"] = "no"
-        new_hostclass_dict["ami"] = ami.id
-        post_hostclass_dict = copy.deepcopy(new_hostclass_dict)
+        new_hostclass_dict = self._generate_deploy_pipeline(
+            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC,
+            pipeline_dict=pipeline_dict,
+            old_group=old_group,
+            ami=ami
+        )
+
+        post_hostclass_dict = self._generate_final_pipeline(
+            pipeline_dict=pipeline_dict,
+            old_group=old_group,
+            ami=ami
+        )
 
         self._disco_aws.spinup([new_hostclass_dict])
 
         try:
-            if (self.wait_for_smoketests(ami.id, desired_size or 1) and
+            if (self.wait_for_smoketests(ami.id, new_hostclass_dict["desired_size"]) and
                     (not run_tests or self.run_tests_with_maintenance_mode(ami))):
                 # Roll forward with new configuration
-                post_hostclass_dict["max_size"] = old_hostclass_dict.get("max_size") or desired_size
-                post_hostclass_dict["min_size"] = old_hostclass_dict.get("min_size") or desired_size
-                post_hostclass_dict["desired_size"] = snap_to_range(
-                    desired_size, post_hostclass_dict["min_size"], post_hostclass_dict["max_size"])
                 self._disco_aws.terminate(self._get_old_instances(ami.id), use_autoscaling=True)
                 self._disco_aws.spinup([post_hostclass_dict])
+                # Create scheduled actions on the ASG.
+                self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
                 self._promote_ami(ami, "tested")
                 return
             else:
@@ -380,12 +378,8 @@ class DiscoDeploy(object):
             logging.exception("Failed to run integration test")
 
         # Revert to old configuration
-        post_hostclass_dict = copy.deepcopy(old_hostclass_dict)
-        post_hostclass_dict["max_size"] = old_hostclass_dict.get("max_size") or desired_size
-        post_hostclass_dict["min_size"] = old_hostclass_dict.get("min_size") or desired_size
-        post_hostclass_dict["desired_size"] = snap_to_range(
-            desired_size, post_hostclass_dict["min_size"], post_hostclass_dict["max_size"])
         post_hostclass_dict["smoke_test"] = "no"
+        post_hostclass_dict.pop("ami", None)
 
         # Revert to the latest tested AMI if possible
         old_ami_id = self._get_latest_other_image_id(ami.id)
@@ -400,7 +394,7 @@ class DiscoDeploy(object):
     # This method handles blue/green from end to end, so it has a lot of logic in it. We should at some point
     # look at breaking it up a bit and/or the feasibility of that.
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-return-statements
-    def handle_blue_green_ami(self, pipeline_dict, ami, old_group,
+    def handle_blue_green_ami(self, ami, pipeline_dict=None, old_group=None,
                               deployable=False, run_tests=False, dry_run=False):
         '''
         Tests hostclasses which we can deploy normally
@@ -418,29 +412,19 @@ class DiscoDeploy(object):
         if dry_run:
             return True
 
+        # Default pipeline dict to being an empty dictionary so that it works with the generate pipeline
+        # functions as well as the scheduled actions functions
+        if not pipeline_dict:
+            pipeline_dict = {}
+
         uses_elb = is_truthy(self.hostclass_option_default(hostclass, "elb", "no"))
 
-        pipeline_dict = pipeline_dict or {}
-
-        new_group_config = copy.deepcopy(pipeline_dict)
-        new_group_config["sequence"] = 1
-        new_group_config["smoke_test"] = "no"
-        new_group_config["ami"] = ami.id
-
-        # If there is an already existing ASG, use its sizing. Otherwise, use the pipeline's sizing or a
-        # reasonable default.
-        if old_group:
-            desired_size = old_group.desired_capacity
-            max_size = old_group.max_size
-            min_size = old_group.min_size
-        else:
-            desired_size = pipeline_dict.get("desired_size", 1)
-            min_size = pipeline_dict.get("min_size", desired_size)
-            max_size = pipeline_dict.get("max_size", desired_size)
-
-        new_group_config["desired_size"] = desired_size
-        new_group_config["min_size"] = min_size
-        new_group_config["max_size"] = max_size
+        new_group_config = self._generate_deploy_pipeline(
+            deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+            pipeline_dict=pipeline_dict,
+            old_group=old_group,
+            ami=ami
+        )
 
         try:
             # Spinup our new autoscaling group in testing mode, making one even if one already exists.
@@ -498,6 +482,7 @@ class DiscoDeploy(object):
                     logging.info("Successfully left testing mode for group %s", new_group.name)
                     # Update ASG to exit testing mode and attach to the normal ELB if applicable.
                     self._disco_aws.spinup([new_group_config], group_name=new_group.name)
+
                     if uses_elb:
                         try:
                             # Wait until the new ASG is registered and marked as healthy by ELB.
@@ -511,6 +496,9 @@ class DiscoDeploy(object):
                                 # Destroy the testing ELB
                                 self._disco_elb.delete_elb(hostclass, testing=True)
                             return False
+
+                    # Create scheduled actions on the new ASG now that we will likely keep it.
+                    self._create_scaling_schedule(pipeline_dict, group_name=new_group.name)
 
                     # we can destroy the old group
                     if old_group:
@@ -558,6 +546,66 @@ class DiscoDeploy(object):
             # Destroy the testing ELB
             self._disco_elb.delete_elb(hostclass, testing=True)
         return False
+
+    def _create_scaling_schedule(self, pipeline_dict, group_name=None, hostclass=None):
+        """ Create scaling schedules from the pipeline dictionary """
+        desired_size = pipeline_dict.get("desired_size", 1)
+        min_size = pipeline_dict.get("min_size", size_as_minimum_int_or_none(desired_size))
+        max_size = pipeline_dict.get("max_size", 0) or size_as_maximum_int_or_none(desired_size)
+
+        self._disco_aws.create_scaling_schedule(
+            min_size,
+            desired_size,
+            max_size,
+            group_name=group_name,
+            hostclass=hostclass
+        )
+
+    def _generate_final_pipeline(self, pipeline_dict, old_group, ami):
+        """Generate pipeline with sizing for post deployment"""
+        new_config = copy.deepcopy(pipeline_dict)
+        new_config["sequence"] = 1
+        new_config["smoke_test"] = "no"
+        new_config["ami"] = ami.id
+
+        # If there is an already existing ASG, use its sizing. Otherwise, use the pipeline's sizing or a
+        # reasonable default.
+        if old_group:
+            desired_size = old_group.desired_capacity
+            max_size = old_group.max_size
+            min_size = old_group.min_size
+        else:
+            # The 'or 1' is because some people set their desired size to 0 in their pipeline.
+            desired_size = int(size_as_maximum_int_or_none(
+                pipeline_dict.get("desired_size", 1) or 1
+            ))
+            min_size = int(size_as_minimum_int_or_none(
+                pipeline_dict.get("min_size", 0)
+            ))
+            # The 'or' on max_size is here for the same reason. So if it's 0, just set it to desired_size so
+            # its a valid entry...
+            max_size = int(size_as_maximum_int_or_none(
+                pipeline_dict.get("max_size", desired_size) or desired_size
+            ))
+
+        new_config["desired_size"] = desired_size
+        new_config["min_size"] = min_size
+        new_config["max_size"] = max_size
+
+        return new_config
+
+    def _generate_deploy_pipeline(self, deployment_strategy, pipeline_dict, old_group, ami):
+        """Generate pipeline with sizing for deployment"""
+        new_config = self._generate_final_pipeline(pipeline_dict, old_group, ami)
+
+        # If we are using classic deployment and an older group exists, we need to double the sizing so that
+        # new instances are actually deployed. These numbers will be later shrunk.
+        if old_group and deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
+            new_config["desired_size"] *= 2
+            new_config["min_size"] = new_config["desired_size"] / 2
+            new_config["max_size"] = new_config["desired_size"]
+
+        return new_config
 
     def _set_maintenance_mode(self, hostclass, instances, mode_on):
         '''
@@ -641,7 +689,6 @@ class DiscoDeploy(object):
         hostclass = DiscoBake.ami_hostclass(ami)
         pipeline_hostclass_dict = self._hostclasses.get(hostclass)
         group = self._disco_autoscale.get_existing_group(hostclass)
-        desired_capacity = group.desired_capacity if group else 0
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 
@@ -658,46 +705,86 @@ class DiscoDeploy(object):
             # only expected to exist in the bakery_environment. This doesn't hold true for update, which
             # should just always deploy things unless explicitly told no.
             deployable = pipeline_hostclass_dict and deployable
-            return self.handle_blue_green_ami(pipeline_hostclass_dict, ami, group, deployable=deployable,
-                                              run_tests=testable, dry_run=dry_run)
+            return self.handle_blue_green_ami(
+                ami,
+                pipeline_dict=pipeline_hostclass_dict,
+                old_group=group,
+                deployable=deployable,
+                run_tests=testable,
+                dry_run=dry_run
+            )
         elif not deployable:
             self.handle_nodeploy_ami(
-                pipeline_hostclass_dict, ami, desired_capacity, dry_run=dry_run)
+                ami,
+                pipeline_dict=pipeline_hostclass_dict,
+                dry_run=dry_run,
+                old_group=group
+            )
         elif testable:
             self.handle_tested_ami(
-                pipeline_hostclass_dict, ami, desired_capacity, run_tests=True, dry_run=dry_run)
+                ami,
+                pipeline_dict=pipeline_hostclass_dict,
+                run_tests=True,
+                dry_run=dry_run,
+                old_group=group
+            )
         elif pipeline_hostclass_dict:
             self.handle_tested_ami(
-                pipeline_hostclass_dict, ami, desired_capacity, dry_run=dry_run)
+                ami,
+                pipeline_dict=pipeline_hostclass_dict,
+                dry_run=dry_run,
+                old_group=group
+            )
         else:
-            self.handle_nodeploy_ami(None, ami, 0, dry_run=dry_run)
+            self.handle_nodeploy_ami(
+                ami,
+                pipeline_dict=None,
+                dry_run=dry_run,
+                old_group=group)
 
     def update_ami(self, ami, dry_run, deployment_strategy=None):
         '''Handles updating a hostclass to the latest tested AMI'''
         logging.info("updating %s %s", ami.id, ami.name)
         hostclass = DiscoBake.ami_hostclass(ami)
-        old_hostclass_dict = self._hostclasses.get(hostclass)
-        if not old_hostclass_dict:
+        pipeline_dict = self._hostclasses.get(hostclass)
+        if not pipeline_dict:
             return
 
         group = self._disco_autoscale.get_existing_group(hostclass)
-        desired_capacity = group.desired_capacity if group else old_hostclass_dict.get("desired_size", 0)
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 
         if deployment_strategy:
             desired_deployment_strategy = deployment_strategy
         else:
-            desired_deployment_strategy = self.hostclass_option_default(hostclass, 'deployment_strategy',
-                                                                        DEPLOYMENT_STRATEGY_CLASSIC)
+            desired_deployment_strategy = self.hostclass_option_default(
+                hostclass, 'deployment_strategy',
+                DEPLOYMENT_STRATEGY_CLASSIC
+            )
 
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:
-            self.handle_blue_green_ami(old_hostclass_dict, ami, group, deployable=deployable,
-                                       run_tests=testable, dry_run=dry_run)
+            self.handle_blue_green_ami(
+                ami,
+                pipeline_dict=pipeline_dict,
+                old_group=group,
+                deployable=deployable,
+                run_tests=testable,
+                dry_run=dry_run
+            )
         elif not deployable:
-            self.handle_nodeploy_ami(old_hostclass_dict, ami, desired_capacity, dry_run=dry_run)
+            self.handle_nodeploy_ami(
+                ami,
+                pipeline_dict=pipeline_dict,
+                dry_run=dry_run,
+                old_group=group
+            )
         else:
-            self.handle_tested_ami(old_hostclass_dict, ami, desired_capacity, dry_run=dry_run)
+            self.handle_tested_ami(
+                ami,
+                pipeline_dict=pipeline_dict,
+                dry_run=dry_run,
+                old_group=group
+            )
 
     def test(self, dry_run=False, deployment_strategy=None):
         '''Tests a single untested AMI and marks it as tested or failed'''

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.146"
+__version__ = "1.0.147"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.144"
+__version__ = "1.0.145"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.145"
+__version__ = "1.0.146"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -46,12 +46,12 @@ class DiscoAWSTests(TestCase):
     def test_create_scaling_schedule_only_desired(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
-        aws.create_scaling_schedule("mhcboo", "1", "2@1 0 * * *:3@6 0 * * *", "5")
+        aws.create_scaling_schedule("1", "2@1 0 * * *:3@6 0 * * *", "5", hostclass="mhcboo")
         aws.autoscale.assert_has_calls([
-            call.delete_all_recurring_group_actions(hostclass='mhcboo'),
-            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo',
+            call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
+            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=None, desired_capacity=2, max_size=None),
-            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo',
+            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=None, desired_capacity=3, max_size=None)
         ], any_order=True)
 
@@ -59,22 +59,26 @@ class DiscoAWSTests(TestCase):
     def test_create_scaling_schedule_no_sched(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
-        aws.create_scaling_schedule("mhcboo", "1", "2", "5")
-        aws.autoscale.assert_has_calls([call.delete_all_recurring_group_actions(hostclass='mhcboo')])
+        aws.create_scaling_schedule("1", "2", "5", hostclass="mhcboo")
+        aws.autoscale.assert_has_calls([
+            call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None)
+        ])
 
     @patch_disco_aws
     def test_create_scaling_schedule_overlapping(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
-        aws.create_scaling_schedule("mhcboo",
-                                    "1@1 0 * * *:2@6 0 * * *",
-                                    "2@1 0 * * *:3@6 0 * * *",
-                                    "6@1 0 * * *:9@6 0 * * *")
+        aws.create_scaling_schedule(
+            "1@1 0 * * *:2@6 0 * * *",
+            "2@1 0 * * *:3@6 0 * * *",
+            "6@1 0 * * *:9@6 0 * * *",
+            hostclass="mhcboo"
+        )
         aws.autoscale.assert_has_calls([
-            call.delete_all_recurring_group_actions(hostclass='mhcboo'),
-            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo',
+            call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
+            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=1, desired_capacity=2, max_size=6),
-            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo',
+            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=2, desired_capacity=3, max_size=9)
         ], any_order=True)
 
@@ -82,19 +86,21 @@ class DiscoAWSTests(TestCase):
     def test_create_scaling_schedule_mixed(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
-        aws.create_scaling_schedule("mhcboo",
-                                    "1@1 0 * * *:2@7 0 * * *",
-                                    "2@1 0 * * *:3@6 0 * * *",
-                                    "6@2 0 * * *:9@6 0 * * *")
+        aws.create_scaling_schedule(
+            "1@1 0 * * *:2@7 0 * * *",
+            "2@1 0 * * *:3@6 0 * * *",
+            "6@2 0 * * *:9@6 0 * * *",
+            hostclass="mhcboo"
+        )
         aws.autoscale.assert_has_calls([
-            call.delete_all_recurring_group_actions(hostclass='mhcboo'),
-            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo',
+            call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
+            call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=1, desired_capacity=2, max_size=None),
-            call.create_recurring_group_action('2 0 * * *', hostclass='mhcboo',
+            call.create_recurring_group_action('2 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=None, desired_capacity=None, max_size=6),
-            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo',
+            call.create_recurring_group_action('6 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=None, desired_capacity=3, max_size=9),
-            call.create_recurring_group_action('7 0 * * *', hostclass='mhcboo',
+            call.create_recurring_group_action('7 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=2, desired_capacity=None, max_size=None)
         ], any_order=True)
 

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -9,6 +9,7 @@ import boto.ec2.instance
 from mock import MagicMock, create_autospec, call
 
 from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoAutoscale, DiscoBake, DiscoELB
+from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN
 from disco_aws_automation.exceptions import (
     TimeoutError,
     MaintenanceModeError,
@@ -70,6 +71,14 @@ MOCK_PIPELINE_DEFINITION = [
         'max_size': '5@30 16 * * 1-5:6@00 17 * * 1-5',
         'integration_test': None,
         'deployable': 'yes'
+    },
+    {
+        'hostclass': 'mhctimedautoscalenodeploy',
+        'min_size': '3@30 16 * * 1-5:4@00 17 * * 1-5',
+        'desired_size': '5@30 16 * * 1-5:6@00 17 * * 1-5',
+        'max_size': '5@30 16 * * 1-5:6@00 17 * * 1-5',
+        'integration_test': None,
+        'deployable': 'no'
     }
 ]
 
@@ -83,11 +92,11 @@ MOCK_CONFIG_DEFINITON = {
         "test_hostclass": "another_test_hostclass"
     },
     "mhcbluegreen": {
-        "deployment_strategy": "blue_green",
+        "deployment_strategy": DEPLOYMENT_STRATEGY_BLUE_GREEN,
         "elb": "yes"
     },
     "mhcbluegreennondeployable": {
-        "deployment_strategy": "blue_green"
+        "deployment_strategy": DEPLOYMENT_STRATEGY_BLUE_GREEN
     }
 }
 
@@ -146,8 +155,7 @@ class DiscoDeployTests(TestCase):
         self._disco_elb = create_autospec(DiscoELB, instance=True)
         self._disco_aws = create_autospec(DiscoAWS, instance=True)
         self._test_aws = self._disco_aws
-        self._existing_group = MagicMock()
-        self._existing_group.desired_capacity = 1
+        self._existing_group = self.mock_group("mhcfoo")
         self._disco_autoscale.get_existing_group.return_value = self._existing_group
         self._disco_bake = MagicMock()
         self._disco_bake.promote_ami = MagicMock()
@@ -418,17 +426,17 @@ class DiscoDeployTests(TestCase):
 
     def test_nodeploy_ami_dry_run(self):
         """We don't call spinup in a no deploy AMI dry_run"""
-        self._ci_deploy.handle_nodeploy_ami(MagicMock(), MagicMock(), 1, dry_run=True)
+        self._ci_deploy.handle_nodeploy_ami(MagicMock(), dry_run=True)
         self.assertEqual(self._disco_aws.spinup.call_count, 0)
 
     def test_tested_ami_dry_run(self):
         """We don't call spinup in a deployed AMI dry_run"""
-        self._ci_deploy.handle_tested_ami(MagicMock(), MagicMock(), 1, dry_run=True)
+        self._ci_deploy.handle_tested_ami(MagicMock(), dry_run=True)
         self.assertEqual(self._disco_aws.spinup.call_count, 0)
 
     def test_blue_green_dry_run(self):
         """We don't call spinup in a blue/green dry_run"""
-        self.assertTrue(self._ci_deploy.handle_blue_green_ami(MagicMock(), MagicMock(), 1, dry_run=True))
+        self.assertTrue(self._ci_deploy.handle_blue_green_ami(MagicMock(), dry_run=True))
         self.assertEqual(self._disco_aws.spinup.call_count, 0)
 
     def test_bg_deploy_works_with_no_orig_group(self):
@@ -621,7 +629,9 @@ class DiscoDeployTests(TestCase):
         self._disco_autoscale.get_instances.return_value = instances
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
-        self.assertTrue(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertTrue(self._ci_deploy.test_ami(ami,
+                                                 deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+                                                 dry_run=False))
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
         self._disco_aws.spinup.assert_called_once_with(
@@ -644,7 +654,9 @@ class DiscoDeployTests(TestCase):
         self._disco_autoscale.get_instances.return_value = instances
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
-        self.assertTrue(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertTrue(self._ci_deploy.test_ami(ami,
+                                                 deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+                                                 dry_run=False))
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
         self._disco_aws.spinup.assert_has_calls(
@@ -659,97 +671,197 @@ class DiscoDeployTests(TestCase):
     def test_bg_with_spinup_error_and_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with old group'''
         ami = MagicMock()
-        ami.name = "mhcfoo 2"
+        ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
-        old_group = self.mock_group("mhcfoo")
-        new_group = self.mock_group("mhcfoo")
+        old_group = self.mock_group("mhcbluegreen")
+        new_group = self.mock_group("mhcbluegreen")
         self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
-        self.assertFalse(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertFalse(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
-              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
-              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_called_once_with([{
+            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
+            'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
+            'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no old group'''
         ami = MagicMock()
-        ami.name = "mhcfoo 2"
+        ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
-        new_group = self.mock_group("mhcfoo")
+        new_group = self.mock_group("mhcbluegreen")
         self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
-        self.assertFalse(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertFalse(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
-              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
-              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_called_once_with([{
+            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
+            'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
+            'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_groups(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no groups'''
         ami = MagicMock()
-        ami.name = "mhcfoo 2"
+        ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
         self._disco_autoscale.get_existing_group.side_effect = [None, None]
-        self.assertFalse(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertFalse(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
-              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
-              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_called_once_with([{
+            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
+            'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
+            'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_autoscale.delete_groups.assert_not_called()
 
     def test_bg_with_error_and_og_and_no_ng(self):
         '''Blue/green can handle an an exception when spinning up the new ASG w/ old group and no new group'''
         ami = MagicMock()
-        ami.name = "mhcfoo 2"
+        ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
-        old_group = self.mock_group("mhcfoo")
+        old_group = self.mock_group("mhcbluegreen")
         self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
-        self.assertFalse(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertFalse(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
-              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
-              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_called_once_with([{
+            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
+            'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
+            'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_autoscale.delete_groups.assert_not_called()
 
     def test_bg_with_too_many_autoscaling_groups(self):
         '''Blue/green can handle too many autoscaling groups error when spinning up a new ASG'''
         ami = MagicMock()
-        ami.name = "mhcfoo 2"
+        ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = TooManyAutoscalingGroups
-        old_group = self.mock_group("mhcfoo")
+        old_group = self.mock_group("mhcbluegreen")
         self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
-        self.assertFalse(self._ci_deploy.test_ami(ami, deployment_strategy='blue_green', dry_run=False))
+        self.assertFalse(self._ci_deploy.test_ami(ami, dry_run=False))
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
-              'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
-              'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
+        self._disco_aws.spinup.assert_called_once_with([{
+            'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
+            'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
+            'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_autoscale.delete_groups.assert_not_called()
+
+    def test_bg_timed_autoscaling(self):
+        '''Blue/green can handle creating timed autoscaling actions'''
+        ami = MagicMock()
+        ami.name = "mhctimedautoscale 2"
+        ami.id = "ami-12345678"
+        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
+        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
+        new_group = self.mock_group("mhctimedautoscale")
+        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
+        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_aws.instances.return_value = instances
+        self._disco_aws.remotecmd.return_value = (0, "")
+        self.assertTrue(self._ci_deploy.test_ami(ami,
+                                                 deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+                                                 dry_run=False))
+        self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
+        self._disco_aws.spinup.assert_has_calls(
+            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
+                    'min_size': 3, 'desired_size': 6, 'max_size': 6}], create_if_exists=True, testing=True),
+             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
+                    'min_size': 3, 'desired_size': 6, 'max_size': 6}], group_name=new_group.name)])
+        self._disco_aws.create_scaling_schedule.assert_called_once_with(
+            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
+            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            group_name=new_group.name,
+            hostclass=None
+        )
+
+    def test_bg_ta_respects_og_size(self):
+        '''Blue/green can handle creating timed autoscaling actions and respects the old group's sizing'''
+        ami = MagicMock()
+        ami.name = "mhctimedautoscale 2"
+        ami.id = "ami-12345678"
+        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
+        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
+        old_group = self.mock_group("mhctimedautoscale", min_size=2, max_size=4, desired_size=3)
+        new_group = self.mock_group("mhctimedautoscale")
+        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
+        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_aws.instances.return_value = instances
+        self._disco_aws.remotecmd.return_value = (0, "")
+        self.assertTrue(self._ci_deploy.test_ami(ami,
+                                                 deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+                                                 dry_run=False))
+        self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
+        self._disco_aws.spinup.assert_has_calls(
+            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
+                    'min_size': 2, 'desired_size': 3, 'max_size': 4}], create_if_exists=True, testing=True),
+             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
+                    'min_size': 2, 'desired_size': 3, 'max_size': 4}], group_name=new_group.name)])
+        self._disco_aws.create_scaling_schedule.assert_called_once_with(
+            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
+            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            group_name=new_group.name,
+            hostclass=None
+        )
+
+    def test_bg_timed_autoscaling_nd(self):
+        '''Blue/green doesn't bother with timed autoscaling for non-deployable hostclasses'''
+        ami = MagicMock()
+        ami.name = "mhctimedautoscalenodeploy 2"
+        ami.id = "ami-12345678"
+        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
+        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
+        new_group = self.mock_group("mhctimedautoscalenodeploy")
+        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
+        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_aws.instances.return_value = instances
+        self._disco_aws.remotecmd.return_value = (0, "")
+        self.assertTrue(self._ci_deploy.test_ami(ami,
+                                                 deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+                                                 dry_run=False))
+
+        self._disco_bake.promote_ami.assert_called_once_with(ami, 'tested')
+        self._disco_aws.spinup.assert_called_once_with(
+            [{
+                'ami': 'ami-12345678',
+                'sequence': 1,
+                'deployable': 'no',
+                'integration_test': None,
+                'smoke_test': 'no',
+                'hostclass': 'mhctimedautoscalenodeploy',
+                'min_size': 3,
+                'desired_size': 6,
+                'max_size': 6
+            }],
+            create_if_exists=True,
+            testing=True
+        )
+        self._disco_aws.create_scaling_schedule.assert_not_called()
 
     def test_integration_tests_with_elb(self):
         '''Integration tests should wait for ELB'''
@@ -796,7 +908,7 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcnewscarey 1 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy.handle_nodeploy_ami(None, ami, 0, dry_run=False)
+        self._ci_deploy.handle_nodeploy_ami(ami, pipeline_dict=None, dry_run=False)
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
         self._disco_aws.spinup.assert_called_once_with(
             [{'ami': 'ami-12345678', 'sequence': 1, 'min_size': 0, 'desired_size': 1,
@@ -826,6 +938,8 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcsmokey 1 2"
         ami.id = "ami-12345678"
         self._existing_group.desired_capacity = 2
+        self._existing_group.max_size = 2
+        self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.test_ami(ami, dry_run=False)
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
@@ -843,6 +957,8 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcsmokey 1 2"
         ami.id = "ami-12345678"
         self._existing_group.desired_capacity = 2
+        self._existing_group.max_size = 2
+        self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
         self._ci_deploy.test_ami(ami, dry_run=False)
         self._disco_bake.promote_ami.assert_called_with(ami, 'failed')
@@ -850,7 +966,7 @@ class DiscoDeployTests(TestCase):
             [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'min_size': 2, 'integration_test': None, 'desired_size': 4,
                     'smoke_test': 'no', 'max_size': 4, 'hostclass': 'mhcsmokey'}]),
-             call([{'deployable': 'yes', 'min_size': 2, 'integration_test': None,
+             call([{'deployable': 'yes', 'sequence': 1, 'min_size': 2, 'integration_test': None,
                     'desired_size': 2, 'max_size': 2, 'hostclass': 'mhcsmokey',
                     'smoke_test': 'no'}])])
 
@@ -860,29 +976,51 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhctimedautoscale 1 2"
         ami.id = "ami-12345678"
         self._existing_group.desired_capacity = 2
+        self._existing_group.max_size = 2
+        self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.test_ami(ami, dry_run=False)
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        # NOTE: the following expected  values were calculated by using values in MOCK_PIPELINE_DEFINITION
-        #       for mhctimedautoscale in conjunction with what's done in
-        #       disco_deploy.py:DiscoDeploy.handle_test_ami()
-        expected_tested_ami_min_size = 2
-        expected_tested_ami_desired_size = 4
-        expected_tested_ami_max_size = 4
-        expected_new_ami_min_size = 3
-        expected_new_ami_desired_size = 3
-        expected_new_ami_max_size = 6
         self._disco_aws.spinup.assert_has_calls(
             [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
-                    'min_size': expected_tested_ami_min_size,
-                    'desired_size': expected_tested_ami_desired_size,
-                    'max_size': expected_tested_ami_max_size}]),
+                    'min_size': 2, 'desired_size': 4, 'max_size': 4}]),
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
-                    'min_size': expected_new_ami_min_size,
-                    'desired_size': expected_new_ami_desired_size,
-                    'max_size': expected_new_ami_max_size}])])
+                    'min_size': 2, 'desired_size': 2, 'max_size': 2}])])
+        self._disco_aws.create_scaling_schedule.assert_called_once_with(
+            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
+            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            group_name=None,
+            hostclass='mhctimedautoscale'
+        )
+
+    def test_timed_autoscaling_ami_success_nd(self):
+        '''Timed autoscaling is not set for non-deployable hostclasses'''
+        ami = MagicMock()
+        ami.name = "mhctimedautoscalenodeploy 1 2"
+        ami.id = "ami-12345678"
+        self._existing_group.desired_capacity = 2
+        self._existing_group.max_size = 2
+        self._existing_group.min_size = 2
+        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
+        self._ci_deploy.test_ami(ami, dry_run=False)
+        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
+        self._disco_aws.spinup.assert_has_calls(
+            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscalenodeploy',
+                    'min_size': 2, 'desired_size': 4, 'max_size': 4}], testing=True),
+             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
+                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscalenodeploy',
+                    'min_size': 2, 'desired_size': 2, 'max_size': 2}])])
+        self._disco_aws.create_scaling_schedule.assert_called_once_with(
+            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
+            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
+            group_name=None,
+            hostclass='mhctimedautoscalenodeploy'
+        )
 
     def test_set_maintenance_mode_on(self):
         '''_set_maintenance_mode makes expected remotecmd call'''
@@ -1034,6 +1172,7 @@ class DiscoDeployTests(TestCase):
         inst2 = self.mock_instance()
         inst2.image_id = ami2.id
         self._existing_group.desired_capacity = 2
+        self._existing_group.max_size = 2
         self._ci_deploy._set_maintenance_mode = MagicMock(return_value=True)
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(side_effect=[True, False])
@@ -1046,7 +1185,7 @@ class DiscoDeployTests(TestCase):
                 call([{'ami': ami2.id, 'sequence': 1, 'deployable': 'yes',
                        'min_size': 2, 'integration_test': 'foo_service', 'desired_size': 4,
                        'smoke_test': 'no', 'max_size': 4, 'hostclass': 'mhcintegrated'}]),
-                call([{'ami': ami1.id, 'deployable': 'yes', 'min_size': 1,
+                call([{'ami': ami1.id, 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
                        'integration_test': 'foo_service', 'desired_size': 2, 'smoke_test': 'no',
                        'max_size': 2, 'hostclass': 'mhcintegrated'}])])
 
@@ -1056,7 +1195,14 @@ class DiscoDeployTests(TestCase):
         self._existing_group.desired_capacity = 2
         self._ci_deploy.handle_nodeploy_ami = MagicMock()
         self._ci_deploy.test_ami(ami, dry_run=False)
-        self._ci_deploy.handle_nodeploy_ami.assert_has_calls([call(None, ami, 0, dry_run=False)])
+        self._ci_deploy.handle_nodeploy_ami.assert_has_calls([
+            call(
+                ami,
+                pipeline_dict=None,
+                dry_run=False,
+                old_group=self._existing_group
+            )
+        ])
 
     def test_update_ami_not_in_pipeline(self):
         '''Test update_ami handling of non-pipeline hostclass'''
@@ -1073,8 +1219,17 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.update_ami(ami, dry_run=False)
         self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcsmokey")
         self._ci_deploy.handle_tested_ami.assert_called_with(
-            {'min_size': 2, 'integration_test': None, 'deployable': 'yes',
-             'desired_size': 2, 'hostclass': 'mhcsmokey'}, ami, 2, dry_run=False)
+            ami,
+            pipeline_dict={
+                'min_size': 2,
+                'integration_test': None,
+                'deployable': 'yes',
+                'desired_size': 2,
+                'hostclass': 'mhcsmokey'
+            },
+            dry_run=False,
+            old_group=None
+        )
 
     def test_update_ami_not_in_autoscale_nodeploy(self):
         '''Test update_ami handling new non-deployable hostclass'''
@@ -1086,8 +1241,17 @@ class DiscoDeployTests(TestCase):
         self.assertEqual(self._ci_deploy.is_deployable.call_count, 1)
         self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcscarey")
         self._ci_deploy.handle_nodeploy_ami.assert_called_with(
-            {'min_size': 1, 'integration_test': None, 'deployable': 'no',
-             'desired_size': 1, 'hostclass': 'mhcscarey'}, ami, 1, dry_run=False)
+            ami,
+            pipeline_dict={
+                'min_size': 1,
+                'integration_test': None,
+                'deployable': 'no',
+                'desired_size': 1,
+                'hostclass': 'mhcscarey'
+            },
+            dry_run=False,
+            old_group=None
+        )
 
     def test_test_with_amis(self):
         '''Test test with amis'''


### PR DESCRIPTION
This is a bit of a refactor to make `disco_deploy.py` understand and
respect the timed autoscaling format we use in the pipeline file. Now,
classic and blue_green deployment strategies will remove the existing
timed autoscaling actions and reapply any that were defined in the
pipeline file. One notable exception is for blue_green deployment: if the
hostclass isn't deployable, then blue_green won't bother to apply the
scheduled actions. The same happens for classic deployment and
non-deployable if the hostclass is not already deployed - the timed
autoscaling actions are not applied. Additionally, hostclasses that take
advantage of timed autoscaling are now expected to respect the sizing
of their already deployed ASG, if one exists.

This required a bit of refactor for the method signatures and structure
of the `handle_*` methods. Now all of them accept the preexisting ASG as
an optional argument, as well as the original pipeline definition if one
exists. The logic for creating the ASG sizing is now centralized in the
two `_generate_*` methods to make everything a bit more DRY. Instead of
passing a pipeline and relying on the logic in provision and spinup to
intepret the current sizing and the timed autoscaling actions, that
logic is now split up. Instead, disco_deploy will use the new
`_generate_*` functions to determine the appropriate sizing, and then
use the new `_create_scheduled_actions` function to create the timed
autoscaling actions as per the original pipeline.

Also fixed a bug where blue_green deployment would break if someone set
`0` as the desired_size in their pipeline file.

Also included some general cleanup of the disco deploy unit tests.