### PR TITLE
Entry-point based command-line setup, with sandbox-creation support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ Environments
 
 Environments created by Asiaq are separated out by VPCs.
 Each environment resides in its own VPC and has its own metanetworks,
-gateways, instances, and so on. All environment management is done with
+gateways, instances, and so on. Most environment management is done with
 the disco_vpc_ui.py tool.
 
 ### Listing Active Environments
@@ -707,6 +707,38 @@ other than the default one without having to alter the config.
 If you will be doing a lot of work in a particular environment you can
 define the DEFAULT_ENV environment variable and disco_aws.py will
 default to working in that environment.
+
+### Working with "sandbox" environments
+
+As a special case, asiaq has a convenience tool that creates VPCs with
+the "sandbox" type, and provides a few shortcuts:
+
+    * the VPC will automatically be provisioned using the pipeline file
+      in "sandboxes/${SANDBOX_NAME}/pipeline.csv
+    * a preset list of configuration files may be synced to an S3
+      bucket, so that hosts that spin up in a named sandbox are able
+      to configure themselves differently if need be (this can be
+      useful for managing service discovery, if the sandbox does not
+      contain an instance of every possible hostclass and its
+      dependencies).
+
+To spin up a sandbox, from a pipeline that has already been created in
+the appropriate configuration location, you can simply run
+
+    asiaq sandbox $SANDBOX_NAME
+
+To configure configuration-file syncing, set the `sandbox_sync_config`
+option in the `disco_aws` section of the main configuration file to
+the name of the S3 bucket, and populate the `sandbox_sync_config`
+option.  This option is line-based, and contains whitespace-separated
+tuples in the form (local file, remote directory): for each line, the file
+`sandboxes/$SANDBOX_NAME/$LOCAL_FILE` will be copied to the s3 bucket
+in the location `$REMOTE_DIRECTORY/$SANDBOX_NAME`.  So, by way of example:
+
+    sandbox_config_bucket=us-west-2.myproject.sandboxes
+    sandbox_sync_config=zk_blacklist zookeeper-sync-black-lists
+        trusted_ip_list   firewall-trusted-cidrs
+
 
 Provisioning a pipeline
 -----------------------

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -1,0 +1,107 @@
+"""
+Code for a conventional entry-point based command-line interface.
+"""
+
+import argparse
+import os
+from logging import getLogger
+
+from . import DiscoVPC, DiscoAWS, read_config
+from .disco_aws_util import read_pipeline_file, graceful
+from .disco_logging import configure_logging
+
+PEERING_SECTION = 'peerings'
+BLACK_LIST_S3_CONTAINER = "zookeeper-sync-black-lists"
+BLACK_LIST_BUCKET = 'us-west-2.mclass.sandboxes'
+
+
+@graceful
+def sandbox_command():
+    args = _command_init("Create and populate a sandbox for local development and testing.",
+                         _sandbox_arg_init)
+    _do_sandbox(args)
+
+
+@graceful
+def super_command():
+    parser = argparse.ArgumentParser(description="All the Asiaq Things")
+    _base_arg_init(parser)
+    subcommands = parser.add_subparsers(dest="command")
+    sandbox_parser = subcommands.add_parser(
+        "sandbox", description="Create and populate a sandbox for local development and testing.")
+    _sandbox_arg_init(sandbox_parser)
+    args = parser.parse_args()
+    configure_logging(debug=args.debug)
+
+    if "sandbox" == args.command:
+        _do_sandbox(args)
+
+
+def _command_init(description, argparse_setup_func):
+    parser = argparse.ArgumentParser(description=description)
+    _base_arg_init(parser)
+    argparse_setup_func(parser)
+    args = parser.parse_args()
+    configure_logging(debug=args.debug)
+    return args
+
+
+def _do_sandbox(args):
+    logger = getLogger("asiaq_sandbox")
+    logger.debug("Updating sandbox %s", args.sandbox_name)
+    sandbox_name = args.sandbox_name
+    pipeline_file = os.path.join("sandboxes", sandbox_name, "pipeline.csv")
+
+    aws_config = read_config()
+    hostclass_dicts = read_pipeline_file(pipeline_file)
+
+    _update_blacklist(sandbox_name)
+
+    logger.info("Checking if environment '%s' already exists", sandbox_name)
+    vpc = DiscoVPC.fetch_environment(environment_name=sandbox_name)
+    if vpc:
+        logger.info("Sandbox %s already exists: updating it.", sandbox_name)
+        vpc.update()
+    else:
+        vpc = DiscoVPC(environment_name=sandbox_name,
+                       environment_type='sandbox',
+                       defer_creation=True)
+        peering_found = False
+        peering_prefixes = ("*:sandbox", ("%s:sandbox" % sandbox_name))
+        if vpc.config.has_section(PEERING_SECTION):
+            for peering in vpc.config.options(PEERING_SECTION):
+                peers = vpc.config.get(PEERING_SECTION, peering)
+                logger.debug("Peering config: %s = '%s'", peering, peers)
+                if peers.startswith(peering_prefixes):
+                    peering_found = True
+                    break
+                elif peering.endswith("_99"):
+                    raise Exception("oh this is going to be a problem")
+        else:
+            logger.warn("No peering section found")
+            vpc.config.add_section(PEERING_SECTION)
+        if not peering_found:
+            logger.warn("Need to update peering config for %s", sandbox_name)
+            vpc.config.set(PEERING_SECTION, "connection_99", "%s:sandbox/intranet ci/intranet" % sandbox_name)
+        vpc.create()
+
+    logger.debug("Hostclass definitions for spin-up: %s", hostclass_dicts)
+    DiscoAWS(aws_config, vpc=vpc).spinup(hostclass_dicts)
+
+
+def _update_blacklist(sandbox_name):
+    local_blacklist = os.path.join("sandboxes", sandbox_name, "blacklist")
+    remote_blacklist = os.path.join(BLACK_LIST_S3_CONTAINER, sandbox_name)
+    logger.info("Uploading blacklist file %s to %s", local_blacklist, remote_blacklist)
+    sandbox_s3_bucket = boto3.resource("s3").Bucket(name=BLACK_LIST_BUCKET)
+    sandbox_s3_bucket.upload_file(local_blacklist, remote_blacklist)
+
+
+def _sandbox_arg_init(parser):
+    "Add arg options for the sandbox command, for top-level or subcommand parser."
+    parser.add_argument("sandbox_name")
+
+
+def _base_arg_init(parser):
+    parser.add_argument("--debug", "-d", action='store_const', const=True,
+                        help='Log at DEBUG level.')

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -6,6 +6,8 @@ import argparse
 import os
 from logging import getLogger
 
