### PR TITLE
Fix integration tests for DiscoVPC

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.152"
+__version__ = "1.0.153"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The integration tests fail because the DHCP `create_tags` call periodically fails if called before the DHCP options have been created in AWS. Solve this by keep trying for a minute