### PR TITLE
Fixes for restore.

### DIFF
--- a/disco_aws_automation/disco_elasticsearch_archive.py
+++ b/disco_aws_automation/disco_elasticsearch_archive.py
@@ -484,6 +484,7 @@ class DiscoESArchive(object):
         """
         Bring back indices within the specified date range (inclusive) from archive to ES cluster
         """
+        self._create_repository()
         date_pattern = re.compile(r'^[\d]{4}(\.[\d]{2}){2}$')
         if not re.match(date_pattern, begin_date):
             raise RuntimeError("Invalid begin date (yyyy.mm.dd): {0}".format(begin_date))
@@ -523,5 +524,8 @@ class DiscoESArchive(object):
         for snap in snapshots:
             logger.info("Restoring snapshot: %s", snap)
             if not dry_run:
-                self.es_client.snapshot.restore(repository=self._repository_name,
-                                                snapshot=snap)
+                self.es_client.snapshot.restore(
+                    repository=self._repository_name,
+                    snapshot=snap,
+                    wait_for_completion=True
+                )

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.157"
+__version__ = "1.0.158"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Restore would request restore of all indexes one after another without
waiting causing ES to error out with
`concurrent_snapshot_execution_exception`. Now we wait for each one.

Restoring to new cluster would not work as we only configure archive
repository with archive. So archive would have needed to run before
recover would succeed. Now we initialize repository on archive and
restore.