### PR TITLE
Use the latest snapshot when cloning a RDS instance

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.168"
+__version__ = "1.0.169"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Previously, we looked for a snapshot named "final-snapshot" when creating a clone DB. This isn't guaranteed to actually be the most recent snapshot so change the code to do that instead.