### PR TITLE
Automatically create autoscaling policies

### DIFF
--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -208,6 +208,23 @@ def run():
             ]
         )
     elif args.mode == "createpolicy":
+        # Parse out the step adjustments, if provided.
+        if args.step_adjustments:
+            allowed_keys = ['MetricIntervalLowerBound', 'MetricIntervalUpperBound', 'ScalingAdjustment']
+            parsed_steps = []
+            for step in args.step_adjustments:
+                parsed_step = {}
+                for entry in step.split(','):
+                    key, value = entry.split('=', 1)
+                    if key not in allowed_keys:
+                        raise Exception(
+                            'Unable to parse step {0}, key {1} not in {2}'.format(step, key, allowed_keys)
+                        )
+                    parsed_step[key] = value
+                parsed_steps.append(parsed_step)
+        else:
+            parsed_steps = []
+
         autoscale.create_policy(
             group_name=args.group_name,
             policy_name=args.policy_name,
@@ -217,7 +234,7 @@ def run():
             scaling_adjustment=args.scaling_adjustment,
             cooldown=args.cooldown,
             metric_aggregation_type=args.metric_aggregation_type,
-            step_adjustments=args.step_adjustments,
+            step_adjustments=parsed_steps,
             estimated_instance_warmup=args.estimated_instance_warmup
         )
     elif args.mode == "deletepolicy":

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -402,12 +402,12 @@ class DiscoAutoscale(object):
                     'Name': result['PolicyName'],
                     'Type': result['PolicyType'],
                     'Adjustment Type': result['AdjustmentType'],
-                    'Scaling Adjustment': result['ScalingAdjustment'] or '-',
-                    'Step Adjustments': result['StepAdjustments'] or '-',
-                    'Min Adjustment': result.get('MinAdjustmentMagnitude', '-'),
-                    'Cooldown': result.get('Cooldown', '-'),
-                    'Warmup': result.get('EstimatedInstanceWarmup') or '-',
-                    'Alarms': result['Alarms'] or '-'
+                    'Scaling Adjustment': result.get('ScalingAdjustment'),
+                    'Step Adjustments': result.get('StepAdjustments'),
+                    'Min Adjustment': result.get('MinAdjustmentMagnitude'),
+                    'Cooldown': result.get('Cooldown'),
+                    'Warmup': result.get('EstimatedInstanceWarmup'),
+                    'Alarms': result.get('Alarms')
                 })
 
         return policies

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -346,19 +346,102 @@ class DiscoAutoscale(object):
         config_list = self.get_launch_configs(hostclass=hostclass, group_name=group_name)
         return config_list[0] if config_list else None
 
-    def list_policies(self):
+    def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""
-        return throttled_call(self.connection.get_all_policies)
+        arguments = {}
+        if group_name:
+            arguments["AutoScalingGroupName"] = group_name
+        if policy_types:
+            arguments["PolicyTypes"] = policy_types
+        if policy_names:
+            arguments["PolicyNames"] = policy_names
 
