### PR TITLE
Fix empty launch config bug

### DIFF
--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -334,7 +334,11 @@ class DiscoAutoscale(object):
         """Returns all launch configurations for a hostclass if any exist, None otherwise"""
         group_list = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
         if group_list:
-            return self.get_configs(names=[group.launch_config_name for group in group_list])
+            return self.get_configs(names=[
+                group.launch_config_name
+                for group in group_list
+                if group.launch_config_name
+            ])
         return None
 
     def get_launch_config(self, hostclass=None, group_name=None):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.156"
+__version__ = "1.0.157"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
There seems to be a racetime condition where we try to get launch
configs before the autoscaling group actually has one added to it.
Adding a little filter that makes sure that the launch config name is
actually a thing and not an empty string should fix it. The bug is a bit
hard to reproduce but it seems like this is what is happening and this
should fix it.