### PR TITLE
Enable cross zone load balancing for ELBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,7 @@ Options:
 -   `elb_sticky_app_cookie` [Optional] Enable sticky sessions by setting the session cookie of your application
 -   `elb_idle_timeout` [Default=300] Timeout before ELB kills idle connections
 -   `elb_connection_draining` [Default=300] The timeout, in seconds, for requests to unhealthy or de-registering instances to complete before instance is removed from ELB
+-   `elb_cross_zone_load_balancing` [Default=True] If true, the ELB will evenly distribute load across instances regardless of their AZs. If false, the ELB will evenly distribute load across AZs regardless of number of instances in each AZ.
 
 ### Commands for managing ELB
 List all ELBs in the environment

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -328,7 +328,15 @@ class DiscoAWS(object):
                     "hostclass": hostclass,
                     "is_testing": "1" if testing else "0",
                     "environment": self.environment_name
-                })
+                },
+                cross_zone_load_balancing=is_truthy(
+                    self.hostclass_option_default(
+                        hostclass,
+                        "elb_cross_zone_load_balancing",
+                        "true"
+                    )
+                )
+            )
 
         if update_autoscaling:
             self.autoscale.update_elb([elb['LoadBalancerName']] if elb else [], hostclass=hostclass)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.164"
+__version__ = "1.0.165"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -357,7 +357,8 @@ class DiscoAWSTests(TestCase):
                 'environment': 'unittestenv',
                 'hostclass': 'mhcelb',
                 'is_testing': '0'
-            }
+            },
+            cross_zone_load_balancing=True
         )
 
     @patch_disco_aws


### PR DESCRIPTION
Automatically enable cross zone load balancing for ELBs. This means that
traffic will be routed evenly across all instances of a hostclass
instead of evenly across AZs. The difference is that if we have 8
instances in AZ foo and 2 instances in AZ bar, 80% of traffic will go to
AZ foo and 20% of traffic will go to AZ bar, instead of evenly splitting
the traffic between AZ foo and AZ bar.