### PR TITLE
Handle RequestLimitExceeded in throttled_call

### DIFF
--- a/disco_aws_automation/resource_helper.py
+++ b/disco_aws_automation/resource_helper.py
@@ -102,7 +102,7 @@ def throttled_call(fun, *args, **kwargs):
             else:
                 error_code = err.response['Error'].get('Code', 'Unknown')
 
-            if (error_code != "Throttling") or (time.time() > expire_time):
+            if (error_code not in ("Throttling", "RequestLimitExceeded")) or (time.time() > expire_time):
                 raise
 
             time.sleep(curr_delay)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.160"
+__version__ = "1.0.161"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The new version of boto3 is throwing RequestLimitExceeded instead of Throttling
exceptions so we need to catch those too when using throttled_call

This is the reason some of our bakes are still failing even after adding `throttled_call` to everywhere to DiscoVPC