### PR TITLE
Added encryption when creating EBS snapshot and volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,12 +1417,12 @@ which work how you would expect them to work.
 
 There is also a create command that allows you to create the initial
 EBS volume snapshot for a hostclass. This initial volume will not be
-formatted.
+formatted. The volume created and its snapshot will be encrypted by default.
+You can pass option --unencrypted to create an unencrypted EBS volume.
 
 
 Identity and Access Management
 ------------------------------
-
 We make use of IAM for access control to AWS resources quite
 extensively. Despite this we treat the IAM configuration in AWS as
 ephemeral, it gets periodically reloaded from configuration stored in

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -31,8 +31,8 @@ def get_parser():
     parser_create.add_argument('--size', dest='size', required=True, type=int, help='Volume size in GB')
     parser_create.add_argument('--hostclass', dest='hostclass', type=str,
                                help="hostclass that uses this snapshot")
-    parser_create.add_argument('--encrypted', action='store_true',
-                               help='create encrypted volume and snapshot')
+    parser_create.add_argument('--unencrypted', action='store_false',
+                               help='create unencrypted volume and snapshot')
 
     parser_list = subparsers.add_parser('list', help='List all EBS snapshots')
     parser_list.set_defaults(mode='list')
@@ -91,7 +91,7 @@ def run():
 
     aws = DiscoAWS(config, environment_name=environment_name)
     if args.mode == "create":
