### PR TITLE
Remove cleaning all autoscale launch configs during deploy

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -632,9 +632,6 @@ class DiscoAWS(object):
               },
             ...]
         """
-
-        self.autoscale.clean_configs()
-
         # If AMI specified lookup hostclass from AMI else lookup AMI from hostclass
         stage = stage if stage else self.vpc.ami_stage()
         bake = DiscoBake(self._config, self.connection)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.170"
+__version__ = "1.0.171"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
This is more of a pain than a benefit. It tries to delete all ASG LCs
blindly, so most of the time it spends its time silently failing because
the launch configs are in use. It would be nice to make this a batch
operation but that's not possible in the boto API, nor does it seem
particularly easy to find unused launch configs in the boto API.
Additionally, since this was introduced we now properly delete our
launch configs when we're done using them, so it should be less of a
problem now. Even more annoying, this also introduces a race condition
where we might delete a launch config after its been created but before
its been added to an autoscaling group.

In the event that we actually do need to cleanup launch configs, it's
possible to do that via disco_autoscale.py's command line interface.