### PR TITLE
Updating NAT gateway EIPs during VPC update

### DIFF
--- a/disco_aws_automation/__init__.py
+++ b/disco_aws_automation/__init__.py
@@ -60,7 +60,6 @@ from .disco_storage import DiscoStorage
 from .disco_log_metrics import DiscoLogMetrics
 from .disco_elasticsearch import DiscoElasticsearch
 from .disco_elasticsearch_archive import DiscoESArchive
-from .disco_ssm import DiscoSSM
 from .exceptions import TimeoutError, ExpectedTimeoutError, AccountError, CommandError, VPCEnvironmentError
 from .exceptions import SmokeTestError, AMIError, VolumeError, InstanceMetadataError, S3WritingError
 from .exceptions import MissingAppAuthError, AppAuthKeyNotFoundError, VPCConfigError, VPCPeeringSyntaxError

--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -189,24 +189,38 @@ class DiscoMetaNetwork(object):
             for subnet in self.disco_subnets.values()
         ]
 
-    def add_nat_gateways(self, allocation_ids):
+    def add_nat_gateways(self, allocation_ids=None, use_dyno_nat=False):
         """
-        Creates a NAT gateway in each of the metanetwork's subnet
+        Creates a NAT gateway in each of the metanetwork's subnet, either using the
+        EIP allocation ids provided or dynamic EIPs, but not both.
         :param allocation_ids: Allocation ids of the Elastic IPs that will be
                                associated with the NAT gateways
+        :param use_dyno_nat:   Indicates whether to dynamic EIPs for creating
+                               the NATs.
         """
-        if len(self.disco_subnets.values()) != len(allocation_ids):
-            raise EIPConfigError("The number of subnets does not match with the "
-                                 "number of NAT gateway EIPs provided for {0}: "
-                                 "{1} != {2}"
-                                 .format(self._resource_name(),
-                                         len(self.disco_subnets.values()),
-                                         len(allocation_ids)))
+        if allocation_ids and not use_dyno_nat:
+            if len(self.disco_subnets.values()) != len(allocation_ids):
+                raise EIPConfigError("The number of subnets does not match with the "
+                                     "number of NAT gateway EIPs provided for {0}: "
+                                     "{1} != {2}"
+                                     .format(self._resource_name(),
+                                             len(self.disco_subnets.values()),
+                                             len(allocation_ids)))
 
-        self._create_route_table_per_subnet()
+            self._create_route_table_per_subnet()
 
-        for disco_subnet, allocation_id in zip(self.disco_subnets.values(), allocation_ids):
-            disco_subnet.create_nat_gateway(allocation_id)
+            for disco_subnet, allocation_id in zip(self.disco_subnets.values(), allocation_ids):
+                disco_subnet.create_nat_gateway(eip_allocation_id=allocation_id)
+
+        elif use_dyno_nat and not allocation_ids:
+            self._create_route_table_per_subnet()
+
+            for disco_subnet in self.disco_subnets.values():
+                disco_subnet.create_nat_gateway(use_dyno_nat=True)
+
+        else:
+            raise RuntimeError("Invalid arguments: allocation_ids ({0}), use_dyno_nat ({1})"
+                               .format(allocation_ids, use_dyno_nat))
 
     def _create_route_table_per_subnet(self):
         if self.centralized_route_table:
@@ -523,13 +537,13 @@ class DiscoMetaNetwork(object):
                 for disco_subnet in self.disco_subnets.values():
                     disco_subnet.replace_route_to_gateway(route_tuple[0], route_tuple[1])
 
-    def add_nat_gateway_route(self, dest_metanetwork):
+    def upsert_nat_gateway_route(self, dest_metanetwork):
         """ Add a default route in each of the subnet's route table to the corresponding NAT gateway
-        of the same AZ in the destination metanetwork """
+        of the same AZ in the destination metanetwork if it's not already there. """
         self._create_route_table_per_subnet()
 
         for zone in self.disco_subnets.keys():