-    def create_policy(self, policy_name, group_name, adjustment, cooldown):
-        """Creates an autoscaling policy and associates it with an autoscaling group"""
-        policy = ScalingPolicy(name=policy_name, adjustment_type='ChangeInCapacity',
-                               as_name=group_name, scaling_adjustment=adjustment, cooldown=cooldown)
-        throttled_call(self.connection.create_scaling_policy, policy)
+        results = throttled_call(self.boto3_autoscale.describe_policies, **arguments)
+        next_token = results.get('NextToken')
+
+        # Next token will be an empty string if we're done
+        while next_token:
+            # Get additional results
+            arguments['NextToken'] = next_token
+            additional_results = throttled_call(self.boto3_autoscale.describe_policies, **arguments)
+
+            # Extend the existing results and setup the next token for another iteration
+            results['ScalingPolicies'] += additional_results['ScalingPolicies']
+            next_token = additional_results.get('NextToken')
+
+        policies = []
+
+        for result in results['ScalingPolicies']:
+            group_name = result['AutoScalingGroupName']
+            if group_name.startswith(self.environment_name):
+                # The usage of 'or' is because those keys are present but sometimes contain empty values, so
+                # its needed to use 'or' to make sure that those empty values become our conventionally
+                # accepted '-' empty values.
+                policies.append({
+                    'ASG': group_name,
+                    'Name': result['PolicyName'],
+                    'Type': result['PolicyType'],
+                    'Adjustment Type': result['AdjustmentType'],
+                    'Scaling Adjustment': result['ScalingAdjustment'] or '-',
+                    'Step Adjustments': result['StepAdjustments'] or '-',
+                    'Min Adjustment': result.get('MinAdjustmentMagnitude', '-'),
+                    'Cooldown': result.get('Cooldown', '-'),
+                    'Warmup': result.get('EstimatedInstanceWarmup') or '-',
+                    'Alarms': result['Alarms'] or '-'
+                })
+
+        return policies
+
+    def create_policy(
+        self,
+        group_name,
+        policy_name,
+        policy_type="SimpleScaling",
+        adjustment_type=None,
+        min_adjustment_magnitude=None,
+        scaling_adjustment=None,
+        cooldown=600,
+        metric_aggregation_type=None,
+        step_adjustments=None,
+        estimated_instance_warmup=None
+    ):
+        """
+        Creates a new autoscaling policy, or updates an existing one if the autoscaling group name and
+        policy name already exist. Handles the logic of constructing the correct autoscaling policy request,
+        because not all parameters are required.
+        """
+        arguments = {
+            "AutoScalingGroupName": group_name,
+            "PolicyName": policy_name,
+            "PolicyType": policy_type,
+            "AdjustmentType": adjustment_type
+        }
+
+        if policy_type == "SimpleScaling":
+            arguments["ScalingAdjustment"] = int(scaling_adjustment)
+            arguments["Cooldown"] = int(cooldown)
+            # Special case here, where if we just blindly add min adjustment magnitude we actually get errors
+            # from boto3 unless the adjustment type is as such.
+            if adjustment_type == "PercentChangeInCapacity":
+                arguments["MinAdjustmentMagnitude"] = int(min_adjustment_magnitude)
+        elif policy_type == "StepScaling":
+            arguments["MetricAggregationType"] = metric_aggregation_type
+            arguments["StepAdjustments"] = step_adjustments
+            arguments["EstimatedInstanceWarmup"] = int(estimated_instance_warmup)
+
+        logger.info(
+            "Creating autoscaling policy '%s' in autoscaling group '%s'",
+            policy_name,
+            group_name
+        )
+
+        logger.debug("Autoscaling policy parameters: %s", arguments)
+
+        return throttled_call(self.boto3_autoscale.put_scaling_policy, **arguments)
 
     def delete_policy(self, policy_name, group_name):
         """Deletes an autoscaling policy"""
-        return throttled_call(self.connection.delete_policy, policy_name, group_name)
+        return throttled_call(self.boto3_autoscale.delete_policy, policy_name, group_name)
 
     def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):
         """Deletes all recurring scheduled actions for a hostclass"""

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.173"
+__version__ = "1.0.174"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_autoscale.py
+++ b/test/unit/test_autoscale.py
@@ -181,10 +181,10 @@ class DiscoAutoscaleTests(TestCase):
 
     def test_create_policy_step_scaling(self):
         '''Test create plicy with step scaling'''
-        mock_group_name="mock_group_name"
-        mock_policy_name="mock_policy_name"
-        mock_adjustment_type="mock_adjustment_type"
-        step_scaling="StepScaling"
+        mock_group_name = "mock_group_name"
+        mock_policy_name = "mock_policy_name"
+        mock_adjustment_type = "mock_adjustment_type"
+        step_scaling = "StepScaling"
         scaling_adjustment = 10
         metric_aggregation_type = "Maximum"
         step_adjustments = [{'MetricIntervalLowerBound': 25,

--- a/test/unit/test_autoscale.py
+++ b/test/unit/test_autoscale.py
@@ -158,31 +158,6 @@ class DiscoAutoscaleTests(TestCase):
             tags=ANY, termination_policies=ANY,
             instance_id=ANY)
 
-    @patch("boto.ec2.autoscale.group.AutoScalingGroup")
-    def test_get_group_with_default_scale_policies(self, mock_group_init):
-        '''Test default scale policies are created when creating an autoscaling group'''
-        mock_group = MagicMock()
-        mock_group.name = "mock_group_name"
-        mock_group_init.return_value = mock_group
-
-        self._autoscale._get_group_generator = MagicMock(return_value=[])
-        self._autoscale.get_group(
-            hostclass="mhcdummy",
-            launch_config="launch_config-X", vpc_zone_id="zone-X",
-            min_size=1, max_size=1, desired_size=1)
-
-        expected_calls = [call(AdjustmentType='PercentChangeInCapacity',
-                               AutoScalingGroupName=mock_group.name,
-                               Cooldown=600, MinAdjustmentMagnitude=1,
-                               PolicyName='up', PolicyType='SimpleScaling',
-                               ScalingAdjustment=10),
-                          call(AdjustmentType='PercentChangeInCapacity',
-                               AutoScalingGroupName=mock_group.name,
-                               Cooldown=600, MinAdjustmentMagnitude=1,
-                               PolicyName='down', PolicyType='SimpleScaling',
-                               ScalingAdjustment=-10)]
-        self._mock_boto3_connection.put_scaling_policy.assert_has_calls(expected_calls)
-
     def test_create_policy_simple_scaling(self):
         '''Test create plicy with simple scaling'''
         mock_group_name = "mock_group_name"

--- a/test/unit/test_autoscale.py
+++ b/test/unit/test_autoscale.py
@@ -128,6 +128,175 @@ class DiscoAutoscaleTests(TestCase):
             instance_id=ANY)
 
     @patch("boto.ec2.autoscale.group.AutoScalingGroup")
