### PR TITLE
Fixed bug that caused pylint checks to silently not execute.

### DIFF
--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -55,7 +55,7 @@ def copy_tree(source, destination, hostclasses=None, dryrun=False):
 
 def _copy_files(source, destination, hostclasses, dryrun=False):
     # TODO Break this into smaller functions
-    # pylint: disable=R0914
+    # pylint: disable=R0914,R0912
 
     for path, dirnames, filenames in os.walk(source):
         destpath = os.path.join(destination, os.path.relpath(path, source))

--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -143,8 +143,8 @@ def parse_arguments():
     return parser.parse_args()
 
 
-# R0912 Allow more than 12 branches so we can parse a lot of commands..
-# pylint: disable=R0912
+# R0912 Allow more than 12 branches and more than 15 local variables so we can have shoddily structured code
+# pylint: disable=R0912, R0914
 def run():
     """Parses command line and dispatches the commands"""
     config = read_config()

--- a/bin/disco_aws.py
+++ b/bin/disco_aws.py
@@ -253,6 +253,7 @@ def get_preferred_private_ip(instance):
 
 
 def parse_ssm_parameters(parameters):
+    "Parse a list of key=value strings into a dictionary of the form {key: [value]}"
     # Borrow the AWS CLI syntax of splitting the name of the parameter and it's value on '='
     keys_to_values = [parameter.split('=', 1) for parameter in parameters]
     # SSM actually supports multiple values for a given key, but we probably don't need that so let's not

--- a/bin/disco_aws.py
+++ b/bin/disco_aws.py
@@ -13,9 +13,8 @@ from dateutil import parser as dateutil_parser
 from disco_aws_automation import DiscoAWS, DiscoBake, DiscoSSM, read_config
 from disco_aws_automation.resource_helper import TimeoutError
 from disco_aws_automation.disco_logging import configure_logging
-from disco_aws_automation.disco_aws_util import graceful, EasyExit, read_pipeline_file
+from disco_aws_automation.disco_aws_util import graceful, read_pipeline_file
 from disco_aws_automation.exceptions import SmokeTestError
-import logging
 
 
 # R0912 Allow more than 12 branches so we can parse a lot of commands..

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -423,7 +423,7 @@ class DiscoAutoscale(object):
             metric_aggregation_type=None,
             step_adjustments=None,
             estimated_instance_warmup=None
