### PR TITLE
Add support for DHCP options updates with NTP server DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,7 +1201,7 @@ to instances on boot with DHCP. We expose a smaller subset of these:
 -   `internal_dns` Primary DNS server
 -   `external_dns` Secondary DNS server
 -   `domain_name` The network domain
--   `ntp_server` Address of NTP server.
+-   `ntp_server` Up to four space separated IP addresses or DNS names of NTP servers.
 
 We use AWS resolver by specifying AmazonProvidedDNS for internal_dns
 and external_dns, alternatively the APIPA address 169.254.169.253 can

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -313,7 +313,7 @@ class DiscoVPC(object):
 
         logger.info("Existing DHCP options: %s", existing_dhcp_options)
 
-        if not dry_run and desired_dhcp_options != existing_dhcp_options:
+        if not dry_run and not self._same_dhcp_options(desired_dhcp_options, existing_dhcp_options):
             created_dhcp_options = self._create_dhcp_options(desired_dhcp_options)
 
             if existing_dhcp_options:
@@ -322,6 +322,15 @@ class DiscoVPC(object):
                                DhcpOptionsId=self.vpc['DhcpOptionsId'])
 
             self.vpc['DhcpOptionsId'] = created_dhcp_options['DhcpOptionsId']
+
+    def _same_dhcp_options(self, desired_options, existing_options):
+        desired_optns_dict = dict([(option_dict['Key'], option_dict['Values'])
+                                   for option_dict in desired_options])
+
+        existing_optns_dict = dict([(option_dict['Key'], option_dict['Values'])
+                                    for option_dict in existing_options])
+
+        return desired_optns_dict == existing_optns_dict
 
     def _get_dhcp_configs(self):
         internal_dns = self.get_config("internal_dns")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.170"
+__version__ = "1.0.171"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mock import MagicMock, patch, PropertyMock
+from mock import MagicMock, patch, PropertyMock, call
 from netaddr import IPSet
 
 from disco_aws_automation import DiscoVPC
