### PR TITLE
Updated config-parsing code, and moved it out of package root.

### DIFF
--- a/bin/disco_accounts.py
+++ b/bin/disco_accounts.py
@@ -39,8 +39,9 @@ from getpass import getpass
 
 from docopt import docopt
 
-from disco_aws_automation import S3AccountBackend, DiscoS3Bucket, DiscoVPC, read_config
+from disco_aws_automation import S3AccountBackend, DiscoS3Bucket, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_alarms.py
+++ b/bin/disco_alarms.py
@@ -31,8 +31,9 @@ import sys
 
 from docopt import docopt
 
-from disco_aws_automation import DiscoSNS, read_config
+from disco_aws_automation import DiscoSNS
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 from disco_aws_automation.disco_alarm_config import DiscoAlarmsConfig
 from disco_aws_automation.disco_alarm import DiscoAlarm

--- a/bin/disco_app_auth.py
+++ b/bin/disco_app_auth.py
@@ -5,8 +5,9 @@ Command line interface for updating application authorization tokens
 
 import argparse
 
-from disco_aws_automation import DiscoAppAuth, DiscoVPC, read_config
+from disco_aws_automation import DiscoAppAuth, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -9,8 +9,9 @@ import sys
 
 from collections import defaultdict
 
-from disco_aws_automation import DiscoAutoscale, read_config
+from disco_aws_automation import DiscoAutoscale
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_aws.py
+++ b/bin/disco_aws.py
@@ -10,9 +10,10 @@ from ConfigParser import NoOptionError
 
 from dateutil import parser as dateutil_parser
 
-from disco_aws_automation import DiscoAWS, DiscoBake, DiscoSSM, read_config
+from disco_aws_automation import DiscoAWS, DiscoBake, DiscoSSM
 from disco_aws_automation.resource_helper import TimeoutError
 from disco_aws_automation.disco_logging import configure_logging
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_aws_util import graceful, read_pipeline_file
 from disco_aws_automation.exceptions import SmokeTestError
 

--- a/bin/disco_chaos.py
+++ b/bin/disco_chaos.py
@@ -8,7 +8,8 @@ import argparse
 
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
-from disco_aws_automation import DiscoChaos, read_config
+from disco_aws_automation.disco_config import read_config
+from disco_aws_automation import DiscoChaos
 
 
 def get_parser():

--- a/bin/disco_creds.py
+++ b/bin/disco_creds.py
@@ -8,8 +8,9 @@ import argparse
 import sys
 import getpass
 
-from disco_aws_automation import DiscoS3Bucket, DiscoVPC, read_config
+from disco_aws_automation import DiscoS3Bucket, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_deploy.py
+++ b/bin/disco_deploy.py
@@ -51,9 +51,9 @@ import sys
 
 from docopt import docopt
 
-from disco_aws_automation import (DiscoAWS, DiscoAutoscale, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC,
-                                  read_config)
+from disco_aws_automation import DiscoAWS, DiscoAutoscale, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_dynamodb.py
+++ b/bin/disco_dynamodb.py
@@ -10,7 +10,7 @@ import decimal
 import datetime
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation import DiscoDynamoDB
-from disco_aws_automation import read_config
+from disco_aws_automation.disco_config import read_config
 
 
 class DecimalEncoder(json.JSONEncoder):

--- a/bin/disco_elasticache.py
+++ b/bin/disco_elasticache.py
@@ -23,8 +23,9 @@ Options:
 from __future__ import print_function
 import sys
 from docopt import docopt
-from disco_aws_automation import DiscoElastiCache, DiscoVPC, DiscoAWS, read_config
+from disco_aws_automation import DiscoElastiCache, DiscoVPC, DiscoAWS
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_elb.py
+++ b/bin/disco_elb.py
@@ -22,10 +22,10 @@ from __future__ import print_function
 import sys
 from docopt import docopt
 
-from disco_aws_automation import DiscoELB, DiscoVPC
+from disco_aws_automation import DiscoELB, DiscoVPC, DiscoAWS
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
-from disco_aws_automation import DiscoAWS, read_config
+from disco_aws_automation.disco_config import read_config
 
 
 def run():

--- a/bin/disco_log_metrics.py
+++ b/bin/disco_log_metrics.py
@@ -27,8 +27,9 @@ Commands:
 from __future__ import print_function
 from docopt import docopt
 