-            self.disco_subnets[zone].add_route_to_nat_gateway(
+            self.disco_subnets[zone].upsert_route_to_nat_gateway(
                 '0.0.0.0/0',
                 dest_metanetwork.disco_subnets[zone].nat_gateway['NatGatewayId']
             )

--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -195,7 +195,7 @@ class DiscoMetaNetwork(object):
         EIP allocation ids provided or dynamic EIPs, but not both.
         :param allocation_ids: Allocation ids of the Elastic IPs that will be
                                associated with the NAT gateways
-        :param use_dyno_nat:   Indicates whether to dynamic EIPs for creating
+        :param use_dyno_nat:   Indicates whether to allocate dynamic EIPs for creating
                                the NATs.
         """
         if allocation_ids and not use_dyno_nat:

--- a/disco_aws_automation/disco_metanetwork.py
+++ b/disco_aws_automation/disco_metanetwork.py
@@ -189,16 +189,14 @@ class DiscoMetaNetwork(object):
             for subnet in self.disco_subnets.values()
         ]
 
-    def add_nat_gateways(self, allocation_ids=None, use_dyno_nat=False):
+    def add_nat_gateways(self, allocation_ids=None):
         """
         Creates a NAT gateway in each of the metanetwork's subnet, either using the
-        EIP allocation ids provided or dynamic EIPs, but not both.
+        EIP allocation ids provided, or dynamic EIPs if EIP allocation_ids are not passed in.
         :param allocation_ids: Allocation ids of the Elastic IPs that will be
-                               associated with the NAT gateways
-        :param use_dyno_nat:   Indicates whether to allocate dynamic EIPs for creating
-                               the NATs.
+                               associated with the NAT gateways.
         """
-        if allocation_ids and not use_dyno_nat:
+        if allocation_ids:
             if len(self.disco_subnets.values()) != len(allocation_ids):
                 raise EIPConfigError("The number of subnets does not match with the "
                                      "number of NAT gateway EIPs provided for {0}: "
@@ -212,15 +210,11 @@ class DiscoMetaNetwork(object):
             for disco_subnet, allocation_id in zip(self.disco_subnets.values(), allocation_ids):
                 disco_subnet.create_nat_gateway(eip_allocation_id=allocation_id)
 
-        elif use_dyno_nat and not allocation_ids:
+        else:
             self._create_route_table_per_subnet()
 
             for disco_subnet in self.disco_subnets.values():
-                disco_subnet.create_nat_gateway(use_dyno_nat=True)
-
-        else:
-            raise RuntimeError("Invalid arguments: allocation_ids ({0}), use_dyno_nat ({1})"
-                               .format(allocation_ids, use_dyno_nat))
+                disco_subnet.create_nat_gateway()
 
     def _create_route_table_per_subnet(self):
         if self.centralized_route_table:

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -170,7 +170,7 @@ class DiscoSubnet(object):
                                      {'NatGatewayIds': [nat_gateway_id]},
                                      'NatGateways', 'deleted', 'State')
 
-                self.disco_eip.release(eip, True)
+                self.disco_eip.release(eip)
                 self._delete_dyno_nat_tag()
 
             self._nat_gateway = None

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -112,7 +112,8 @@ class DiscoSubnet(object):
                 # If there is an association between this subnet and the old route table
                 # copy the routes to the new route table and disassociate the old one
                 for route in self.route_table['Routes']:
-                    if not route.get('GatewayId') or route['GatewayId'] != 'local':
+                    if (not route.get('GatewayId') or route['GatewayId'] != 'local') and \
+                       route.get('DestinationCidrBlock'):
                         self._add_route(route_table_id=new_route_table['RouteTableId'],
                                         destination_cidr_block=route['DestinationCidrBlock'],
                                         gateway_id=route.get('GatewayId'),

--- a/disco_aws_automation/disco_vpc_gateways.py
+++ b/disco_aws_automation/disco_vpc_gateways.py
@@ -235,7 +235,7 @@ class DiscoVPCGateways(object):
                 logger.info("Setting up NAT gateways in meta network %s using dyno NATs.",
                             network.name)
                 if not dry_run:
-                    network.add_nat_gateways(use_dyno_nat=True)
+                    network.add_nat_gateways()
 
             else:
                 eips = [eip.strip() for eip in eips.split(",")]

--- a/disco_aws_automation/disco_vpc_gateways.py
+++ b/disco_aws_automation/disco_vpc_gateways.py
@@ -306,4 +306,4 @@ class DiscoVPCGateways(object):
         if eips:
             logger.info("Releasing temporary NAT EIPs: %s.", " ".join(eips))
         for eip in eips:
-            self.eip.release(eip, True)
+            self.eip.release(eip)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.164"
+__version__ = "1.0.165"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.165"
+__version__ = "1.0.166"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.166"
+__version__ = "1.0.167"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.167"
+__version__ = "1.0.168"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_metanetwork.py
+++ b/test/unit/test_disco_metanetwork.py
@@ -116,7 +116,7 @@ class DiscoMetaNetworkTests(TestCase):
         """ Verify that NAT gateways are properly created for a meta network using dynamic EIPs"""
 
         self.meta_network.create()
-        self.meta_network.add_nat_gateways(use_dyno_nat=True)
+        self.meta_network.add_nat_gateways()
 
         self.assertFalse(self.meta_network.centralized_route_table)
         self.mock_vpc_conn.delete_route_table.assert_called_once_with(MOCK_ROUTE_TABLE.id)
@@ -125,7 +125,7 @@ class DiscoMetaNetworkTests(TestCase):
         nat_gateway_calls = []
         for _ in range(len(MOCK_ZONES)):
             recreate_route_table_calls.append(call())
-            nat_gateway_calls.append(call(use_dyno_nat=True))
+            nat_gateway_calls.append(call())
 
         mock_recreate_route_table.assert_has_calls(recreate_route_table_calls)
         mock_create_nat_gateway.assert_has_calls(nat_gateway_calls)

--- a/test/unit/test_disco_subnet.py
+++ b/test/unit/test_disco_subnet.py
@@ -4,7 +4,10 @@ import copy
 
 from mock import MagicMock, call
 
-from disco_aws_automation.disco_subnet import DiscoSubnet
+from disco_aws_automation.disco_subnet import (
+    DiscoSubnet,
+    DYNO_NAT_TAG_KEY
+)
 from test.helpers.patch_disco_aws import TEST_ENV_NAME
 
 
@@ -14,6 +17,7 @@ MOCK_VPC_NAME = 'mock_vpc_name'
 MOCK_VPC_ID = 'mock_vpc_id'
 MOCK_ROUTE_TABLE_ID = 'centralized_route_table_id'
 MOCK_ALLOCATION_ID = 'mock_allocation_id'
+MOCK_PUBLIC_IP = '102.102.102.102'
 MOCK_NAT_GATEWAY_ID = 'nat_gateway_id'
 MOCK_SUBNET_ID = 'subnet_id'
 MOCK_ROUTE_TABLE_ASSOC_ID = 'route_table_association_id'
@@ -21,7 +25,8 @@ MOCK_REPLACE_CIDR = '111.111.111.111/24'
 MOCK_SUBNET = {'SubnetId': MOCK_SUBNET_ID,
                'State': 'available',
                'VpcId': MOCK_VPC_ID,
-               'CidrBlock': MOCK_CIDR}
+               'CidrBlock': MOCK_CIDR,
+               'Tags': []}
 MOCK_ROUTE_TABLE = {'RouteTableId': MOCK_ROUTE_TABLE_ID,
                     'Routes': [{'DestinationCidrBlock': MOCK_REPLACE_CIDR,
                                 'GatewayId': 'mock_gateway_id1'},
@@ -35,7 +40,8 @@ MOCK_NEW_ROUTE_TABLE = {'RouteTableId': 'new_route_table_id'}
 MOCK_NAT_GATEWAY = {'VpcId': MOCK_VPC_ID,
                     'SubnetId': MOCK_SUBNET_ID,
                     'NatGatewayId': MOCK_NAT_GATEWAY_ID,
-                    'NatGatewayAddresses': [{'AllocationId': MOCK_ALLOCATION_ID}]}
+                    'NatGatewayAddresses': [{'AllocationId': MOCK_ALLOCATION_ID,
+                                             'PublicIp': MOCK_PUBLIC_IP}]}
 MOCK_ROUTE = {'RouteId': 'route_id'}
 MOCK_TAG = [{'Value': "{0}_{1}_{2}".format(TEST_ENV_NAME,
                                            MOCK_VPC_NAME,
@@ -84,7 +90,10 @@ def _get_ec2_conn_mock(test_disco_subnet):
             return {'Subnets': []}
 
     def _mock_create_subnet(*_, **__):
-        return {'Subnet': MOCK_SUBNET}
+        if not test_disco_subnet.existing_subnet:
+            test_disco_subnet.existing_subnet = MOCK_SUBNET
+
+        return {'Subnet': test_disco_subnet.existing_subnet}
 
     def _mock_create_route(*_, **params):
         test_disco_subnet.route_table['Routes'].append(
@@ -127,6 +136,17 @@ def _get_ec2_conn_mock(test_disco_subnet):
     return ret
 
 
+def _get_disco_eip_mock():
+    ret = MagicMock()
+
+    eip_mock = MagicMock()
+    eip_mock.allocation_id = MOCK_ALLOCATION_ID
+
+    ret.allocate.return_value = eip_mock
+
+    return ret
+
+
 class DiscoSubnetTests(TestCase):
     """Test DiscoSubnet"""
 
@@ -137,9 +157,11 @@ class DiscoSubnetTests(TestCase):
 
         self.mock_metanetwork = _get_metanetwork_mock()
         self.mock_ec2_conn = _get_ec2_conn_mock(self)
+        self.mock_disco_eip = _get_disco_eip_mock()
 
         self.subnet = DiscoSubnet(MOCK_SUBNET_NAME, self.mock_metanetwork,
-                                  MOCK_CIDR, MOCK_ROUTE_TABLE_ID, self.mock_ec2_conn)
+                                  MOCK_CIDR, MOCK_ROUTE_TABLE_ID, self.mock_ec2_conn,
+                                  self.mock_disco_eip)
 
     def test_init_subnet_with_cntrlzd_rt_tbl(self):
         """ Verify that subnet is initialized properly when there is an existing centralized route table """
@@ -224,13 +246,26 @@ class DiscoSubnetTests(TestCase):
 
     def test_create_nat_gateway(self):
         """ Verify creation of a new NAT gateway for the subnet """
-        self.subnet.create_nat_gateway(MOCK_ALLOCATION_ID)
+        self.subnet.create_nat_gateway(eip_allocation_id=MOCK_ALLOCATION_ID)
 
         self.assertEqual(self.subnet.nat_eip_allocation_id, MOCK_ALLOCATION_ID)
         self.assertEqual(self.subnet.nat_gateway, MOCK_NAT_GATEWAY)
 
         self.mock_ec2_conn.create_nat_gateway.assert_called_once_with(AllocationId=MOCK_ALLOCATION_ID,
                                                                       SubnetId=MOCK_SUBNET['SubnetId'])
+
+    def test_create_dyno_nat_gateway(self):
+        """ Verify creation of a new NAT gateway for the subnet """
+        self.subnet.create_nat_gateway(use_dyno_nat=True)
+
+        self.mock_disco_eip.allocate.assert_called_once_with()
+        self.assertEqual(self.subnet.nat_eip_allocation_id, MOCK_ALLOCATION_ID)
+        self.assertEqual(self.subnet.nat_gateway, MOCK_NAT_GATEWAY)
+        self.mock_ec2_conn.create_nat_gateway.assert_called_once_with(AllocationId=MOCK_ALLOCATION_ID,
+                                                                      SubnetId=MOCK_SUBNET['SubnetId'])
+        self.mock_ec2_conn.create_tags.assert_has_calls(
+            [call(Resources=[MOCK_SUBNET_ID],
+                  Tags=[{'Key': DYNO_NAT_TAG_KEY, 'Value': ''}])])
 
     def test_delete_nat_gateway(self):
         """ Verify that a NAT gateway can be properly deleted """
@@ -240,6 +275,19 @@ class DiscoSubnetTests(TestCase):
 
         self.assertEqual(self.subnet.nat_eip_allocation_id, None)
         self.assertEqual(self.subnet.nat_gateway, None)
+
+    def test_delete_dyno_nat_gateway(self):
+        """ Verify that a NAT gateway created with a dynamic EIP can be properly deleted """
+        self.subnet.create_nat_gateway(use_dyno_nat=True)
+        self.existing_subnet['Tags'].append({'Key': DYNO_NAT_TAG_KEY, 'Value': ''})
+
+        self.subnet.delete_nat_gateway()
+
+        self.assertEqual(self.subnet.nat_eip_allocation_id, None)
+        self.assertEqual(self.subnet.nat_gateway, None)
+        self.mock_disco_eip.release.assert_called_once_with(MOCK_PUBLIC_IP)
+        self.mock_ec2_conn.delete_tags.assert_has_calls(
+            [call(Resources=[MOCK_SUBNET_ID], Tags=[{'Key': DYNO_NAT_TAG_KEY}])])
 
     def test_recreate_route_table(self):
         """ Verify a new route table is created to replace an existing one """
@@ -323,3 +371,38 @@ class DiscoSubnetTests(TestCase):
                         if route['DestinationCidrBlock'] == destination_cidr_block and
                         route['GatewayId'] == gateway_id]
         self.assertTrue(route_to_nat)
+
+    def test_upsert_route_to_nat_gateway(self):
+        """ Verify that a new route to a NAT gateway can be created properly """
+        self.subnet.create_nat_gateway(eip_allocation_id=MOCK_ALLOCATION_ID)
+
+        # Calling method under test
+        self.subnet.upsert_route_to_nat_gateway('0.0.0.0/0', MOCK_NAT_GATEWAY_ID)
+
+        # Verification
+        nat_gateway_route = [route for route in self.route_table['Routes']
+                             if route.get('DestinationCidrBlock') == '0.0.0.0/0']
+        self.assertTrue(len(nat_gateway_route) == 1)
+        self.assertEqual(nat_gateway_route[0]['NatGatewayId'], MOCK_NAT_GATEWAY_ID)
+
+    def test_change_to_new_nat_gateway(self):
+        """ Verify that updating NAT gateway with a new EIP can be done properly """
+        self.subnet.create_nat_gateway(eip_allocation_id=MOCK_ALLOCATION_ID)
+        self.subnet.upsert_route_to_nat_gateway('0.0.0.0/0', MOCK_NAT_GATEWAY_ID)
+
+        new_mock_nat_gateway_id = 'new_mock_nat_gateway_id'
+
+        # Calling method under test
+        self.subnet.create_nat_gateway(use_dyno_nat=True)
+        self.subnet.upsert_route_to_nat_gateway('0.0.0.0/0', new_mock_nat_gateway_id)
+
+        # Verification
+        self.mock_ec2_conn.delete_nat_gateway.assert_called_once_with(NatGatewayId=MOCK_NAT_GATEWAY_ID)
+        expected_create_calls = [call(AllocationId=MOCK_ALLOCATION_ID, SubnetId=MOCK_SUBNET_ID),
+                                 call(AllocationId=MOCK_ALLOCATION_ID, SubnetId=MOCK_SUBNET_ID)]
+        self.mock_ec2_conn.create_nat_gateway.assert_has_calls(expected_create_calls)
+
+        nat_gateway_route = [route for route in self.route_table['Routes']
+                             if route.get('DestinationCidrBlock') == '0.0.0.0/0']
+        self.assertTrue(len(nat_gateway_route) == 1)
+        self.assertEqual(nat_gateway_route[0]['NatGatewayId'], new_mock_nat_gateway_id)

--- a/test/unit/test_disco_subnet.py
+++ b/test/unit/test_disco_subnet.py
@@ -256,7 +256,7 @@ class DiscoSubnetTests(TestCase):
 
     def test_create_dyno_nat_gateway(self):
         """ Verify creation of a new NAT gateway for the subnet """
-        self.subnet.create_nat_gateway(use_dyno_nat=True)
+        self.subnet.create_nat_gateway()
 
         self.mock_disco_eip.allocate.assert_called_once_with()
         self.assertEqual(self.subnet.nat_eip_allocation_id, MOCK_ALLOCATION_ID)
@@ -278,7 +278,7 @@ class DiscoSubnetTests(TestCase):
 
     def test_delete_dyno_nat_gateway(self):
         """ Verify that a NAT gateway created with a dynamic EIP can be properly deleted """
-        self.subnet.create_nat_gateway(use_dyno_nat=True)
+        self.subnet.create_nat_gateway()
         self.existing_subnet['Tags'].append({'Key': DYNO_NAT_TAG_KEY, 'Value': ''})
 
         self.subnet.delete_nat_gateway()
@@ -393,7 +393,7 @@ class DiscoSubnetTests(TestCase):
         new_mock_nat_gateway_id = 'new_mock_nat_gateway_id'
 
         # Calling method under test
-        self.subnet.create_nat_gateway(use_dyno_nat=True)
+        self.subnet.create_nat_gateway()
         self.subnet.upsert_route_to_nat_gateway('0.0.0.0/0', new_mock_nat_gateway_id)
 
         # Verification

--- a/test/unit/test_disco_vpc_gateways.py
+++ b/test/unit/test_disco_vpc_gateways.py
@@ -166,20 +166,15 @@ class DiscoVPCGatewaysTests(unittest.TestCase):
             return ret
 
         meta_network_mock.side_effect = _meta_network_mock
-
-        eip = MagicMock()
-        eip.public_ip = "10.0.0.1"
-        self.disco_vpc_gateways.eip.allocate.return_value = eip
         # End of setting up test
 
         # Calling method under test
         self.disco_vpc_gateways.update_nat_gateways_and_routes()
 
         # Verifying correct behavior
-        network_intranet_mock.add_nat_gateway_route.assert_called_once_with(network_tunnel_mock)
-        network_tunnel_mock.add_nat_gateways.assert_called_once_with([
+        network_intranet_mock.upsert_nat_gateway_route.assert_called_once_with(network_tunnel_mock)
+        network_tunnel_mock.add_nat_gateways.assert_called_once_with(allocation_ids=[
             self.disco_vpc_gateways.eip.find_eip_address('eip').allocation_id,
             self.disco_vpc_gateways.eip.find_eip_address('eip').allocation_id,
             self.disco_vpc_gateways.eip.find_eip_address('eip').allocation_id
         ])
-        self.disco_vpc_gateways.eip.allocate.assert_any_call()


### PR DESCRIPTION
This is PR is to add support for updating NAT gateways in an existing VPC according to changes in `disco_vpc.ini`. NAT gateways in a live VPC can now be switched between dynamically generated EIPs and pre-allocated EIPs, or between two different sets of pre-allocated EIPs.