-        ):
+    ):
         """
         Creates a new autoscaling policy, or updates an existing one if the autoscaling group name and
         policy name already exist. Handles the logic of constructing the correct autoscaling policy request,

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -8,7 +8,6 @@ import boto.ec2
 import boto.ec2.autoscale
 import boto.ec2.autoscale.launchconfig
 import boto.ec2.autoscale.group
-from boto.ec2.autoscale.policy import ScalingPolicy
 from boto.exception import BotoServerError
 from botocore.exceptions import WaiterError
 import boto3
@@ -413,18 +412,18 @@ class DiscoAutoscale(object):
         return policies
 
     def create_policy(
-        self,
-        group_name,
-        policy_name,
-        policy_type="SimpleScaling",
-        adjustment_type=None,
-        min_adjustment_magnitude=None,
-        scaling_adjustment=None,
-        cooldown=600,
-        metric_aggregation_type=None,
-        step_adjustments=None,
-        estimated_instance_warmup=None
-    ):
+            self,
+            group_name,
+            policy_name,
+            policy_type="SimpleScaling",
+            adjustment_type=None,
+            min_adjustment_magnitude=None,
+            scaling_adjustment=None,
+            cooldown=600,
+            metric_aggregation_type=None,
+            step_adjustments=None,
+            estimated_instance_warmup=None
+        ):
         """
         Creates a new autoscaling policy, or updates an existing one if the autoscaling group name and
         policy name already exist. Handles the logic of constructing the correct autoscaling policy request,

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -38,7 +38,6 @@ from .disco_remote_exec import DiscoRemoteExec
 from .disco_storage import DiscoStorage
 from .disco_vpc import DiscoVPC
 from .resource_helper import (
-    TimeoutError,
     keep_trying,
     wait_for_state,
 )

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -63,9 +63,9 @@ def graceful(func):
     wrapper is actually extremely simple.
     """
     @wraps(func)
-    def run_func():
+    def _run_func():
         run_gracefully(func)
-    return run_func
+    return _run_func
 
 
 def read_pipeline_file(pipeline_file):

--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -289,7 +289,7 @@ class DiscoElasticsearch(object):
 
             if desired_elasticsearch_name in all_elasticsearch_names:
                 try:
-                    del(desired_es_config["ElasticsearchVersion"])
+                    del desired_es_config["ElasticsearchVersion"]
                     logging.debug("Ignoring ElasticsearchVersion specification on update")
                 except KeyError:
                     pass

--- a/disco_aws_automation/disco_ssm.py
+++ b/disco_aws_automation/disco_ssm.py
@@ -1,6 +1,7 @@
 """
 Manage AWS SSM document creation and execution
 """
+from __future__ import print_function
 import os
 import logging
 import time
@@ -14,7 +15,6 @@ from . import read_config
 from .resource_helper import throttled_call, wait_for_state_boto3
 from .exceptions import TimeoutError
 from .disco_creds import DiscoS3Bucket
-from .resource_helper import throttled_call
 from .disco_constants import (
     DEFAULT_CONFIG_SECTION
 )
@@ -155,8 +155,9 @@ class DiscoSSM(object):
                 instance_ids
             )
             time.sleep(5)
-        raise TimeoutException(
-            "Timed out waiting for execution of document '%s' against instances %s after '%s' seconds".format(
+        raise TimeoutError(
+            "Timed out waiting for execution of document '{0}' against instances {1} after '{2}' "
+            "seconds".format(
                 document_name,
                 instance_ids,
                 timeout
@@ -239,12 +240,12 @@ class DiscoSSM(object):
         if stdout_keys:
             stdout = bucket.get_key(stdout_keys[0]).decode('utf-8').strip()
         else:
-            stdout = '-'
+            stdout = u'-'
 
         if stderr_keys:
             stderr = bucket.get_key(stderr_keys[0]).decode('utf-8').strip()
         else:
-            stderr = '-'
+            stderr = u'-'
 
         plugin_output = {
             'name': command_plugin['Name'],

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -6,14 +6,14 @@ import logging
 
 from boto.exception import EC2ResponseError
 import boto3
-
-from . import read_config
-from .resource_helper import tag2dict, create_filters, throttled_call
-from .exceptions import VPCPeeringSyntaxError
 # FIXME: Disabling complaint about relative-import. This seems to be the only
 # way that works for unit tests.
 # pylint: disable=W0403
 import disco_vpc
+
+from . import read_config
+from .resource_helper import tag2dict, create_filters, throttled_call
+from .exceptions import VPCPeeringSyntaxError
 from .disco_constants import VPC_CONFIG_FILE
 
 logger = logging.getLogger(__name__)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tasks/lint/merge_config.py
+++ b/tasks/lint/merge_config.py
@@ -32,6 +32,7 @@ def main(args):
     # the configobj pads things with spaces that pylint doesn't like
     file_data = re.sub("\s=\s", "=", file_data)
     file_data = re.sub(",\s", ",", file_data)
+    file_data = re.sub('=""', "=", file_data)
 
     with open(merged_config_file, 'w') as f:
         f.write(file_data)

--- a/tasks/lint/pylintrc
+++ b/tasks/lint/pylintrc
@@ -87,9 +87,6 @@ comment=no
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
 # Disco: Allowing the use of 'map' and 'filter'
 bad-functions=apply,input
@@ -204,10 +201,6 @@ additional-builtins=
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/test/unit/test_autoscale.py
+++ b/test/unit/test_autoscale.py
@@ -254,7 +254,7 @@ class DiscoAutoscaleTests(TestCase):
 
         shared_vars = {'next_token': next_token}
 
-        def _mock_describe_policies(**args):
+        def _mock_describe_policies(**_kwargs):
             if shared_vars['next_token']:
                 temp_token = shared_vars['next_token']
                 shared_vars['next_token'] = None

--- a/test/unit/test_disco_elasticsearch.py
+++ b/test/unit/test_disco_elasticsearch.py
@@ -268,7 +268,7 @@ class DiscoElastiSearchTests(TestCase):
         self._es.update(elasticsearch_name)
         self.assertEquals(len(self._es.list()), 1)
         new_domain_config = self._es._describe_es_domain(self._es.get_domain_name(elasticsearch_name))
-        del(original_domain_config['DomainStatus']['ElasticsearchVersion'])
+        del original_domain_config['DomainStatus']['ElasticsearchVersion']
         self.assertEquals(original_domain_config.viewitems(), new_domain_config.viewitems())
 
     def test_create_and_delete_a_domain(self):

--- a/test/unit/test_disco_elb.py
+++ b/test/unit/test_disco_elb.py
@@ -44,7 +44,7 @@ class DiscoELBTests(TestCase):
         self.acm.get_certificate_arn.return_value = TEST_CERTIFICATE_ARN_ACM
         self.iam.get_certificate_arn.return_value = TEST_CERTIFICATE_ARN_IAM
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, R0914
     def _create_elb(self, hostclass=TEST_HOSTCLASS, public=False, tls=False,
                     instance_protocol='HTTP', instance_port=80,
                     elb_protocols='HTTP', elb_ports='80',
@@ -214,7 +214,7 @@ class DiscoELBTests(TestCase):
         )
 
     @mock_elb
-    def test_get_elb_with_tls_and_cert_name_not_found(self):
+    def test_get_elb_cert_name_not_found(self):
         """Test creation an ELB with TLS and a specific cert name that doesn't exist"""
         elb_client = self.disco_elb.elb_client
         elb_client.create_load_balancer = MagicMock(wraps=elb_client.create_load_balancer)