+    def test_get_group_with_default_scale_policies(self, mock_group_init):
+        '''Test default scale policies are created when creating an autoscaling group'''
+        mock_group = MagicMock()
+        mock_group.name = "mock_group_name"
+        mock_group_init.return_value = mock_group
+
+        self._autoscale._get_group_generator = MagicMock(return_value=[])
+        self._autoscale.get_group(
+            hostclass="mhcdummy",
+            launch_config="launch_config-X", vpc_zone_id="zone-X",
+            min_size=1, max_size=1, desired_size=1)
+
+        expected_calls = [call(AdjustmentType='PercentChangeInCapacity',
+                               AutoScalingGroupName=mock_group.name,
+                               Cooldown=600, MinAdjustmentMagnitude=1,
+                               PolicyName='up', PolicyType='SimpleScaling',
+                               ScalingAdjustment=10),
+                          call(AdjustmentType='PercentChangeInCapacity',
+                               AutoScalingGroupName=mock_group.name,
+                               Cooldown=600, MinAdjustmentMagnitude=1,
+                               PolicyName='down', PolicyType='SimpleScaling',
+                               ScalingAdjustment=-10)]
+        self._mock_boto3_connection.put_scaling_policy.assert_has_calls(expected_calls)
+
+    def test_create_policy_simple_scaling(self):
+        '''Test create plicy with simple scaling'''
+        mock_group_name = "mock_group_name"
+        mock_policy_name = "mock_policy_name"
+        mock_adjustment_type = "PercentChangeInCapacity"
+        min_adjustment_magnitude = 1
+        scaling_adjustment = 10
+
+        self._autoscale.create_policy(group_name=mock_group_name,
+                                      policy_name=mock_policy_name,
+                                      adjustment_type=mock_adjustment_type,
+                                      scaling_adjustment=scaling_adjustment,
+                                      min_adjustment_magnitude=min_adjustment_magnitude)
+
+        self._mock_boto3_connection.put_scaling_policy.assert_called_with(
+            AdjustmentType=mock_adjustment_type,
+            AutoScalingGroupName=mock_group_name,
+            Cooldown=600, MinAdjustmentMagnitude=min_adjustment_magnitude,
+            PolicyName=mock_policy_name,
+            PolicyType='SimpleScaling', ScalingAdjustment=scaling_adjustment)
+
+    def test_create_policy_step_scaling(self):
+        '''Test create plicy with step scaling'''
+        mock_group_name="mock_group_name"
+        mock_policy_name="mock_policy_name"
+        mock_adjustment_type="mock_adjustment_type"
+        step_scaling="StepScaling"
+        scaling_adjustment = 10
+        metric_aggregation_type = "Maximum"
+        step_adjustments = [{'MetricIntervalLowerBound': 25,
+                             'MetricIntervalUpperBound': 75,
+                             'ScalingAdjustment': 30}]
+        estimated_instance_warmup = 123
+
+        self._autoscale.create_policy(group_name=mock_group_name,
+                                      policy_name=mock_policy_name,
+                                      policy_type=step_scaling,
+                                      adjustment_type=mock_adjustment_type,
+                                      scaling_adjustment=scaling_adjustment,
+                                      metric_aggregation_type=metric_aggregation_type,
+                                      step_adjustments=step_adjustments,
+                                      estimated_instance_warmup=estimated_instance_warmup)
+
+        self._mock_boto3_connection.put_scaling_policy.assert_called_with(
+            AdjustmentType=mock_adjustment_type,
+            AutoScalingGroupName=mock_group_name,
+            EstimatedInstanceWarmup=estimated_instance_warmup,
+            MetricAggregationType=metric_aggregation_type,
+            PolicyName=mock_policy_name,
+            PolicyType=step_scaling,
+            StepAdjustments=step_adjustments)
+
+    def test_create_policy_invalid_args(self):
+        '''Test error is raised due to invalid arguments'''
+        # Scaling adjustment must be passed in for simple scaling
+        with self.assertRaises(TypeError):
+            self._autoscale.create_policy(group_name="mock_group_name",
+                                          policy_name="mock_policy_name",
+                                          policy_type="SimpleScaling")
+
+        # Min adjustment magnitude must be passed in if PercentChangeInCapacity is used
+        with self.assertRaises(TypeError):
+            self._autoscale.create_policy(group_name="mock_group_name",
+                                          policy_name="mock_policy_name",
+                                          adjustment_type="PercentChangeInCapacity",
+                                          policy_type="SimpleScaling")
+
+    def test_list_policies(self):
+        '''Test listing ploicies'''
+        group_name = "mock_group_name"
+        policy_types = ["mock_policy_type"]
+        policy_names = ["mock_policy_name"]
+        next_token = "mock_token"
+        mock_policies = [{'AutoScalingGroupName': self.environment_name + 'ASG_name_1',
+                          'PolicyName': 'policy_name_1',
+                          'PolicyType': 'policy_type_1',
+                          'AdjustmentType': 'adjustment_type_1',
+                          'ScalingAdjustment': 'scaling_adjustment_1',
+                          'StepAdjustments': [{'mock_step': 'mock_step_1'}],
+                          'MinAdjustmentMagnitude': 1,
+                          'Cooldown': 200,
+                          'EstimatedInstanceWarmup': 333,
+                          'Alarms': ['mock_alarm_1']},
+                         {'AutoScalingGroupName': self.environment_name + 'ASG_name_2',
+                          'PolicyName': 'policy_name_2',
+                          'PolicyType': 'policy_type_2',
+                          'AdjustmentType': 'adjustment_type_2',
+                          'ScalingAdjustment': 'scaling_adjustment_2',
+                          'StepAdjustments': [{'mock_step': 'mock_step_2'}],
+                          'MinAdjustmentMagnitude': 2,
+                          'Cooldown': 400,
+                          'EstimatedInstanceWarmup': 666,
+                          'Alarms': ['mock_alarm_2']}]
+
+        shared_vars = {'next_token': next_token}
+
+        def _mock_describe_policies(**args):
+            if shared_vars['next_token']:
+                temp_token = shared_vars['next_token']
+                shared_vars['next_token'] = None
+                return {'ScalingPolicies': [mock_policies[0]],
+                        'NextToken': temp_token}
+            else:
+                return {'ScalingPolicies': [mock_policies[1]]}
+
+        self._mock_boto3_connection.describe_policies.side_effect = _mock_describe_policies
+
+        # Calling method under test
+        policies = self._autoscale.list_policies(group_name=group_name,
+                                                 policy_types=policy_types,
+                                                 policy_names=policy_names)
+
+        # Verifying results
+        expected_policies = [{'Warmup': mock_policies[0]['EstimatedInstanceWarmup'],
+                              'Cooldown': mock_policies[0]['Cooldown'],
+                              'ASG': mock_policies[0]['AutoScalingGroupName'],
+                              'Name': mock_policies[0]['PolicyName'],
+                              'Step Adjustments': mock_policies[0]['StepAdjustments'],
+                              'Alarms': mock_policies[0]['Alarms'],
+                              'Adjustment Type': mock_policies[0]['AdjustmentType'],
+                              'Min Adjustment': mock_policies[0]['MinAdjustmentMagnitude'],
+                              'Type': mock_policies[0]['PolicyType'],
+                              'Scaling Adjustment': mock_policies[0]['ScalingAdjustment']},
+                             {'Warmup': mock_policies[1]['EstimatedInstanceWarmup'],
+                              'Cooldown': mock_policies[1]['Cooldown'],
+                              'ASG': mock_policies[1]['AutoScalingGroupName'],
+                              'Name': mock_policies[1]['PolicyName'],
+                              'Step Adjustments': mock_policies[1]['StepAdjustments'],
+                              'Alarms': mock_policies[1]['Alarms'],
+                              'Adjustment Type': mock_policies[1]['AdjustmentType'],
+                              'Min Adjustment': mock_policies[1]['MinAdjustmentMagnitude'],
+                              'Type': mock_policies[1]['PolicyType'],
+                              'Scaling Adjustment': mock_policies[1]['ScalingAdjustment']}]
+        self.assertEqual(expected_policies, policies)
+
+        expected_calls = [call(AutoScalingGroupName=group_name,
+                               PolicyNames=policy_names,
+                               PolicyTypes=policy_types),
+                          call(AutoScalingGroupName=group_name,
+                               NextToken=next_token,
+                               PolicyNames=policy_names,
+                               PolicyTypes=policy_types)]
+        self._mock_boto3_connection.describe_policies.assert_has_calls(expected_calls)
+
+    @patch("boto.ec2.autoscale.group.AutoScalingGroup")
     def test_get_fresh_group_with_none_desired(self, mock_group_init):
         '''Test getting a fresh group with None as max_size'''
         self._autoscale._get_group_generator = MagicMock(return_value=[])


### PR DESCRIPTION
Summary of changes:

- Two simple default autoscaling policies (scaling out & scaling in) will now be created for any autoscaling groups
- Updating code to use boto3 for creating SimpleScaling and StepScaling autoscaling policies
- Adding filter options for the `listpolicies` sub-command

Associated story: https://amplify-litco.atlassian.net/browse/AS-415