+import boto3
+
 from . import DiscoVPC, DiscoAWS, read_config
 from .disco_aws_util import read_pipeline_file, graceful
 from .disco_logging import configure_logging
@@ -15,26 +17,123 @@ BLACK_LIST_S3_CONTAINER = "zookeeper-sync-black-lists"
 BLACK_LIST_BUCKET = 'us-west-2.mclass.sandboxes'
 
 
+class CliCommand(object):
+    """
+    Abstract(ish) base class for CLI subcommand drivers.  Common behaviors of all subcommands
+    can be implemented here, but of course there's no real guarantee that they'll be honored.
+
+    Required elements in subclasses:
+
+    * a static field called DESCRIPTION, which will be used in arg parsers
+    * a class or static method called "init_args", which takes an ArgumentParser as its
+      input and adds to it whatever arguments and options this command needs.
+    """
+
+    DESCRIPTION = "This command has no description.  Perhaps you should add one?"
+
+    def __init__(self):
+        self.logger = getLogger(type(self).__name__)
+
+    def run(self, args):
+        raise Exception("This is an abstact method. Override it so this command does something useful!")
+
+    @classmethod
+    def init_args(cls, parser):
+        """
+        Set up any arguments and options for this command/subcommand.
+        """
+        pass
+
+
+class SandboxCommand(CliCommand):
+    """
+    Command to manage sandboxes (currently, just creates, but should get other functions later).
+    """
+
+    DESCRIPTION = "Create and populate a sandbox for local development and testing."
+
+    @classmethod
+    def init_args(cls, parser):
+        parser.add_argument("sandbox_name")
+
+    def run(self, args):
+        self.logger.debug("Updating sandbox %s", args.sandbox_name)
+        sandbox_name = args.sandbox_name
+        pipeline_file = os.path.join("sandboxes", sandbox_name, "pipeline.csv")
+
+        aws_config = read_config()
+        hostclass_dicts = read_pipeline_file(pipeline_file)
+
+        self._update_blacklist(sandbox_name)
+
+        self.logger.info("Checking if environment '%s' already exists", sandbox_name)
+        vpc = DiscoVPC.fetch_environment(environment_name=sandbox_name)
+        if vpc:
+            self.logger.info("Sandbox %s already exists: updating it.", sandbox_name)
+            vpc.update()
+        else:
+            vpc = DiscoVPC(environment_name=sandbox_name,
+                        environment_type='sandbox',
+                        defer_creation=True)
+            peering_found = False
+            peering_prefixes = ("*:sandbox", ("%s:sandbox" % sandbox_name))
+            if vpc.config.has_section(PEERING_SECTION):
+                for peering in vpc.config.options(PEERING_SECTION):
+                    peers = vpc.config.get(PEERING_SECTION, peering)
+                    self.logger.debug("Peering config: %s = '%s'", peering, peers)
+                    if peers.startswith(peering_prefixes):
+                        peering_found = True
+                        break
+                    elif peering.endswith("_99"):
+                        raise Exception("oh this is going to be a problem")
+            else:
+                self.logger.warn("No peering section found")
+                vpc.config.add_section(PEERING_SECTION)
+            if not peering_found:
+                self.logger.warn("Need to update peering config for %s", sandbox_name)
+                vpc.config.set(PEERING_SECTION, "connection_99", "%s:sandbox/intranet ci/intranet" % sandbox_name)
+            vpc.create()
+
+        self.logger.debug("Hostclass definitions for spin-up: %s", hostclass_dicts)
+        DiscoAWS(aws_config, sandbox_name, vpc=vpc).spinup(hostclass_dicts)
+
+
+    def _update_blacklist(self, sandbox_name):
+        local_blacklist = os.path.join("sandboxes", sandbox_name, "blacklist")
+        remote_blacklist = os.path.join(BLACK_LIST_S3_CONTAINER, sandbox_name)
+        self.logger.info("Uploading blacklist file %s to %s", local_blacklist, remote_blacklist)
+        sandbox_s3_bucket = boto3.resource("s3").Bucket(name=BLACK_LIST_BUCKET)
+        sandbox_s3_bucket.upload_file(local_blacklist, remote_blacklist)
+
+
+def _base_arg_init(parser):
+    parser.add_argument("--debug", "-d", action='store_const', const=True,
+                        help='Log at DEBUG level.')
+
+SUBCOMMANDS = {
+    "sandbox": SandboxCommand
+}
+
 @graceful
 def sandbox_command():