-from disco_aws_automation import read_config, DiscoLogMetrics
+from disco_aws_automation import DiscoLogMetrics
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -8,7 +8,7 @@ import argparse
 import sys
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_vpc import DiscoVPC
-from disco_aws_automation import read_config
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -5,8 +5,9 @@ Command line tool for dealing with ELB snapshots
 from __future__ import print_function
 import argparse
 
-from disco_aws_automation import DiscoAWS, read_config
+from disco_aws_automation import DiscoAWS
 from disco_aws_automation.disco_aws_util import run_gracefully
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
 
 

--- a/bin/disco_ssh.py
+++ b/bin/disco_ssh.py
@@ -23,7 +23,8 @@ import socket
 
 from docopt import docopt
 
-from disco_aws_automation import DiscoAWS, read_config
+from disco_aws_automation import DiscoAWS
+from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_aws_util import run_gracefully, EasyExit
 from disco_aws_automation.disco_logging import configure_logging
 

--- a/disco_aws_automation/__init__.py
+++ b/disco_aws_automation/__init__.py
@@ -1,37 +1,5 @@
 ''' For package documentation, see README '''
 
-from os import getenv
-from os.path import join, exists
-from ConfigParser import ConfigParser
-
-
-ASIAQ_CONFIG = getenv("ASIAQ_CONFIG", ".")
-DEFAULT_CONFIG_FILE = "disco_aws.ini"
-
-
-def read_config(config_file=DEFAULT_CONFIG_FILE):
-    """
-    Normalize and read in a config file (defaulting to "disco_aws.ini").
-    """
-    real_config_file = normalize_path(config_file)
-    config = ConfigParser()
-    config.read(real_config_file)
-    return config
-
-
-def normalize_path(path):
-    """
-    If ASIAQ_CONFIG is set prepend it to path, otherwise just return path.
-    """
-    normalized_path = join(ASIAQ_CONFIG, path)
-    if exists(normalized_path):
-        return normalized_path
-    else:
-        raise RuntimeError("Config path not found: %s" % normalized_path)
-
-
-# The following imports are at the bottom to avoid a circular import when importing read_config
-# pylint: disable=wrong-import-position
 from .disco_acm import DiscoACM
 from .disco_autoscale import DiscoAutoscale
 from .disco_aws import DiscoAWS

--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -8,7 +8,8 @@ from ConfigParser import ConfigParser
 
 from boto.ec2.cloudwatch import MetricAlarm
 
-from . import read_config, DiscoAutoscale
+from . import DiscoAutoscale
+from .disco_config import read_config
 from .exceptions import AlarmConfigError
 from .disco_aws_util import is_truthy
 from .disco_elb import DiscoELB

--- a/disco_aws_automation/disco_app_auth.py
+++ b/disco_aws_automation/disco_app_auth.py
@@ -12,7 +12,8 @@ import random
 from hashlib import sha512
 from base64 import standard_b64encode
 
-from disco_aws_automation import DiscoS3Bucket, normalize_path
+from . import DiscoS3Bucket
+from .disco_config import normalize_path
 from .resource_helper import check_written_s3
 from .exceptions import MissingAppAuthError, AppAuthKeyNotFoundError
 

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -11,16 +11,9 @@ from boto.exception import EC2ResponseError
 from botocore.exceptions import ClientError
 
 from .disco_constants import YES_LIST
+from .exceptions import EasyExit
 
 logger = getLogger(__name__)
-
-
-class EasyExit(Exception):
-    """
-    Raise this exception to exit your program with a log message and a non-zero status, but no stack trace
-    (assuming you are running it with run_gracefully).
-    """
-    pass
 
 
 def get_tag_value(tag_list, key):
@@ -97,6 +90,8 @@ def run_gracefully(main_function):
     except EasyExit as msg:
         logger.error(str(msg))
         sys.exit(1)
+    except EarlyExitException as non_error_msg:
+        logger.info(str(non_error_msg))
     except KeyboardInterrupt:
         # swallow the exception unless we turned on debugging, in which case
         # we might want to know what infinite loop we were stuck in

--- a/disco_aws_automation/disco_aws_util.py
+++ b/disco_aws_automation/disco_aws_util.py
@@ -11,7 +11,7 @@ from boto.exception import EC2ResponseError
 from botocore.exceptions import ClientError
 
 from .disco_constants import YES_LIST
