### PR TITLE
Long disk name metrics fix

### DIFF
--- a/disco_aws_automation/disco_metrics.py
+++ b/disco_aws_automation/disco_metrics.py
@@ -124,7 +124,7 @@ class DiscoMetrics(object):
         Returns df disk utilization percentage info in a map.
         Raises RuntimeError if it fails to parse df output.
         """
-        output = check_output(['df'])
+        output = check_output(['df', '-P'])
         regex = re.compile(r"(\S+)\s+\d+\s+\d+\s+\d+\s+(\d+)%.*")
         info = {regex.match(line).group(1): regex.match(line).group(2)
                 for line in output.split("\n")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.155"
+__version__ = "1.0.156"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
- Changed `df` output to be posix standard. This allows names like `/dev/mapper/VolGroup00-LogVol00` to be in a single line.<br>
 `df` : 
<pre>
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/mapper/VolGroup00-LogVol00
                      36533824   4690160  29957868  14% /
/dev/hda1               101086     16491     79376  18% /boot
tmpfs                  3833916         0   3833916   0% /dev/shm
/dev/xvdb             51606140    186512  48798188   1% /mnt/san-nfs
</pre>

 `df -P`:
<pre>
Filesystem         1024-blocks      Used Available Capacity Mounted on
/dev/mapper/VolGroup00-LogVol00  36533824   4690192  29957836      14% /
/dev/hda1               101086     16491     79376      18% /boot
tmpfs                  3833916         0   3833916       0% /dev/shm
/dev/xvdb             51606140    186512  48798188       1% /mnt/san-nfs
</pre>