### PR TITLE
AS-461 Use ELB name rather than id for AWS/ELB alarm dimension

### DIFF
--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -103,7 +103,7 @@ class DiscoAlarmConfig(object):
             return {key: value}
 
         if self.namespace == 'AWS/ELB':
-            return {'LoadBalancerName': DiscoELB.get_elb_id(self.environment, self.hostclass)}
+            return {'LoadBalancerName': DiscoELB.get_elb_name(self.environment, self.hostclass)}
 
         if self.namespace == 'AWS/ES':
             return {

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.172"
+__version__ = "1.0.173"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_alarm.py
+++ b/test/unit/test_disco_alarm.py
@@ -218,7 +218,7 @@ class DiscoAlarmTests(TestCase):
 
         alarm_configs = disco_alarms_config.get_alarms('mhcbanana')
         self.assertEqual(1, len(alarm_configs))
-        self.assertEquals({'LoadBalancerName': DiscoELB.get_elb_id('testenv', 'mhcbanana')},
+        self.assertEquals({'LoadBalancerName': DiscoELB.get_elb_name('testenv', 'mhcbanana')},
                           alarm_configs[0].dimensions)
 
     def test_get_alarm_config_es_metric(self):


### PR DESCRIPTION
Perhaps there's more to it than this, but I thought I would give it a shot.
