### PR TITLE
Simple port forwarding support in disco_ssh.py

### DIFF
--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -44,7 +44,7 @@ class DiscoSSH(object):
         self.env = self.args["--env"] or self.config.get("disco_aws", "default_environment")
         self.pick_instance = self.args['--first']
         configure_logging(args["--debug"])
-        self.tunnel = self.args["--tunnel"]
+        self.tunnel = self.expand_tunnel(self.args["--tunnel"])
 
     def is_ip(self, string):
         """Returns True if the given string is an IPv4 address"""
@@ -130,6 +130,19 @@ class DiscoSSH(object):
             raise EasyExit("No direct route to host and no jump host in {}".format(self.env))
 
         return [jump_host_ip, instance.private_ip_address]
+
+    def expand_tunnel(self, tunnel):
+        """
+        Expands the host specified in the tunnel string if necessary.  If the hostname provided is
+        not a full url, it is assumed to be a database name, and a full url is constructed from the
+        database name based on the environment.
+        """
+        lport, host, rport = tunnel.split(":")
+
+        if "." not in host:
+            host = self.env + "-" + host + ".aws.wgen.net"
+
+        return lport + ":" + host + ":" + rport
 
     def build_ssh_cmd(self, ips):
         """

--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -134,8 +134,8 @@ class DiscoSSH(object):
     def expand_tunnel(self, tunnel):
         """
         Expands the host specified in the tunnel string if necessary.  If the hostname provided is
-        not a full url, it is assumed to be a database name, and a full url is constructed from the
-        database name based on the environment.
+        not a full url, it is checked to see if it's a database name or a hostclass name, and if so
+        a full url is constructed from the short name based on the environment.
         """
         lport, host, rport = tunnel.split(":")
 

--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -140,7 +140,10 @@ class DiscoSSH(object):
         lport, host, rport = tunnel.split(":")
 
         if "." not in host:
-            host = self.env + "-" + host + ".aws.wgen.net"
+            if host.startswith("mhc"):
+                host = host + "-" + self.env + ".aws.wgen.net"
+            elif host.endswith("db"):
+                host = self.env + "-" + host + ".aws.wgen.net"
 
         return lport + ":" + host + ":" + rport
 

--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -10,11 +10,11 @@ Variables:
      <host>                 A hostname/hostclass/instance substring
 
 Options:
-     -h --help                  Show this screen
-     --debug                    Log in debug level
-     --env ENV                  Environment to operate in
-     --first                    In case of multiple matching instances, connect to the first instead of failing
-     --tunnel LPORT:HOST:RPORT  Establish a secure connection between a local port and a port on a remote host   
+     -h --help              Show this screen
+     --debug                Log in debug level
+     --env ENV              Environment to operate in
+     --first                In case of multiple matching instances, connect to the first instead of failing
+     --tunnel PRT:HOST:PRT  Establish a secure connection between a local port and a port on a remote host
 """
 
 import logging

--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -157,7 +157,7 @@ class DiscoSSH(object):
                 raise EasyExit("No jump host in {}".format(self.env))
             ips = [jump_host_ip]
 
-        else:    
+        else:
             ips = self.detect_best_route(host)
 
         cmd = self.build_ssh_cmd(ips)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.1"
+__version__ = "1.1.12"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
New option:
```
    --tunnel LOCALPORT:REMOTEPORT
```
Example:
```
    disco_ssh.py --env sb-sandbox --tunnel 9000:1521 sb-sandbox-txdb.aws.wgen.net
```
which creates a tunnel from localhost:9000 to sb-sandbox-txdb.aws.wgen.net:1521 via the jumpbox.

The tunnel is created in the background.  To close the tunnel, kill the background ssh process.

