### PR TITLE
Add an option for specifying which domain to use ELB certs for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ Options:
 -   `elb_idle_timeout` [Default=300] Timeout before ELB kills idle connections
 -   `elb_connection_draining` [Default=300] The timeout, in seconds, for requests to unhealthy or de-registering instances to complete before instance is removed from ELB
 -   `elb_cross_zone_load_balancing` [Default=True] If true, the ELB will evenly distribute load across instances regardless of their AZs. If false, the ELB will evenly distribute load across AZs regardless of number of instances in each AZ.
+-   `elb_cert_name` [Optional] ELBs will use HTTPS certs by looking them up by the ELB's CNAME. Use this option to force the ELB to use a cert for a different domain
 
 ### Commands for managing ELB
 List all ELBs in the environment

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -323,6 +323,7 @@ class DiscoAWS(object):
                 connection_draining_timeout=int(self.hostclass_option_default(hostclass,
                                                                               "elb_connection_draining",
                                                                               300)),
+                cert_name=self.hostclass_option_default(hostclass, "elb_cert_name"),
                 testing=testing,
                 tags={
                     "hostclass": hostclass,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.174"
+__version__ = "1.0.175"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -358,7 +358,8 @@ class DiscoAWSTests(TestCase):
                 'hostclass': 'mhcelb',
                 'is_testing': '0'
             },
-            cross_zone_load_balancing=True
+            cross_zone_load_balancing=True,
+            cert_name=None
         )
 
     @patch_disco_aws


### PR DESCRIPTION
ELBs by default pick up a cert by looking in ACM and IAM for a cert with the same name as the CNAME of the ELB. 

Make this configurable by adding a elb_cert_name option for specifying a different cert name

@kelibezhani 