-        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size, args.encrypted)
+        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size, args.unencrypted)
     elif args.mode == "list":
         for snapshot in aws.disco_storage.get_snapshots(args.hostclasses):
             print("{0:26} {1:13} {2:9} {3} {4:4}".format(

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -31,7 +31,7 @@ def get_parser():
     parser_create.add_argument('--size', dest='size', required=True, type=int, help='Volume size in GB')
     parser_create.add_argument('--hostclass', dest='hostclass', type=str,
                                help="hostclass that uses this snapshot")
-    parser_create.add_argument('--unencrypted', action='store_false',
+    parser_create.add_argument('--unencrypted', action='store_true',
                                help='create unencrypted volume and snapshot')
 
     parser_list = subparsers.add_parser('list', help='List all EBS snapshots')
@@ -91,7 +91,7 @@ def run():
 
     aws = DiscoAWS(config, environment_name=environment_name)
     if args.mode == "create":
-        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size, args.unencrypted)
+        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size, not args.unencrypted)
     elif args.mode == "list":
         for snapshot in aws.disco_storage.get_snapshots(args.hostclasses):
             print("{0:26} {1:13} {2:9} {3} {4:4}".format(

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -31,6 +31,8 @@ def get_parser():
     parser_create.add_argument('--size', dest='size', required=True, type=int, help='Volume size in GB')
     parser_create.add_argument('--hostclass', dest='hostclass', type=str,
                                help="hostclass that uses this snapshot")
+    parser_create.add_argument('--encrypted', action='store_true',
+                               help='create encrypted volume and snapshot')
 
     parser_list = subparsers.add_parser('list', help='List all EBS snapshots')
     parser_list.set_defaults(mode='list')
@@ -89,7 +91,7 @@ def run():
 
     aws = DiscoAWS(config, environment_name=environment_name)
     if args.mode == "create":
-        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size)
+        aws.disco_storage.create_ebs_snapshot(args.hostclass, args.size, args.encrypted)
     elif args.mode == "list":
         for snapshot in aws.disco_storage.get_snapshots(args.hostclasses):
             print("{0:26} {1:13} {2:9} {3} {4:4}".format(

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -254,7 +254,12 @@ class DiscoAWS(object):
                 ephemeral_disk_count=self.disco_storage.get_ephemeral_disk_count(instance_type))]
         else:
             block_device_mappings = [old_config.block_device_mappings]
-        return block_device_mappings
+
+        if is_ebs_encrypted(instance_type):
+            return block_device_mappings
+        else:
+            raise RuntimeError('Instance type {} does not support \
+                                encrypted EBS volumes'.format(instance_type))
 
     def create_floating_interfaces(self, meta_network, hostclass):
         """Creates any floating interfaces as needed"""

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -262,7 +262,7 @@ class DiscoAWS(object):
         else:
             block_device_mappings = [old_config.block_device_mappings]
 
-        if is_ebs_encrypted(instance_type):
+        if self.disco_storage.is_ebs_encrypted(instance_type) or old_config:
             return block_device_mappings
         else:
             raise RuntimeError('Instance type {} does not support \

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -261,12 +261,7 @@ class DiscoAWS(object):
                 ephemeral_disk_count=self.disco_storage.get_ephemeral_disk_count(instance_type))]
         else:
             block_device_mappings = [old_config.block_device_mappings]
-
-        if self.disco_storage.is_ebs_encrypted(instance_type) or old_config:
-            return block_device_mappings
-        else:
-            raise RuntimeError('Instance type {} does not support \
-                                encrypted EBS volumes'.format(instance_type))
+        return block_device_mappings
 
     def create_floating_interfaces(self, meta_network, hostclass):
         """Creates any floating interfaces as needed"""

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -233,7 +233,7 @@ class DiscoStorage(object):
 
         return bdm
 
-    def create_ebs_snapshot(self, hostclass, size, encrypted=False):
+    def create_ebs_snapshot(self, hostclass, size, encrypted=True):
         """
         Creates an EBS snapshot in the first listed availability zone.
 

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -117,51 +117,6 @@ EBS_OPTIMIZED = [
     "r3.4xlarge"
 ]
 
-EBS_ENCRYPTED = [
-    "m3.medium",
-    "m3.large",
-    "m3.xlarge",
-    "m3.2xlarge",
-    "m4.large",
-    "m4.xlarge",
-    "m4.2xlarge",
-    "m4.4xlarge",
-    "m4.10xlarge",
-    "m4.16xlarge",
-    "t2.nano",
-    "t2.micro",
-    "t2.small",
-    "t2.medium",
-    "c4.large",
-    "c4.xlarge",
-    "c4.2xlarge",
-    "c4.4xlarge",
-    "c4.8xlarge",
-    "c3.large",
-    "c3.xlarge",
-    "c3.2xlarge",
-    "c3.4xlarge",
-    "r1.8xlarge",
-    "r3.large",
-    "r3.xlarge",
-    "r3.2xlarge",
-    "r3.4xlarge",
-    "r3.8xlarge",
-    "x1.16xlarge",
-    "d2.xlarge",
-    "d2.2xlarge",
-    "d2.4xlarge",
-    "d2.8xlarge",
-    "i2.xlarge",
-    "i2.2xlarge",
-    "i2.4xlarge",
-    "g2.2xlarge",
-    "g2.8xlarge",
-    "p2.xlarge",
-    "p2.8xlarge"
-]
-
-
 class DiscoStorage(object):
     """
     Wrapper class to handle all DiscoAWS storage functions
@@ -174,10 +129,6 @@ class DiscoStorage(object):
     def is_ebs_optimized(self, instance_type):
         """Returns true if the instance type is EBS Optimized"""
         return instance_type in EBS_OPTIMIZED
-
-    def is_ebs_encrypted(self, instance_type):
-        """Returns true if the instance type supports encrypted EBS"""
-        return instance_type in EBS_ENCRYPTED
 
     def get_ephemeral_disk_count(self, instance_type):
         """Returns number of ephemeral disks available for each instance type"""
@@ -207,8 +158,7 @@ class DiscoStorage(object):
     def create_snapshot_bdm(self, snapshot, iops):
         """Create a Block Device Mapping for a Snapshot"""
         device = boto.ec2.blockdevicemapping.EBSBlockDeviceType(
-            snapshot_id=snapshot.id, size=snapshot.volume_size,
-            delete_on_termination=True, encrypted=True)
+            snapshot_id=snapshot.id, size=snapshot.volume_size, delete_on_termination=True)
         if iops:
             device.volume_type = PROVISIONED_IOPS_VOLUME_TYPE
             device.iops = iops
@@ -282,7 +232,7 @@ class DiscoStorage(object):
 
         return bdm
 
-    def create_ebs_snapshot(self, hostclass, size):
+    def create_ebs_snapshot(self, hostclass, size, encrypted):
         """
         Creates an EBS snapshot in the first listed availability zone.
 
@@ -291,6 +241,7 @@ class DiscoStorage(object):
 
         :param hostclass:  The hostclass that uses this snapshot
         :param size:  The size of the snapshot in GB
+        :param encrypted:  Boolean whether snapshot is encrypted
         """
         zones = throttled_call(self.connection.get_all_zones)
         if not zones:
@@ -307,8 +258,8 @@ class DiscoStorage(object):
                     logger.error("Couldn't destroy temporary volume %s", volume.id)
 
             try:
-                volume = throttled_call(self.connection.create_volume,
-                                        size=size, zone=zone, encrypted=True)
+                volume = throttled_call(self.connection.create_volume, size=size,
+                                        zone=zone, encrypted=encrypted)
                 logger.info("Created temporary volume %s in zone %s.", volume.id, zone.name)
                 wait_for_state(volume, 'available', state_attr='status')
                 snapshot = volume.create_snapshot()

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -265,7 +265,6 @@ class DiscoStorage(object):
                 snapshot = volume.create_snapshot()
                 snapshot.add_tag('hostclass', hostclass)
                 snapshot.add_tag('env', self.environment_name)