-from .exceptions import EasyExit
+from .exceptions import EasyExit, EarlyExitException
 
 logger = getLogger(__name__)
 

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -17,7 +17,7 @@ import boto.exception
 import dateutil.parser
 from pytz import UTC
 
-from . import normalize_path, read_config
+from .disco_config import normalize_path, read_config
 from .resource_helper import wait_for_sshable, keep_trying, wait_for_state
 from .disco_storage import DiscoStorage
 from .disco_remote_exec import DiscoRemoteExec, SSH_DEFAULT_OPTIONS
@@ -419,8 +419,6 @@ class DiscoBake(object):
             wait_for_state(image, u'available',
                            int(self.hc_option_default(hostclass, "ami_available_wait_time", "600")))
             logger.info("Created %s AMI %s", image_name, image_id)
-        except EarlyExitException as early_exit:
-            logger.info(str(early_exit))
         except:
             logger.exception("Snap shot failed. See trace below.")
             raise

--- a/disco_aws_automation/disco_config.py
+++ b/disco_aws_automation/disco_config.py
@@ -5,12 +5,13 @@ Package for reading configurations out of standard locations.
 import os
 import os.path
 from ConfigParser import ConfigParser
-import argparse
+from logging import getLogger
 
 from .exceptions import AsiaqConfigError
 
 ASIAQ_CONFIG = os.getenv("ASIAQ_CONFIG", ".")
 DEFAULT_CONFIG_FILE = "disco_aws.ini"
+_LOG = getLogger(__name__)
 
 
 def read_config(*path_components, **kwargs):
@@ -25,9 +26,8 @@ def read_config(*path_components, **kwargs):
     all_components = list(path_components)  # copy the list to avoid aliasing
     if 'config_file' in kwargs:
         all_components.append(kwargs['config_file'])
-    if not all_components:
-        all_components
-    real_config_file = normalize_path(all_components)
+    real_config_file = normalize_path(all_components or DEFAULT_CONFIG_FILE)
+    _LOG.debug("Reading config file %s", real_config_file)
     config = ConfigParser()
     config.read(real_config_file)
     return config

--- a/disco_aws_automation/disco_config.py
+++ b/disco_aws_automation/disco_config.py
@@ -1,0 +1,61 @@
+"""
+Package for reading configurations out of standard locations.
+"""
+
+import os
+import os.path
+from ConfigParser import ConfigParser
+import argparse
+
+from .exceptions import AsiaqConfigError
+
+ASIAQ_CONFIG = os.getenv("ASIAQ_CONFIG", ".")
+DEFAULT_CONFIG_FILE = "disco_aws.ini"
+
+
+def read_config(*path_components, **kwargs):
+    """
+    Normalize and read in a config file (defaulting to "disco_aws.ini").
+
+    For call compatibility, we allow either an arglist or a named argument.  If you are sufficiently
+    over-clever to use both the config_file keyword argument and an argument list, you should get
+    a reasonable behavior (the keyword arg will be the file, the other parts will be the directory path),
+    but seriously why?
+    """
+    all_components = list(path_components)  # copy the list to avoid aliasing
+    if 'config_file' in kwargs:
+        all_components.append(kwargs['config_file'])
+    if not all_components:
+        all_components
+    real_config_file = normalize_path(all_components)
+    config = ConfigParser()
+    config.read(real_config_file)
+    return config
+
+
+def normalize_path(*path_components):
+    """
+    Prepend ASIAQ_CONFIG (or ".") to the list of path components, and join them into a path string.
+    If the resulting path points to a nonexistent file, raise AsiaqConfigError, otherwise return the path.
+
+    Takes either an arglist or a single list as an argument.
+
+    NOTE: directories and symlinks "exist" for purposes of this function.
+    """
+    real_components = (
+        path_components[0] if path_components and isinstance(path_components[0], (tuple, list))
+        else path_components)
+    normalized_path = os.path.join(ASIAQ_CONFIG, *real_components)
+    if os.path.exists(normalized_path):
+        return normalized_path
+    else:
+        raise AsiaqConfigError("Config path not found: %s" % normalized_path)
+
+
+def open_normalized(*path_components, **kwargs):
+    """
+    Find a file in the configuration directory and open it.  Non-keyword arguments
+    are treated as path segments; keyword arguments are passed through to the "open" function.
+    """
+    real_path = normalize_path(path_components)
+    return open(real_path, **kwargs)

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -8,7 +8,8 @@ import sys
 from ConfigParser import NoOptionError, NoSectionError
 from boto.exception import EC2ResponseError
 
