### PR TITLE
Made pipeline-file-reading a utility, and increased gracefulness.

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.167"
+__version__ = "1.0.168"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.169"
+__version__ = "1.0.170"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Moved the pipeline-reading code from bin/disco_aws.py to the utilities package, made
run_gracefully aware of the botocore exception that is now raised instead of the one
it was expecting, and made it available as a decorator, in case people prefer that
way of applying it.