-                snapshot.add_tag('encrypted', encrypted)
                 logger.info("Created snapshot %s from volume %s.", snapshot.id, volume.id)
             except Exception:
                 _destroy_volume(volume)

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -117,6 +117,7 @@ EBS_OPTIMIZED = [
     "r3.4xlarge"
 ]
 
+
 class DiscoStorage(object):
     """
     Wrapper class to handle all DiscoAWS storage functions
@@ -232,7 +233,7 @@ class DiscoStorage(object):
 
         return bdm
 
-    def create_ebs_snapshot(self, hostclass, size, encrypted):
+    def create_ebs_snapshot(self, hostclass, size, encrypted=False):
         """
         Creates an EBS snapshot in the first listed availability zone.
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.175"
+__version__ = "1.0.178"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.177"
+__version__ = "1.0.178"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.0.178"
+__version__ = "1.1.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_storage.py
+++ b/test/unit/test_disco_storage.py
@@ -18,7 +18,7 @@ class DiscoStorageTests(TestCase):
     def setUp(self):
         self.storage = DiscoStorage(environment_name='unittestenv')
 
-    def _create_snapshot(self, hostclass, env, encrypted=False):
+    def _create_snapshot(self, hostclass, env, encrypted=True):
         client = boto3.client('ec2')
         volume = client.create_volume(
             Size=100,
@@ -108,23 +108,23 @@ class DiscoStorageTests(TestCase):
 
     @mock_ec2
     def test_create_ebs_snapshot(self):
-        """Test creating a snapshot"""
+        """Test creating a snapshot (encrypted by default)"""
         self.storage.create_ebs_snapshot('mhcfoo', 250)
 
         snapshots = self.storage.get_snapshots('mhcfoo')
 
         self.assertEquals(250, snapshots[0].volume_size)
-        self.assertEquals(False, snapshots[0].encrypted)
+        self.assertEquals(True, snapshots[0].encrypted)
 
     @mock_ec2
-    def test_create_ebs_snapshot_encrypted(self):
-        """Test creating an encrypted snapshot"""
-        self.storage.create_ebs_snapshot('mhcfoo', 250, True)
+    def test_create_ebs_snapshot_unencrypted(self):
+        """Test creating an unencrypted snapshot"""
+        self.storage.create_ebs_snapshot('mhcfoo', 250, False)
 
         snapshots = self.storage.get_snapshots('mhcfoo')
 
         self.assertEquals(250, snapshots[0].volume_size)
-        self.assertEquals(True, snapshots[0].encrypted)
+        self.assertEquals(False, snapshots[0].encrypted)
 
     @mock_ec2
     def test_take_snapshot(self):

--- a/test/unit/test_disco_storage.py
+++ b/test/unit/test_disco_storage.py
@@ -72,7 +72,7 @@ class DiscoStorageTests(TestCase):
         """Test getting all of the snapshots for an environment"""
         self._create_snapshot('foo', 'unittestenv')
         self._create_snapshot('foo', 'otherenv')
-        self._create_snapshot('foo', 'encyptedenv', True)
+        self._create_snapshot('foo', 'encryptedenv', True)
 
         self.assertEquals(1, len(self.storage.get_snapshots()))
 
@@ -97,9 +97,9 @@ class DiscoStorageTests(TestCase):
         self._create_snapshot('foo', 'otherenv')
         self._create_snapshot('foo', 'otherenv')
         self._create_snapshot('foo', 'otherenv')
-        self._create_snapshot('foo', 'encyptedenv', True)
-        self._create_snapshot('foo', 'encyptedenv', True)
-        self._create_snapshot('foo', 'encyptedenv', True)
+        self._create_snapshot('foo', 'encryptedenv', True)
+        self._create_snapshot('foo', 'encryptedenv', True)
+        self._create_snapshot('foo', 'encryptedenv', True)
 
         self.storage.cleanup_ebs_snapshots(keep_last_n=2)
 


### PR DESCRIPTION
By default, all additional volumes created will continue to be unencrypted to maintain backward compatibility. Creating an encrypted volume requires passing the option **--encrypted** when using `disco_snapshot.py`.

Currently all instance types provided by AWS support encrypted EBS volumes, therefore we are not adding a check on instance type when assigning an encrypted EBS volume. 

The following types of data are encrypted:

* Data at rest inside the volume
* All data moving between the volume and the instance
* All snapshots created from the volume

Snapshots that are taken from encrypted volumes are automatically encrypted. Volumes that are created from encrypted snapshots are also automatically encrypted.

To change the encryption state of your data, from unencrypted to encrypted, and vice-versa, follow instructions in the following link: [Changing the Encryption State of Your Data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_considerations)