-from . import DiscoBake, read_config
+from . import DiscoBake
+from .disco_config import read_config
 from .exceptions import (
     TimeoutError,
     MaintenanceModeError,

--- a/disco_aws_automation/disco_dynamodb.py
+++ b/disco_aws_automation/disco_dynamodb.py
@@ -6,7 +6,7 @@ import json
 
 import boto3
 
-from . import normalize_path
+from .disco_config import normalize_path
 from .exceptions import DynamoDBEnvironmentError
 from .resource_helper import throttled_call
 

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -11,7 +11,7 @@ import boto3
 import botocore
 from semantic_version import Spec, Version
 
-from . import normalize_path
+from .disco_config import normalize_path
 from .disco_route53 import DiscoRoute53
 from .exceptions import CommandError
 from .resource_helper import throttled_call

--- a/disco_aws_automation/disco_elasticsearch.py
+++ b/disco_aws_automation/disco_elasticsearch.py
@@ -10,7 +10,7 @@ import boto3
 
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import BotoCoreError
-from . import read_config
+from .disco_config import read_config
 from .disco_route53 import DiscoRoute53
 from .resource_helper import throttled_call
 from .disco_aws_util import is_truthy

--- a/disco_aws_automation/disco_elasticsearch_archive.py
+++ b/disco_aws_automation/disco_elasticsearch_archive.py
@@ -18,7 +18,8 @@ from elasticsearch import (
 )
 from requests_aws4auth import AWS4Auth
 
-from . import read_config, DiscoElasticsearch, DiscoIAM
+from . import DiscoElasticsearch, DiscoIAM
+from .disco_config import read_config
 from .disco_aws_util import is_truthy
 from .exceptions import TimeoutError
 from .disco_constants import ES_CONFIG_FILE

--- a/disco_aws_automation/disco_iam.py
+++ b/disco_aws_automation/disco_iam.py
@@ -15,7 +15,7 @@ import boto.iam
 import boto3
 import botocore
 
-from . import read_config
+from .disco_config import read_config
 from .disco_aws_util import is_truthy
 
 logger = logging.getLogger(__name__)

--- a/disco_aws_automation/disco_log_metrics.py
+++ b/disco_aws_automation/disco_log_metrics.py
@@ -7,7 +7,7 @@ from ConfigParser import ConfigParser
 
 import boto3
 
-from . import normalize_path
+from .disco_config import normalize_path
 from .resource_helper import throttled_call
 
 logger = logging.getLogger(__name__)

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -3,13 +3,12 @@ RDS Module. Can be used to perform various RDS operations
 """
 
 from __future__ import print_function
-import os
 import datetime
 import logging
 import time
 import sys
 import threading
-from ConfigParser import ConfigParser, NoOptionError, NoSectionError
+from ConfigParser import NoOptionError, NoSectionError
 
 import boto3
 import botocore

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -15,7 +15,7 @@ import boto3
 import botocore
 import pytz
 
-from . import read_config, ASIAQ_CONFIG
+from .disco_config import read_config, ASIAQ_CONFIG
 from .disco_alarm import DiscoAlarm
 from .disco_aws_util import is_truthy
 from .disco_creds import DiscoS3Bucket

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -15,7 +15,7 @@ import boto3
 import botocore
 import pytz
 
-from .disco_config import read_config, ASIAQ_CONFIG
+from .disco_config import read_config
 from .disco_alarm import DiscoAlarm
 from .disco_aws_util import is_truthy
 from .disco_creds import DiscoS3Bucket
@@ -373,20 +373,14 @@ class RDS(threading.Thread):
         self.create_db_parameter_group(db_parameter_group_name, db_parameter_group_family)
 
         # Extract the Custom Values from the config file
-        custom_param_file = os.path.join(ASIAQ_CONFIG,
-                                         'rds', 'engine_specific',
-                                         '{0}.ini'.format(database_name))
-
-        if os.path.isfile(custom_param_file):
-            custom_config = ConfigParser()
-            custom_config.read(custom_param_file)
-            try:
-                custom_db_params = custom_config.items(env_name)
-                logger.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
-                            db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
-                self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
-            except NoSectionError:
-                logger.info("Using Default RDS param")
+        try:
+            custom_config = read_config('rds', 'engine_specific', '{0}.ini'.format(database_name))
+            custom_db_params = custom_config.items(env_name)
+            logger.info("Updating RDS db_parameter_group %s (family: %s, #params: %s)",
+                        db_parameter_group_name, db_parameter_group_family, len(custom_db_params))
+            self.modify_db_parameter_group(db_parameter_group_name, custom_db_params)
+        except (NoSectionError, AsiaqConfigError):
+            logger.info("Using Default RDS param")
 
     def update_cluster(self):
         """

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -21,7 +21,7 @@ from .disco_aws_util import is_truthy
 from .disco_creds import DiscoS3Bucket
 from .disco_route53 import DiscoRoute53
 from .disco_vpc_sg_rules import DiscoVPCSecurityGroupRules
-from .exceptions import TimeoutError, RDSEnvironmentError
+from .exceptions import TimeoutError, RDSEnvironmentError, AsiaqConfigError
 from .resource_helper import keep_trying, tag2dict, throttled_call
 
 logger = logging.getLogger(__name__)

--- a/disco_aws_automation/disco_ssm.py
+++ b/disco_aws_automation/disco_ssm.py
@@ -10,7 +10,7 @@ from ConfigParser import NoOptionError
 import boto3
 from botocore.exceptions import ClientError
 
-from . import read_config
+from .disco_config import read_config
 from .resource_helper import throttled_call, wait_for_state_boto3
 from .exceptions import TimeoutError
 from .disco_creds import DiscoS3Bucket

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -18,7 +18,7 @@ from netaddr import IPNetwork, IPSet, IPAddress
 from netaddr.core import AddrFormatError
 
 from disco_aws_automation.network_helper import calc_subnet_offset
-from . import normalize_path
+from .disco_config import normalize_path
 
 from .disco_alarm import DiscoAlarm
 from .disco_alarm_config import DiscoAlarmsConfig

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -7,7 +7,7 @@ import logging
 from boto.exception import EC2ResponseError
 import boto3
 
-from . import read_config
+from .disco_config import read_config
 from .resource_helper import tag2dict, create_filters, throttled_call
 from .exceptions import VPCPeeringSyntaxError
 # FIXME: Disabling complaint about relative-import. This seems to be the only

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -18,12 +18,32 @@ class ExpectedTimeoutError(TimeoutError):
 
 
 class EarlyExitException(Exception):
-    "Special no-op Exception class for non-error early exits from the program."
+    """
+    Special no-op Exception class for non-error early exits from the program.
+
+    Contrast with EasyExit, which is intended to terminate with a non-zero status (if the @graceful
+    decoration is used).
+    """
+    pass
+
+
+class EasyExit(Exception):
+    """
+    Raise this exception to exit your program with a log message and a non-zero status, but no stack trace
+    (assuming you are running it with run_gracefully).
+
+    Contrast with EarlyExitException, which is intended to short-circuit out with a non-error status.
+    """
     pass
 
 
 class ProgrammerError(Exception):
     "An exception state that resulted from a coding error, not an environment error."
+    pass
+
+
+class AsiaqConfigError(EasyExit):
+    "An exception that results from a config file not being found (no stack trace needed)."
     pass
 
 

--- a/disco_aws_automation/hostclass_templating.py
+++ b/disco_aws_automation/hostclass_templating.py
@@ -6,7 +6,7 @@ Right now only substitutes the template name and hostclass
 from string import Template  # pylint: disable=W0402
 import os
 
-from . import normalize_path
+from .disco_config import normalize_path
 from .disco_constants import HOSTCLASS_PREFIX
 
 TEMPLATES = [

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_config.py
+++ b/test/unit/test_disco_config.py
@@ -1,0 +1,68 @@
+"""Tests for disco_config utilities."""
+
+from unittest import TestCase
+from mock import patch, Mock
+import os
+
+from disco_aws_automation import disco_config, exceptions
+
+
+@patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
+class TestStuff(TestCase):
+    ""
+
+    @patch('os.path.exists')
+    def test__normalized_path__no_such_path__exception(self, path_exists):
+        path_exists.return_value = False
+        self.assertRaises(exceptions.AsiaqConfigError, disco_config.normalize_path, "yabba", "dabba")
+        path_exists.assert_called_once_with("FAKE_CONFIG_DIR/yabba/dabba")
+
+    @patch('os.path.exists')
+    def test__normalized_path__path_exists__path_returned(self, path_exists):
+        path_exists.return_value = True
+        found = disco_config.normalize_path("yabba", "dabba")
+        self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
+        path_exists.assert_called_once_with(found)
+
+    @patch('os.path.exists')
+    def test__normalized_path__list_arg__correct_path_returned(self, path_exists):
+        path_exists.return_value = True
+        found = disco_config.normalize_path(["yabba", "dabba"])
+        self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
+        path_exists.assert_called_once_with(found)
+
+    @patch('os.path.exists', Mock(return_value=True))
+    @patch('disco_aws_automation.disco_config.ConfigParser')
+    def test__read_config__named_arg__expected_behavior(self, configparser_constructor):
+        parser = Mock()
+        configparser_constructor.return_value = parser
+        parsed = disco_config.read_config(config_file="Foobar")
+        self.assertIs(parsed, parser)
+        parser.read.assert_called_once_with("FAKE_CONFIG_DIR/Foobar")
+
+    @patch('os.path.exists', Mock(return_value=True))
+    @patch('disco_aws_automation.disco_config.ConfigParser')
+    def test__read_config__arglist__expected_behavior(self, configparser_constructor):
+        parser = Mock()
+        configparser_constructor.return_value = parser
+        parsed = disco_config.read_config("foo", "bar")
+        self.assertIs(parsed, parser)
+        parser.read.assert_called_once_with("FAKE_CONFIG_DIR/foo/bar")
+
+    @patch('os.path.exists', Mock(return_value=True))
+    @patch('disco_aws_automation.disco_config.ConfigParser')
+    def test__read_config__arg_combo__named_arg_last(self, configparser_constructor):
+        parser = Mock()
+        configparser_constructor.return_value = parser
+        parsed = disco_config.read_config("foo", "bar", config_file="baz.ini")
+        self.assertIs(parsed, parser)
+        parser.read.assert_called_once_with("FAKE_CONFIG_DIR/foo/bar/baz.ini")
+
+    @patch('os.path.exists', Mock(return_value=True))
+    @patch('disco_aws_automation.disco_config.open')
+    def test__open_normalized__passthrough_successful(self, open_mock):
+        expected = Mock()
+        open_mock.return_value = expected
+        found = disco_config.open_normalized("path", "to", "file", mode="moody")
+        self.assertIs(expected, found)
+        open_mock.assert_called_once_with("FAKE_CONFIG_DIR/path/to/file", mode="moody")

--- a/test/unit/test_disco_config.py
+++ b/test/unit/test_disco_config.py
@@ -2,14 +2,13 @@
 
 from unittest import TestCase
 from mock import patch, Mock
-import os
 
 from disco_aws_automation import disco_config, exceptions
 
 
 @patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
-class TestStuff(TestCase):
-    ""
+class TestDiscoConfig(TestCase):
+    "Test functions for finding, opening and reading configuration files in ASIAQ_CONFIG."
 
     @patch('os.path.exists')
     def test__normalized_path__no_such_path__exception(self, path_exists):
@@ -30,6 +29,15 @@ class TestStuff(TestCase):
         found = disco_config.normalize_path(["yabba", "dabba"])
         self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
         path_exists.assert_called_once_with(found)
+
+    @patch('os.path.exists', Mock(return_value=True))
+    @patch('disco_aws_automation.disco_config.ConfigParser')
+    def test__read_config__no_arg__default_behavior(self, configparser_constructor):
+        parser = Mock()
+        configparser_constructor.return_value = parser
+        parsed = disco_config.read_config()
+        self.assertIs(parsed, parser)
+        parser.read.assert_called_once_with("FAKE_CONFIG_DIR/disco_aws.ini")
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.ConfigParser')

--- a/test/unit/test_disco_config.py
+++ b/test/unit/test_disco_config.py
@@ -7,32 +7,49 @@ from disco_aws_automation import disco_config, exceptions
 
 
 @patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
-class TestDiscoConfig(TestCase):
-    "Test functions for finding, opening and reading configuration files in ASIAQ_CONFIG."
+class TestNormalizePath(TestCase):
+    """Tests for the normalize_path utility function."""
 
     @patch('os.path.exists')
-    def test__normalized_path__no_such_path__exception(self, path_exists):
+    def test__no_such_path__exception(self, path_exists):
+        "Normalize path finds no such path - exception."
         path_exists.return_value = False
         self.assertRaises(exceptions.AsiaqConfigError, disco_config.normalize_path, "yabba", "dabba")
         path_exists.assert_called_once_with("FAKE_CONFIG_DIR/yabba/dabba")
 
     @patch('os.path.exists')
-    def test__normalized_path__path_exists__path_returned(self, path_exists):
+    def test__path_exists__path_returned(self, path_exists):
+        "Normalize path thinks the path exists - path is returned"
         path_exists.return_value = True
         found = disco_config.normalize_path("yabba", "dabba")
         self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
         path_exists.assert_called_once_with(found)
 
     @patch('os.path.exists')
-    def test__normalized_path__list_arg__correct_path_returned(self, path_exists):
+    def test__list_arg__correct_path_returned(self, path_exists):
+        "Normalize path works with a single list-typed argument"
         path_exists.return_value = True
         found = disco_config.normalize_path(["yabba", "dabba"])
         self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
         path_exists.assert_called_once_with(found)
 
+    @patch('os.path.exists')
+    def test__tuple_arg__correct_path_returned(self, path_exists):
+        "Normalize path with a single tuple-typed argument"
+        path_exists.return_value = True
+        found = disco_config.normalize_path(("yabba", "dabba"))
+        self.assertEquals(found, "FAKE_CONFIG_DIR/yabba/dabba")
+        path_exists.assert_called_once_with(found)
+
+
+@patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
+class TestReadConfig(TestCase):
+    """Tests for the read_config utility function."""
+
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.ConfigParser')
-    def test__read_config__no_arg__default_behavior(self, configparser_constructor):
+    def test__no_arg__default_behavior(self, configparser_constructor):
+        "Default argument for read_config works"
         parser = Mock()
         configparser_constructor.return_value = parser
         parsed = disco_config.read_config()
@@ -41,7 +58,8 @@ class TestDiscoConfig(TestCase):
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.ConfigParser')
-    def test__read_config__named_arg__expected_behavior(self, configparser_constructor):
+    def test__named_arg__expected_behavior(self, configparser_constructor):
+        "Keyword argument for read_config works"
         parser = Mock()
         configparser_constructor.return_value = parser
         parsed = disco_config.read_config(config_file="Foobar")
@@ -50,7 +68,8 @@ class TestDiscoConfig(TestCase):
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.ConfigParser')
-    def test__read_config__arglist__expected_behavior(self, configparser_constructor):
+    def test__arglist__expected_behavior(self, configparser_constructor):
+        "Unnamed argument list for read_config works"
         parser = Mock()
         configparser_constructor.return_value = parser
         parsed = disco_config.read_config("foo", "bar")
@@ -59,16 +78,23 @@ class TestDiscoConfig(TestCase):
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.ConfigParser')
-    def test__read_config__arg_combo__named_arg_last(self, configparser_constructor):
+    def test__arg_combo__named_arg_last(self, configparser_constructor):
+        "Combined keyword and listed args for read_config work"
         parser = Mock()
         configparser_constructor.return_value = parser
         parsed = disco_config.read_config("foo", "bar", config_file="baz.ini")
         self.assertIs(parsed, parser)
         parser.read.assert_called_once_with("FAKE_CONFIG_DIR/foo/bar/baz.ini")
 
+
+@patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
+class TestOpenNormalized(TestCase):
+    """Tests for the open_normalized utility function."""
+
     @patch('os.path.exists', Mock(return_value=True))
     @patch('disco_aws_automation.disco_config.open')
-    def test__open_normalized__passthrough_successful(self, open_mock):
+    def test__path_exists__passthrough_successful(self, open_mock):
+        "Valid path for open_normalized - 'open' called"
         expected = Mock()
         open_mock.return_value = expected
         found = disco_config.open_normalized("path", "to", "file", mode="moody")


### PR DESCRIPTION
Added a new disco_config package that can hold read_config, normalize_path and related code, removed those from the package root, updated all importers, and added a new Exception type to explicitly handle missing or bad configuration.

Concurrently, straightened out some weirdness about similarly-named but differently-behaved exceptions in different subpackages.

NOTE FOR REVIEWERS: 32 out of 36 modified files are just rearranging imports, since I moved something important.