### PR TITLE
Don't pass in version when updating cluster.

### DIFF
--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -288,6 +288,11 @@ class DiscoElasticsearch(object):
             desired_es_config = es_config or self._get_es_config(desired_elasticsearch_name)
 
             if desired_elasticsearch_name in all_elasticsearch_names:
+                try:
+                    del(desired_es_config["ElasticsearchVersion"])
+                    logging.debug("Ignoring ElasticsearchVersion specification on update")
+                except KeyError:
+                    pass
                 logger.info('Updating ElasticSearch domain %s', domain_name)
                 throttled_call(self.conn.update_elasticsearch_domain_config, **desired_es_config)
             else:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.158"
+__version__ = "1.0.159"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Our upsert would pass in ES version on update which invalid according to
AWS spec .. as a result it would fail. Now we only pass in version on
create but not on update.