@@ -327,7 +327,7 @@ class DiscoELBTests(TestCase):
         )
 
     @mock_elb
-    def test_get_elb_without_cross_zone_load_balancing(self):
+    def test_get_elb_no_cross_zone_lb(self):
         """Test creating ELB without cross zone load balancing"""
         client = self.disco_elb.elb_client
         client.modify_load_balancer_attributes = MagicMock(wraps=client.modify_load_balancer_attributes)

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -199,6 +199,7 @@ class RDSTests(unittest.TestCase):
     @patch('disco_aws_automation.disco_rds.DiscoRoute53')
     @patch('disco_aws_automation.disco_rds.DiscoS3Bucket', return_value=_get_bucket_mock())
     def test_clone_uses_latest_snapshot(self, bucket_mock, r53_mock, vpc_mock):
+        """test that an RDS clone uses the latest available snapshot"""
         self.rds._get_db_instance = MagicMock(return_value=None)
         self.rds.config_rds = get_mock_config({
             'some-env-db-name': {

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -150,7 +150,7 @@ class DiscoVPCTests(unittest.TestCase):
         possible_vpcs = ['10.0.0.0/26', '10.0.0.64/26', '10.0.0.128/26', '10.0.0.192/26']
         self.assertIn(str(auto_vpc.vpc['CidrBlock']), possible_vpcs)
 
-    # pylint: disable=unused-argument
+    # pylint: disable=unused-argument,too-many-arguments,too-many-locals
     @patch('socket.gethostbyname')
     @patch('disco_aws_automation.disco_vpc.DiscoRDS')
     @patch('disco_aws_automation.disco_vpc.DiscoVPCEndpoints')
@@ -219,7 +219,7 @@ class DiscoVPCTests(unittest.TestCase):
         boto3_client_mock.return_value = client_mock
 
         # Calling method under test
-        auto_vpc = DiscoVPC('auto-vpc', 'auto-vpc-type')
+        DiscoVPC('auto-vpc', 'auto-vpc-type')
 
         # Verifying result
         actual_ntp_servers = [


### PR DESCRIPTION
Fixed the merge_config.py utility so that it merges our non-existent local config with the upstream config correctly, allowing pylint to run and show that we have many pylint errors.

Also removed deprecated no-op configuration from the standard pylintrc, because that seemed like a reasonable thing to do (both changes also pushed upstream to the template).

NOTE: this is now presumably going to fail the PR build.  Other people are invited (nay, implored) to update this branch with fixes to the various broken things that the build previously failed to catch.

TODO:
* [x] asiaq.disco_aws_util
* [x] asiaq.disco_autoscale
* [x] asiaq.disco_elasticsearch
* [x] asiaq.disco_aws
* [x] asiaq.disco_vpc_peerings
* [x] asiaq.disco_ssm
* [x] bin.acfg1
* [x] bin.disco_autoscale
* [x] bin.disco_aws
* [x] test.unit.test_autoscale
* [x] test.unit.test_disco_elb
* [x] test.unit.test_disco_elasticsearch
* [x] test.unit.test_disco_ssm
* [x] test.unit.test_disco_vpc