-    args = _command_init("Create and populate a sandbox for local development and testing.",
-                         _sandbox_arg_init)
-    _do_sandbox(args)
+    args = _command_init(SandboxCommand.DESCRIPTION, SandboxCommand.init_args)
+    SandboxCommand().run(args)
 
 
 @graceful
 def super_command():
     parser = argparse.ArgumentParser(description="All the Asiaq Things")
     _base_arg_init(parser)
-    subcommands = parser.add_subparsers(dest="command")
-    sandbox_parser = subcommands.add_parser(
-        "sandbox", description="Create and populate a sandbox for local development and testing.")
-    _sandbox_arg_init(sandbox_parser)
+    subcommands = parser.add_subparsers(title="subcommands", dest="command")
+    for subcommand, driver in SUBCOMMANDS.items():
+        sub_parser = subcommands.add_parser(subcommand,
+                                            help=driver.DESCRIPTION, description=driver.DESCRIPTION)
+        driver.init_args(sub_parser)
     args = parser.parse_args()
     configure_logging(debug=args.debug)
 
-    if "sandbox" == args.command:
-        _do_sandbox(args)
+    if args.command:
+        SUBCOMMANDS[args.command]().run(args)
 
 
 def _command_init(description, argparse_setup_func):
@@ -44,64 +143,3 @@ def _command_init(description, argparse_setup_func):
     args = parser.parse_args()
     configure_logging(debug=args.debug)
     return args