@@ -72,7 +72,8 @@ class DiscoVPCTests(unittest.TestCase):
     def test_create_meta_networks_static_dynamic(self, meta_network_mock, config_mock, endpoints_mock):
         """Test creating meta networks with a mix of static and dynamic ip ranges"""
         vpc_mock = {'CidrBlock': '10.0.0.0/28',
-                    'VpcId': 'mock_vpc_id'}
+                    'VpcId': 'mock_vpc_id',
+                    'DhcpOptionsId': 'mock_dhcp_options_id'}
 
         config_mock.return_value = get_mock_config({
             'envtype:auto-vpc-type': {
@@ -135,7 +136,8 @@ class DiscoVPCTests(unittest.TestCase):
         # pylint: disable=C0103
         def _create_vpc_mock(CidrBlock):
             return {'Vpc': {'CidrBlock': CidrBlock,
-                            'VpcId': 'mock_vpc_id'}}
+                            'VpcId': 'mock_vpc_id',
+                            'DhcpOptionsId': 'mock_dhcp_options_id'}}
 
         client_mock = MagicMock()
         client_mock.create_vpc.side_effect = _create_vpc_mock
@@ -147,3 +149,85 @@ class DiscoVPCTests(unittest.TestCase):
 
         possible_vpcs = ['10.0.0.0/26', '10.0.0.64/26', '10.0.0.128/26', '10.0.0.192/26']
         self.assertIn(str(auto_vpc.vpc['CidrBlock']), possible_vpcs)
+
+    # pylint: disable=unused-argument
+    @patch('socket.gethostbyname')
+    @patch('disco_aws_automation.disco_vpc.DiscoRDS')
+    @patch('disco_aws_automation.disco_vpc.DiscoVPCEndpoints')
+    @patch('disco_aws_automation.disco_vpc.DiscoSNS')
+    @patch('disco_aws_automation.disco_vpc.DiscoVPCGateways')
+    @patch('time.sleep')
+    @patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
+    @patch('boto3.client')
+    @patch('boto3.resource')
+    @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork')
+    def test_create_vpc_ntp_names(self, meta_network_mock, boto3_resource_mock,
+                                  boto3_client_mock, config_mock,
+                                  sleep_mock, gateways_mock, sns_mock, endpoints_mock, rds_mock,
+                                  gethostbyname_mock):
+        """Test creating VPC with NTP server names"""
+        # FIXME This needs to mock way too many things. DiscoVPC needs to be refactored
+
+        local_dict = {
+            'dhcp_options_created': False,
+            'ntp_servers_dict': {
+                '0.mock.ntp.server': '100.10.10.10',
+                '1.mock.ntp.server': '100.10.10.11',
+                '2.mock.ntp.server': '100.10.10.12'
+            },
+            'new_mock_dhcp_options_id': 'new_mock_dhcp_options_id',
+            'mock_vpc_id': 'mock_vpc_id'
+        }
+
+        config_mock.return_value = get_mock_config({
+            'envtype:auto-vpc-type': {
+                'ip_space': '10.0.0.0/24',
+                'vpc_cidr_size': '26',
+                'intranet_cidr': 'auto',
+                'tunnel_cidr': 'auto',
+                'dmz_cidr': 'auto',
+                'maintenance_cidr': 'auto',
+                'ntp_server': ' '.join(local_dict['ntp_servers_dict'].keys())
+            }
+        })
+
+        # pylint: disable=C0103
+        def _create_vpc_mock(CidrBlock):
+            return {'Vpc': {'CidrBlock': CidrBlock,
+                            'VpcId': local_dict['mock_vpc_id'],
+                            'DhcpOptionsId': 'mock_dhcp_options_id'}}
+
+        def _create_create_dhcp_mock(**args):
+            local_dict['dhcp_options_created'] = True
+            return {'DhcpOptions': {'DhcpOptionsId': local_dict['new_mock_dhcp_options_id']}}
+
+        def _create_describe_dhcp_mock(**args):
+            if local_dict['dhcp_options_created']:
+                return {'DhcpOptions': [{'DhcpOptionsId': local_dict['new_mock_dhcp_options_id']}]}
+            else:
+                return {'DhcpOptions': []}
+
+        def _create_gethostbyname_mock(hostname):
+            return local_dict['ntp_servers_dict'][hostname]
+
+        client_mock = MagicMock()
+        client_mock.create_vpc.side_effect = _create_vpc_mock
+        client_mock.get_all_zones.return_value = [MagicMock()]
+        client_mock.create_dhcp_options.side_effect = _create_create_dhcp_mock
+        client_mock.describe_dhcp_options.side_effect = _create_describe_dhcp_mock
+        gethostbyname_mock.side_effect = _create_gethostbyname_mock
+        boto3_client_mock.return_value = client_mock
+
+        # Calling method under test
+        auto_vpc = DiscoVPC('auto-vpc', 'auto-vpc-type')
+
+        # Verifying result
+        actual_ntp_servers = [
+            option['Values']
+            for option in client_mock.create_dhcp_options.call_args[1]['DhcpConfigurations']
+            if option['Key'] == 'ntp-servers'][0]
+        self.assertEquals(set(actual_ntp_servers), set(local_dict['ntp_servers_dict'].values()))
+
+        client_mock.associate_dhcp_options.assert_has_calls(
+            [call(DhcpOptionsId=local_dict['new_mock_dhcp_options_id'],
+                  VpcId=local_dict['mock_vpc_id'])])

--- a/test/unit/test_disco_vpc_sg_rules.py
+++ b/test/unit/test_disco_vpc_sg_rules.py
@@ -39,7 +39,8 @@ def _get_vpc_mock(random_subnet_mock=None, meta_network_mock=None, boto3_resourc
     # pylint: disable=C0103
     def _create_vpc_mock(CidrBlock):
         return {'Vpc': {'CidrBlock': CidrBlock,
-                        'VpcId': 'mock_vpc_id'}}
+                        'VpcId': 'mock_vpc_id',
+                        'DhcpOptionsId': 'mock_dhcp_options_id'}}
 
     random_subnet_mock.return_value = IPNetwork('10.0.0.0/26')
 


### PR DESCRIPTION
The PR adds support for DHCP options update during VPC updates. We can now also use DNS names, in addition to IPs and IP offsets, to specify the NTP servers that should go into the DHCP options. Asiqa would resolve the IPs from the DNS names and add them to DHCP options.

Remaining TODO:
- [x] Update asiaq README.md

Here is the accompanying PR for asiaq_astro_config: https://github.com/amplifylitco/asiaq_astro_config/pull/966

Associated story: https://amplify-litco.atlassian.net/browse/AS-397
