### PR TITLE
Made DiscoAWS nicer about its argument processing.

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -48,6 +48,7 @@ from .exceptions import (
     SmokeTestError,
     CommandError,
     TimeoutError,
+    ProgrammerError,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,9 +59,15 @@ class DiscoAWS(object):
 
     # Too many arguments, but we want to mock a lot of things out, so...
     # pylint: disable=too-many-arguments
-    def __init__(self, config, environment_name, boto2_conn=None, vpc=None, remote_exec=None, storage=None,
-                 autoscale=None, elb=None, log_metrics=None, alarms=None):
-        self.environment_name = environment_name
+    def __init__(self, config, environment_name=None, boto2_conn=None, vpc=None, remote_exec=None,
+                 storage=None, autoscale=None, elb=None, log_metrics=None, alarms=None):
+
+        if not environment_name and not vpc:
+            raise ProgrammerError("Either 'vpc' or 'environment_name' must always be specified.")
+        elif environment_name:
+            self.environment_name = environment_name
+        else:
+            self.environment_name = vpc.environment_name
         self._config = config
         self._project_name = self._config.get("disco_aws", "project_name")
         self._connection = boto2_conn or None  # lazily initialized

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -22,6 +22,11 @@ class EarlyExitException(Exception):
     pass
 
 
+class ProgrammerError(Exception):
+    "An exception state that resulted from a coding error, not an environment error."
+    pass
+
+
 class AccountError(Exception):
     """ Account manipulation error """
     pass

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.176"
+__version__ = "1.0.177"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
When we supply a VPC, the VPC has a name already, and we can read environment_name
from it: updated argument processing to acknowledge that, and added a new exception
type to specifically call out the case where the error is in the calling code, not
the data.