-
-
-def _do_sandbox(args):
-    logger = getLogger("asiaq_sandbox")
-    logger.debug("Updating sandbox %s", args.sandbox_name)
-    sandbox_name = args.sandbox_name
-    pipeline_file = os.path.join("sandboxes", sandbox_name, "pipeline.csv")
-
-    aws_config = read_config()
-    hostclass_dicts = read_pipeline_file(pipeline_file)
-
-    _update_blacklist(sandbox_name)
-
-    logger.info("Checking if environment '%s' already exists", sandbox_name)
-    vpc = DiscoVPC.fetch_environment(environment_name=sandbox_name)
-    if vpc:
-        logger.info("Sandbox %s already exists: updating it.", sandbox_name)
-        vpc.update()
-    else:
-        vpc = DiscoVPC(environment_name=sandbox_name,
-                       environment_type='sandbox',
-                       defer_creation=True)
-        peering_found = False
-        peering_prefixes = ("*:sandbox", ("%s:sandbox" % sandbox_name))
-        if vpc.config.has_section(PEERING_SECTION):
-            for peering in vpc.config.options(PEERING_SECTION):
-                peers = vpc.config.get(PEERING_SECTION, peering)
-                logger.debug("Peering config: %s = '%s'", peering, peers)
-                if peers.startswith(peering_prefixes):
-                    peering_found = True
-                    break
-                elif peering.endswith("_99"):
-                    raise Exception("oh this is going to be a problem")
-        else:
-            logger.warn("No peering section found")
-            vpc.config.add_section(PEERING_SECTION)
-        if not peering_found:
-            logger.warn("Need to update peering config for %s", sandbox_name)
-            vpc.config.set(PEERING_SECTION, "connection_99", "%s:sandbox/intranet ci/intranet" % sandbox_name)
-        vpc.create()
-
-    logger.debug("Hostclass definitions for spin-up: %s", hostclass_dicts)
-    DiscoAWS(aws_config, vpc=vpc).spinup(hostclass_dicts)
-
-
-def _update_blacklist(sandbox_name):
-    local_blacklist = os.path.join("sandboxes", sandbox_name, "blacklist")
-    remote_blacklist = os.path.join(BLACK_LIST_S3_CONTAINER, sandbox_name)
-    logger.info("Uploading blacklist file %s to %s", local_blacklist, remote_blacklist)
-    sandbox_s3_bucket = boto3.resource("s3").Bucket(name=BLACK_LIST_BUCKET)
-    sandbox_s3_bucket.upload_file(local_blacklist, remote_blacklist)
-
-
-def _sandbox_arg_init(parser):
-    "Add arg options for the sandbox command, for top-level or subcommand parser."
-    parser.add_argument("sandbox_name")
-
-
-def _base_arg_init(parser):
-    parser.add_argument("--debug", "-d", action='store_const', const=True,
-                        help='Log at DEBUG level.')

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -50,8 +50,6 @@ class SandboxCommand(CliCommand):
 
     DESCRIPTION = "Create and populate a sandbox for local development and testing."
 
