### PR TITLE
Increase ELB Instance State timeout

### DIFF
--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -369,7 +369,7 @@ class DiscoELB(object):
         return instances["InstanceStates"]
 
     def wait_for_instance_health_state(self, hostclass, testing=False, instance_ids=None, state="InService",
-                                       timeout=180):
+                                       timeout=600):
         """
         Waits for instances attached to an ELB to enter a specific state. At least one instance must enter the
         specified state.

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -397,8 +397,12 @@ class DiscoELB(object):
                 return
             # Update scope to be the instances that have not yet entered the desired state
             scope = [instance["InstanceId"] for instance in instances if instance["State"] != state]
-            logger.info("Waiting for %s in ELB %s to enter state (%s)",
-                        scope or original_scope, elb_name, state)
+            logger.info(
+                "Waiting for %s in ELB (%s) to enter state (%s)",
+                scope or original_scope,
+                elb_name,
+                state
+            )
             time.sleep(5)
         raise TimeoutError(
             "Timed out after waiting {} seconds for {} in ELB ({}) to enter state ({})".format(timeout,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.150"
+__version__ = "1.0.151"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
It looks like fairly frequently instances are not able to attach to an
ELB within the current timeout. This might be due to delays in AWS
making instances routable. AWS doesn't appear to give any guidelines on
how long an instance should take to attach to an ELB, so trying a nice
round number like 10 minutes.