### PR TITLE
Bug fix: Empty size is returned from ES for red indices

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.161"
+__version__ = "1.0.162"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
It appears that when an ElasticSearch index is red, the ES api would return a blank value for its `store.size` property. `disco_elasticsearch_archive.py` needs to be updated to handle such situation and assume the size to be 0.