-    PEERING_SECTION = 'peerings'
-
     @classmethod
     def init_args(cls, parser):
         parser.add_argument("sandbox_name")
@@ -75,24 +73,6 @@ class SandboxCommand(CliCommand):
             vpc = DiscoVPC(environment_name=sandbox_name,
                            environment_type='sandbox',
                            defer_creation=True)
-            peering_found = False
-            peering_prefixes = ("*:sandbox", ("%s:sandbox" % sandbox_name))
-            if vpc.config.has_section(self.PEERING_SECTION):
-                for peering in vpc.config.options(self.PEERING_SECTION):
-                    peers = vpc.config.get(self.PEERING_SECTION, peering)
-                    self.logger.debug("Peering config: %s = '%s'", peering, peers)
-                    if peers.startswith(peering_prefixes):
-                        peering_found = True
-                        break
-                    elif peering.endswith("_99"):
-                        raise Exception("oh this is going to be a problem")
-            else:
-                self.logger.warn("No peering section found")
-                vpc.config.add_section(self.PEERING_SECTION)
-            if not peering_found:
-                self.logger.warn("Need to update peering config for %s", sandbox_name)
-                vpc.config.set(self.PEERING_SECTION, "connection_99",
-                               "%s:sandbox/intranet ci/intranet" % sandbox_name)
             vpc.create()
 
         self.logger.debug("Hostclass definitions for spin-up: %s", hostclass_dicts)

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -457,7 +457,6 @@ class DiscoVPC(object):
         """Filters used to get only the current VPC when filtering an AWS reply by 'vpc-id'"""
         return create_filters({'vpc-id': [self.vpc['VpcId']]})
 
-
     def update(self, dry_run=False):
         """ Update the existing VPC """
         # Ignoring changes in CIDR for now at least

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ import re
 import sys
 import os.path
 
-
+MODULE_NAME = "disco_aws_automation"
 VERSION_REGEX = re.compile(r"""
     ^__version__\s=\s
     ['"](?P<version>.*?)['"]
 """, re.MULTILINE | re.VERBOSE)
 
-VERSION_FILE = os.path.join("disco_aws_automation", "version.py")
+VERSION_FILE = os.path.join(MODULE_NAME, "version.py")
 
 
 def get_version():
@@ -95,8 +95,10 @@ setup(name='asiaq',
                                             "../jenkins/base_boto.cfg", "../jenkins/base_aws.config"] },
     install_requires=get_requirements(),
     test_suite = 'nose.collector',
-    entry_points="""
-        [paste.app_factory]
-        main=disco_aws_automation:main
-    """,
+    entry_points={
+        'console_scripts': [
+            'asiaq_sandbox = %s.asiaq_cli:sandbox' % MODULE_NAME,
+            'asiaq = %s.asiaq_cli:super_command' % MODULE_NAME
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(name='asiaq',
     test_suite = 'nose.collector',
     entry_points={
         'console_scripts': [
-            'asiaq_sandbox = %s.asiaq_cli:sandbox' % MODULE_NAME,
+            'asiaq_sandbox = %s.asiaq_cli:sandbox_command' % MODULE_NAME,
             'asiaq = %s.asiaq_cli:super_command' % MODULE_NAME
         ]
     },


### PR DESCRIPTION
We currently do all our CLI access through a series of ad-hoc scripts in the `bin` directory, which is somewhat contrary to "standard" python practice (not that standard practice is anything to write home about), and also makes it harder to discover which functions are available.  This PR attempts to start movement toward some combination of the git-style "single supercommand" and the old "lots of individual commands" approaches, using standard setuptools entrypoints in all cases (and using a hopefully-sane extension-point pattern for subcommand creation).