### PR TITLE
Add wildcard configuration for vpc name when peering VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,25 @@ customer has two networks to route via IGW:
 
     dmz_vgw_routes=10.123.0.0/16 1.124.0.0/16
 
+#### VPC Peering
+
+Peering can be configured between VPCs to enable communication between them. 
+The syntax for the peering config is `vpc_name[:vpc_type]/metanetwork vpc_name[:vpc_type]/metanetwork`.
+`vpc_name` can either be the name of an existing VPC or `*` to match any VPC of a certain type. 
+
+For example:
+
+    [peerings]
+    connection_1=example-vpc:sandbox/tunnel ci/intranet
+    connection_2=*:sandbox/tunnel ci/intranet
+    
+The keys for the peering config don't matter except that they must be unique and start with `connection_`
+    
+The `connection_1` configuration will create a peering connection from the `example-vpc` to a vpc named `ci`. 
+Security groups will be updated to allow traffic from `example-vpc`'s tunnel metanetwork to `ci`'s intranet metanetwork.
+    
+The `connection_2` configuration will create peering connections to any VPC of type `sandbox` to `ci`
+
 ### Instance Network Options
 
 #### Instance IP Addresses

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -5,7 +5,6 @@ environments, and between an environment and the internet.  In particular non-VP
 """
 
 import logging
-import random
 
 import socket
 import time
@@ -13,11 +12,12 @@ from ConfigParser import ConfigParser
 
 from boto.exception import EC2ResponseError
 import boto3
+from botocore.exceptions import ClientError
 
-from netaddr import IPNetwork, IPSet, IPAddress
+from netaddr import IPNetwork, IPAddress
 from netaddr.core import AddrFormatError
 
-from disco_aws_automation.network_helper import calc_subnet_offset
+from disco_aws_automation.network_helper import calc_subnet_offset, get_random_free_subnet
 from . import normalize_path
 
 from .disco_alarm import DiscoAlarm
@@ -35,9 +35,7 @@ from .disco_vpc_gateways import DiscoVPCGateways
 from .disco_vpc_peerings import DiscoVPCPeerings
 from .disco_vpc_sg_rules import DiscoVPCSecurityGroupRules
 from .resource_helper import (tag2dict, create_filters, keep_trying, throttled_call)
-from .exceptions import (
-    MultipleVPCsForVPCNameError, VPCConfigError, VPCEnvironmentError,
-    VPCNameNotFound)
+from .exceptions import (VPCConfigError, VPCEnvironmentError)
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +69,7 @@ class DiscoVPC(object):
         self.elb = DiscoELB(vpc=self)
         self.disco_vpc_sg_rules = DiscoVPCSecurityGroupRules(vpc=self, boto3_ec2=self.boto3_ec2)
         self.disco_vpc_gateways = DiscoVPCGateways(vpc=self, boto3_ec2=self.boto3_ec2)
-        self.disco_vpc_peerings = DiscoVPCPeerings(vpc=self, boto3_ec2=self.boto3_ec2)
+        self.disco_vpc_peerings = DiscoVPCPeerings(boto3_ec2=self.boto3_ec2)
         self.elasticache = DiscoElastiCache(vpc=self)
         self.log_metrics = DiscoLogMetrics(environment=environment_name)
 
@@ -241,7 +239,7 @@ class DiscoVPC(object):
         for network_name, cidr in networks.iteritems():
             # pick a random ip range if there isn't one configured for the network in the config
             if cidr == 'auto':
-                cidr = DiscoVPC.get_random_free_subnet(self.vpc['CidrBlock'], meta_network_size, used_cidrs)
+                cidr = get_random_free_subnet(self.vpc['CidrBlock'], meta_network_size, used_cidrs)
 
                 if not cidr:
                     raise VPCConfigError("Can't create metanetwork %s. No subnets available", network_name)
@@ -305,7 +303,7 @@ class DiscoVPC(object):
                 Filters=[{'Name': 'tag:Name', 'Values': [self.environment_name]}]
             )['DhcpOptions'][0]['DhcpConfigurations']
 
-        except IndexError:
+        except (IndexError, ClientError):
             existing_dhcp_options = []
 
         for option in existing_dhcp_options:
@@ -393,7 +391,7 @@ class DiscoVPC(object):
             # get the cidr for all other VPCs so we can avoid overlapping with other VPCs
             occupied_network_cidrs = [vpc['cidr_block'] for vpc in self.list_vpcs()]
 
-            vpc_cidr = DiscoVPC.get_random_free_subnet(ip_space, int(vpc_size), occupied_network_cidrs)
+            vpc_cidr = get_random_free_subnet(ip_space, int(vpc_size), occupied_network_cidrs)
 
             if vpc_cidr is None:
                 raise VPCConfigError('Cannot create VPC %s. No subnets available' % self.environment_name)
@@ -424,7 +422,7 @@ class DiscoVPC(object):
         self.disco_vpc_gateways.update_nat_gateways_and_routes()
         self.disco_vpc_endpoints.update()
         self.configure_notifications()
-        self.disco_vpc_peerings.update_peering_connections()
+        self.disco_vpc_peerings.update_peering_connections(self)
         self.rds.update_all_clusters_in_vpc(parallel=True)
 
     def configure_notifications(self, dry_run=False):
@@ -469,7 +467,7 @@ class DiscoVPC(object):
         logger.info("Updating VPC S3 endpoints...")
         self.disco_vpc_endpoints.update(dry_run=dry_run)
         logger.info("Updating VPC peering connections...")
-        self.disco_vpc_peerings.update_peering_connections(dry_run)
+        self.disco_vpc_peerings.update_peering_connections(self, dry_run, delete_extra_connections=True)
         logger.info("Updating alarm notifications...")
         self.configure_notifications(dry_run)
 
@@ -487,7 +485,7 @@ class DiscoVPC(object):
         self.disco_vpc_gateways.destroy_igw_and_detach_vgws()
         self._destroy_interfaces()
         self.disco_vpc_sg_rules.destroy()
-        DiscoVPCPeerings.delete_peerings(self.get_vpc_id())
+        self.disco_vpc_peerings.delete_peerings(self.get_vpc_id())
         self._destroy_subnets()
         self.disco_vpc_endpoints.delete()
         self._destroy_routes()
@@ -579,21 +577,6 @@ class DiscoVPC(object):
                 throttled_call(self.boto3_ec2.delete_dhcp_options, DhcpOptionsId=dhcp_options_id)
 
     @staticmethod
-    def find_vpc_id_by_name(vpc_name):
-        """Find VPC by name"""
-        client = boto3.client('ec2')
-        vpcs = throttled_call(
-            client.describe_vpcs,
-            Filters=create_filters({'tag:Name': [vpc_name]})
-        )['Vpcs']
-        if len(vpcs) == 1:
-            return vpcs[0]['VpcId']
-        elif len(vpcs) == 0:
-            raise VPCNameNotFound("No VPC is named as {}".format(vpc_name))
-        else:
-            raise MultipleVPCsForVPCNameError("More than 1 VPC is named as {}".format(vpc_name))
-
-    @staticmethod
     def list_vpcs():
         """Returns list of boto.vpc.vpc.VPC classes, one for each existing VPC"""
         client = boto3.client('ec2')
@@ -602,26 +585,3 @@ class DiscoVPC(object):
                  'tags': tag2dict(vpc['Tags'] if 'Tags' in vpc else None),
                  'cidr_block': vpc['CidrBlock']}
                 for vpc in vpcs['Vpcs']]
-
-    @staticmethod
-    def get_random_free_subnet(network_cidr, network_size, occupied_network_cidrs):
-        """
-        Pick a random available subnet from a bigger network
-        Args:
-            network_cidr (str): CIDR string describing a network
-            network_size (int): The number of bits for the CIDR of the subnet
-            occupied_network_cidrs (List[str]): List of CIDR strings describing existing networks
-                                                to avoid overlapping with
-
-        Returns str: The CIDR of a randomly chosen subnet that doesn't intersect with
-                     the ip ranges of any of the given other networks
-        """
-        possible_subnets = IPNetwork(network_cidr).subnet(int(network_size))
-        occupied_networks = [IPSet(IPNetwork(cidr)) for cidr in occupied_network_cidrs]
-
-        # find the subnets that don't overlap with any other networks
-        available_subnets = [subnet for subnet in possible_subnets
-                             if all([IPSet(subnet).isdisjoint(occupied_network)
-                                     for occupied_network in occupied_networks])]
-
-        return random.choice(available_subnets) if available_subnets else None

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -71,7 +71,7 @@ class DiscoVPCPeerings(object):
             for route_table in self._get_peering_route_tables(peering['VpcPeeringConnectionId']):
                 tags_dict = tag2dict(route_table['Tags'])
 
-                subnet_env, subnet_network = tags_dict['Name'].split('_')
+                subnet_env, subnet_network = tags_dict['Name'].split('_')[:2]
                 if subnet_env == vpc.environment_name:
                     source_endpoint = PeeringEndpoint(
                         vpc.environment_name,

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -3,6 +3,9 @@ This module contains logic that processes a VPC's peering connections
 """
 
 import logging
+from sets import ImmutableSet
+
+from itertools import product
 
 from boto.exception import EC2ResponseError
 import boto3
@@ -13,7 +16,7 @@ import disco_vpc
 
 from . import read_config
 from .resource_helper import tag2dict, create_filters, throttled_call
-from .exceptions import VPCPeeringSyntaxError
+from .exceptions import VPCPeeringSyntaxError, VPCConfigError
 from .disco_constants import VPC_CONFIG_FILE
 
 logger = logging.getLogger(__name__)
@@ -25,81 +28,95 @@ class DiscoVPCPeerings(object):
     """
     This class takes care of processing of a VPC's peering connections
     """
-    def __init__(self, vpc, boto3_ec2):
-        self.disco_vpc = vpc
-        self.boto3_ec2 = boto3_ec2
 
-    def update_peering_connections(self, dry_run=False):
+    def __init__(self, boto3_ec2=None):
+        if boto3_ec2:
+            self.client = boto3_ec2
+        else:
+            self.client = boto3.client('ec2')
+
+    def update_peering_connections(self, vpc, dry_run=False, delete_extra_connections=False):
         """ Update peering connections for a VPC """
-        desired_peerings = self.parse_peering_strs_config(self.disco_vpc.environment_name)
-        existing_peerings = self._get_existing_peerings()
+        desired_peerings = self._get_peerings_from_config(vpc.get_vpc_id())
+        existing_peerings = self._get_existing_peerings(vpc)
 
         logger.info("Desired VPC peering connections: %s", desired_peerings)
         logger.info("Existing VPC peering connections: %s", existing_peerings)
 
-        if existing_peerings > desired_peerings:
+        if delete_extra_connections and existing_peerings > desired_peerings:
             raise RuntimeError("Some existing VPC peering connections are not "
                                "defined in the configuration: {0}. Deletion of VPC peerings is "
                                "not implemented yet."
                                .format(existing_peerings - desired_peerings))
 
-        peerings_config = self.parse_peerings_config(self.disco_vpc.get_vpc_id())
-        logger.debug("Desired VPC peering config: %s", peerings_config)
         if not dry_run:
-            DiscoVPCPeerings.create_peering_connections(peerings_config)
+            self._create_peering_connections(desired_peerings - existing_peerings)
+            self._create_peering_routes(desired_peerings)
 
-    def _get_existing_peerings(self):
+    def _get_existing_peerings(self, vpc):
+        """
+        Get the set of PeeringConnections for the existing peerings for given DiscoVPC object
+        """
         current_peerings = set()
+        for peering in self.list_peerings(vpc.get_vpc_id()):
 
-        for peering in DiscoVPCPeerings.list_peerings(self.disco_vpc.get_vpc_id()):
-
-            peer_vpc_id = self._get_peer_vpc_id(peering)
-            peer_vpc = self._find_peer_vpc(peer_vpc_id)
+            peer_vpc = self._find_peer_vpc(self._get_peer_vpc_id(vpc.get_vpc_id(), peering))
             if not peer_vpc:
                 logger.warning("Failed to find the peer VPC (%s) associated with peering (%s). "
                                "If the VPC no longer exists, please delete the peering manually.",
-                               peer_vpc_id, peering['VpcPeeringConnectionId'])
+                               peer_vpc['VpcId'], peering['VpcPeeringConnectionId'])
                 continue
 
-            peering_query = create_filters(
-                {'route.vpc-peering-connection-id': [peering['VpcPeeringConnectionId']]}
-            )
-
-            vpc_peering_route_tables = throttled_call(self.boto3_ec2.describe_route_tables,
-                                                      Filters=peering_query)['RouteTables']
+            vpc_peering_route_tables = throttled_call(
+                self.client.describe_route_tables,
+                Filters=create_filters({
+                    'route.vpc-peering-connection-id': [peering['VpcPeeringConnectionId']]
+                })
+            )['RouteTables']
 
             for route_table in vpc_peering_route_tables:
                 tags_dict = tag2dict(route_table['Tags'])
 
                 subnet_name_parts = tags_dict['Name'].split('_')
-                if subnet_name_parts[0] == self.disco_vpc.environment_name:
-                    source_network = subnet_name_parts[0] + ':' + \
-                        self.disco_vpc.environment_type + '/' + \
-                        subnet_name_parts[1]
+                if subnet_name_parts[0] == vpc.environment_name:
+                    source_endpoint = PeeringEndpoint(
+                        vpc.environment_name,
+                        vpc.environment_type,
+                        subnet_name_parts[1],
+                        vpc.vpc
+                    )
 
-                    route_cidrs = [route['DestinationCidrBlock']
-                                   for route in route_table['Routes']
-                                   if route.get('VpcPeeringConnectionId') ==
-                                   peering['VpcPeeringConnectionId']]
+                    # find the metanetwork of the peering connection by matching the peering routes with
+                    # the CIDRs of the VPC metanetworks
+                    route_cidrs = [
+                        route['DestinationCidrBlock'] for route in route_table['Routes']
+                        if route.get('VpcPeeringConnectionId') == peering['VpcPeeringConnectionId']
+                    ]
 
-                    for network in peer_vpc.networks.values():
-                        if str(network.network_cidr) in route_cidrs:
-                            dest_network = peer_vpc.environment_name + ':' + \
-                                peer_vpc.environment_type + '/' + network.name
+                    peered_networks = [network for network in peer_vpc.networks.values()
+                                       if str(network.network_cidr) in route_cidrs]
 
-                            current_peerings.add(source_network + ' ' + dest_network)
+                    if peered_networks:
+                        target_endpoint = PeeringEndpoint(
+                            peer_vpc.environment_name,
+                            peer_vpc.environment_type,
+                            peered_networks[0].name,
+                            peer_vpc.vpc
+                        )
+
+                        current_peerings.add(PeeringConnection(source_endpoint, target_endpoint))
 
         return current_peerings
 
-    def _get_peer_vpc_id(self, peering):
-        if peering['AccepterVpcInfo']['VpcId'] != self.disco_vpc.get_vpc_id():
+    def _get_peer_vpc_id(self, vpc_id, peering):
+        if peering['AccepterVpcInfo']['VpcId'] != vpc_id:
             return peering['AccepterVpcInfo']['VpcId']
         else:
             return peering['RequesterVpcInfo']['VpcId']
 
     def _find_peer_vpc(self, peer_vpc_id):
         try:
-            peer_vpc = throttled_call(self.boto3_ec2.describe_vpcs, VpcIds=[peer_vpc_id])['Vpcs'][0]
+            peer_vpc = throttled_call(self.client.describe_vpcs, VpcIds=[peer_vpc_id])['Vpcs'][0]
         except Exception:
             return None
 
@@ -110,98 +127,88 @@ class DiscoVPCPeerings(object):
         except UnboundLocalError:
             raise RuntimeError("VPC {0} is missing tags: 'Name', 'type'.".format(peer_vpc_id))
 
-    @staticmethod
-    def create_peering_connections(peering_configs):
-        """ create vpc peering configuration from the peering config dictionary"""
-        client = boto3.client('ec2')
-        for peering in peering_configs.keys():
-            vpc_map = peering_configs[peering]['vpc_map']
-            vpc_metanetwork_map = peering_configs[peering]['vpc_metanetwork_map']
-            vpc_ids = [vpc.vpc['VpcId'] for vpc in vpc_map.values()]
+    def _create_peering_connections(self, peerings):
+        """ Create peerings in AWS for the given PeeringConnection objects"""
+        for peering in peerings:
+            peering_conn = throttled_call(
+                self.client.create_vpc_peering_connection,
+                VpcId=peering.source_endpoint.vpc['VpcId'],
+                PeerVpcId=peering.target_endpoint.vpc['VpcId']
+            )['VpcPeeringConnection']
 
-            existing_peerings = throttled_call(
-                client.describe_vpc_peering_connections,
-                Filters=create_filters({'status-code': ['active'],
-                                        'accepter-vpc-info.vpc-id': [vpc_ids[0]],
-                                        'requester-vpc-info.vpc-id': [vpc_ids[1]]})
-            )['VpcPeeringConnections']
+            # wait for the peering connection to be ready
+            waiter = self.client.get_waiter('vpc_peering_connection_exists')
+            waiter.wait(
+                VpcPeeringConnectionIds=[peering_conn['VpcPeeringConnectionId']],
+                Filters=[{'Name': 'status-code', 'Values': LIVE_PEERING_STATES}]
+            )
 
-            existing_peerings += throttled_call(
-                client.describe_vpc_peering_connections,
-                Filters=create_filters({'status-code': ['active'],
-                                        'accepter-vpc-info.vpc-id': [vpc_ids[1]],
-                                        'requester-vpc-info.vpc-id': [vpc_ids[0]]})
-            )['VpcPeeringConnections']
+            throttled_call(
+                self.client.accept_vpc_peering_connection,
+                VpcPeeringConnectionId=peering_conn['VpcPeeringConnectionId']
+            )
 
-            # create peering when peering doesn't exist
-            if not existing_peerings:
-                peering_conn = throttled_call(
-                    client.create_vpc_peering_connection,
-                    VpcId=vpc_ids[0], PeerVpcId=vpc_ids[1]
-                )['VpcPeeringConnection']
-
-                # wait for the peering connection to be ready
-                waiter = client.get_waiter('vpc_peering_connection_exists')
-                waiter.wait(
-                    VpcPeeringConnectionIds=[peering_conn['VpcPeeringConnectionId']],
-                    Filters=[{'Name': 'status-code', 'Values': LIVE_PEERING_STATES}]
-                )
-
-                throttled_call(
-                    client.accept_vpc_peering_connection,
-                    VpcPeeringConnectionId=peering_conn['VpcPeeringConnectionId']
-                )
-                logger.info("Created new peering connection %s for %s",
-                            peering_conn['VpcPeeringConnectionId'], peering)
-            else:
-                peering_conn = existing_peerings[0]
-                logger.info("Peering connection %s exists for %s",
-                            existing_peerings[0]['VpcPeeringConnectionId'], peering)
-            DiscoVPCPeerings.create_peering_routes(vpc_map, vpc_metanetwork_map, peering_conn)
-
-    @staticmethod
-    def create_peering_routes(vpc_map, vpc_metanetwork_map, peering_conn):
+    def _create_peering_routes(self, peerings):
         """ create/update routes via peering connections between VPCs """
-        cidr_map = {
-            _: vpc_map[_].networks[vpc_metanetwork_map[_]].network_cidr
-            for _ in vpc_map.keys()
-        }
-        network_map = {
-            _: vpc_map[_].networks[vpc_metanetwork_map[_]]
-            for _ in vpc_map.keys()
-        }
-        for vpc_name, network in network_map.iteritems():
-            remote_vpc_names = vpc_map.keys()
-            remote_vpc_names.remove(vpc_name)
+        connection_map = {}
+        for peering_connection in self.list_peerings():
+            source_target_key = '%s-%s' % (peering_connection['AccepterVpcInfo']['VpcId'],
+                                           peering_connection['RequesterVpcInfo']['VpcId'])
+            connection_map[source_target_key] = peering_connection['VpcPeeringConnectionId']
 
-            network.create_peering_route(peering_conn['VpcPeeringConnectionId'],
-                                         str(cidr_map[remote_vpc_names[0]]))
+            target_source_key = '%s-%s' % (peering_connection['RequesterVpcInfo']['VpcId'],
+                                           peering_connection['AccepterVpcInfo']['VpcId'])
+            connection_map[target_source_key] = peering_connection['VpcPeeringConnectionId']
 
-    @staticmethod
-    def parse_peerings_config(vpc_id=None):
+        for peering in peerings:
+            source_vpc = disco_vpc.DiscoVPC(peering.source_endpoint.name,
+                                            peering.source_endpoint.type,
+                                            peering.source_endpoint.vpc)
+
+            target_vpc = disco_vpc.DiscoVPC(peering.target_endpoint.name,
+                                            peering.target_endpoint.type,
+                                            peering.target_endpoint.vpc)
+
+            source_network = source_vpc.networks[peering.source_endpoint.metanetwork]
+            target_network = target_vpc.networks[peering.target_endpoint.metanetwork]
+
+            peering_conn_key = '%s-%s' % (peering.source_endpoint.vpc['VpcId'],
+                                          peering.target_endpoint.vpc['VpcId'])
+
+            if peering_conn_key in connection_map:
+                vpc_peering_conn_id = connection_map[peering_conn_key]
+            else:
+                raise RuntimeError('Peering connection %s not found. Cannot create routes' % peering_conn_key)
+
+            source_network.create_peering_route(
+                vpc_peering_conn_id,
+                str(target_network.network_cidr)
+            )
+
+            target_network.create_peering_route(
+                vpc_peering_conn_id,
+                str(source_network.network_cidr)
+            )
+
+    def _get_peerings_from_config(self, vpc_id=None):
         """
         Parses configuration from disco_vpc.ini's peerings sections.
         If vpc_id is specified, only configuration relevant to vpc_id is included.
         """
-        peerings = DiscoVPCPeerings._get_peering_lines()
-
-        client = boto3.client('ec2')
-        peering_configs = {}
-        for peering in peerings:
-            peering_config = DiscoVPCPeerings.parse_peering_connection_line(peering, client)
-            vpc_ids_in_peering = [vpc.vpc['VpcId'] for vpc in peering_config.get("vpc_map", {}).values()]
-
-            if len(vpc_ids_in_peering) < 2:
-                pass  # not all vpcs were up, nothing to do
-            elif vpc_id and vpc_id not in vpc_ids_in_peering:
-                logger.debug("Skipping peering %s because it doesn't include %s", peering, vpc_id)
-            else:
-                peering_configs[peering] = peering_config
+        peering_configs = set()
+        for peering in self._get_peering_lines():
+            # resolve the peering line into a list of PeeringConnection objects
+            # a single peering line might resolve to multiple peerings if there are wildcards
+            resolved_peerings = self._resolve_peering_connection_line(peering)
+            for resolved_peering in resolved_peerings:
+                if vpc_id and not resolved_peering.contains_vpc_id(vpc_id):
+                    logger.debug("Skipping peering %s because it doesn't include %s", peering, vpc_id)
+                else:
+                    peering_configs.add(resolved_peering)
 
         return peering_configs
 
-    @staticmethod
-    def _get_peering_lines():
+    def _get_peering_lines(self):
         logger.debug("Parsing peerings configuration specified in %s", VPC_CONFIG_FILE)
         config = read_config(VPC_CONFIG_FILE)
 
@@ -224,139 +231,38 @@ class DiscoVPCPeerings(object):
 
         return peerings
 
-    @staticmethod
-    def parse_peering_strs_config(source_vpc_name):
-        """
-        Return a set of peering string from the VPC's config file
-        """
-        def _parse_endponit(endpoint):
-            endpoint_parts = endpoint.split('/')
-            vpc_parts = endpoint_parts[0].strip().split(':')
-            vpc_name = vpc_parts[0].strip()
-            vpc_type = vpc_parts[-1].strip()
-            network_name = endpoint_parts[1].strip()
-
-            return vpc_name, vpc_name + ':' + vpc_type + '/' + network_name
-
-        peering_strs = set()
-        peering_lines = DiscoVPCPeerings._get_peering_lines()
-        for line in peering_lines:
-            endpoints_map = {}
-            for endpoint in line.split(' '):
-                endpoint = _parse_endponit(endpoint)
-                endpoints_map[endpoint[0]] = endpoint[1]
-
-            if source_vpc_name in endpoints_map.keys():
-                peer_vpc_name = [vpc_name for vpc_name in endpoints_map.keys()
-                                 if vpc_name != source_vpc_name][0]
-
-                peering_strs.add(endpoints_map[source_vpc_name] +
-                                 ' ' + endpoints_map[peer_vpc_name])
-
-        return peering_strs
-
-    @staticmethod
-    def parse_peering_connection_line(line, vpc_conn):
-        """
-        Parses vpc connections of the form `vpc_name[:vpc_type]/metanetwork vpc_name[:vpc_type]/metanetwork`
-        and returns the data in two dictionaries: vpc_name -> DiscoVPC instance and vpc_name -> metanetwork.
-        vpc_type defaults to vpc_name if unspecified.
-        """
-        logger.debug('checking existence for peering %s', line)
-        endpoints = line.split(' ')
-
-        def get_vpc_name(endpoint):
-            """return name from `name[:type]/metanetwork`"""
-            return endpoint.split('/')[0].split(':')[0].strip()
-
-        def get_vpc_type(endpoint):
-            """return type from `name[:type]/metanetwork`, defaulting to name if type is omitted"""
-            return endpoint.split('/')[0].split(':')[-1].strip()
-
-        def get_metanetwork(endpoint):
-            """return metanetwork from `name[:type]/metanetwork`"""
-            return endpoint.split('/')[1].strip()
-
-        def safe_get_from_list(_list, i):
-            """returns the i-th element in a list, or None if it doesn't exist"""
-            return _list[i] if _list and len(_list) > i else None
-
-        vpc_type_map = {
-            get_vpc_name(endpoint): get_vpc_type(endpoint)
-            for endpoint in endpoints
-        }
-
-        vpc_objects = {
-            vpc_name: safe_get_from_list(
-                throttled_call(
-                    vpc_conn.describe_vpcs,
-                    Filters=create_filters({'tag-value': [vpc_name]})
-                )['Vpcs'], 0)
-            for vpc_name in vpc_type_map.keys()
-        }
-
-        missing_vpcs = [vpc_name for vpc_name, vpc_object in vpc_objects.items() if not vpc_object]
-        if missing_vpcs:
-            logger.debug(
-                "Skipping peering %s because the following VPC(s) are not up: %s",
-                line, ", ".join(map(str, missing_vpcs)))
-            return {}
-
-        vpc_map = {
-            k: disco_vpc.DiscoVPC(k, v, vpc_objects[k])
-            for k, v in vpc_type_map.iteritems()
-        }
-
-        for vpc in vpc_map.values():
-            if not vpc.networks:
-                raise RuntimeError("No metanetworks found for vpc {}. Are you sure it's of type {}?".format(
-                    vpc.environment_name, vpc.environment_type))
-
-        vpc_metanetwork_map = {
-            get_vpc_name(endpoint): get_metanetwork(endpoint)
-            for endpoint in endpoints
-        }
-
-        return {
-            'vpc_metanetwork_map': vpc_metanetwork_map,
-            'vpc_map': vpc_map
-        }
-
-    @staticmethod
-    def delete_peerings(vpc_id=None):
+    def delete_peerings(self, vpc_id=None):
         """Delete peerings. If vpc_id is specified, delete all peerings of the VPCs only"""
-        client = boto3.client('ec2')
-        for peering in DiscoVPCPeerings.list_peerings(vpc_id):
+        for peering in self.list_peerings(vpc_id):
             try:
                 logger.info('deleting peering connection %s', peering['VpcPeeringConnectionId'])
                 throttled_call(
-                    client.delete_vpc_peering_connection,
+                    self.client.delete_vpc_peering_connection,
                     VpcPeeringConnectionId=peering['VpcPeeringConnectionId']
                 )
             except EC2ResponseError:
-                raise RuntimeError('Failed to delete VPC Peering connection \
-                                    {}'.format(peering['VpcPeeringConnectionId']))
+                raise RuntimeError(
+                    'Failed to delete VPC Peering connection {}'.format(peering['VpcPeeringConnectionId'])
+                )
 
-    @staticmethod
-    def list_peerings(vpc_id=None, include_failed=False):
+    def list_peerings(self, vpc_id=None, include_failed=False):
         """
         Return list of live vpc peering connection id.
         If vpc_id is given, return only that vpcs peerings
         Peerings that cannot be manipulated are ignored.
         """
-        client = boto3.client('ec2')
         if vpc_id:
             peerings = throttled_call(
-                client.describe_vpc_peering_connections,
+                self.client.describe_vpc_peering_connections,
                 Filters=create_filters({'requester-vpc-info.vpc-id': [vpc_id]})
             )['VpcPeeringConnections']
 
             peerings += throttled_call(
-                client.describe_vpc_peering_connections,
+                self.client.describe_vpc_peering_connections,
                 Filters=create_filters({'accepter-vpc-info.vpc-id': [vpc_id]})
             )['VpcPeeringConnections']
         else:
-            peerings = throttled_call(client.describe_vpc_peering_connections)['VpcPeeringConnections']
+            peerings = throttled_call(self.client.describe_vpc_peering_connections)['VpcPeeringConnections']
 
         peering_states = LIVE_PEERING_STATES + (["failed"] if include_failed else [])
         return [
@@ -364,3 +270,129 @@ class DiscoVPCPeerings(object):
             for peering in peerings
             if peering['Status']['Code'] in peering_states
         ]
+
+    def _resolve_peering_connection_line(self, line):
+        """
+        Resolve a peering connection line into a set of PeeringConnections. Expand any wildcards
+
+        Args:
+            line (str): A peering line like `vpc_name[:vpc_type]/metanetwork vpc_name[:vpc_type]/metanetwork`
+                        `vpc_name` may be the name of a VPC or a `*` wildcard to peer with any VPC of vpc_type
+        """
+
+        # convert the config line into a PeeringConnection but it may contain wildcards
+        unresolved_peering = PeeringConnection.from_peering_line(line)
+
+        # get all VPCs created through Asiaq. Ones that have type and Name tags
+        existing_vpcs = [vpc for vpc in throttled_call(self.client.describe_vpcs).get('Vpcs', [])
+                         if all(tag in tag2dict(vpc.get('Tags', [])) for tag in ['type', 'Name'])]
+
+        if '*' in (unresolved_peering.source_endpoint.type, unresolved_peering.target_endpoint.type):
+            raise VPCConfigError('Wildcards are not allowed for VPC type in "%s". '
+                                 'Please specify a VPC type when using a wild card for the VPC name' % line)
+
+        def resolve_endpoint(endpoint):
+            """
+            Convert a PeeringEndpoint that may contain wildcards into a list of PeeringEndpoints
+            with wildcards resolved
+            """
+            endpoints = []
+            for vpc in existing_vpcs:
+                tags = tag2dict(vpc['Tags'])
+                if endpoint.name in ('*', tags['Name']) and endpoint.type == tags['type']:
+                    endpoints.append(PeeringEndpoint(tags['Name'], tags['type'], endpoint.metanetwork, vpc))
+            return endpoints
+
+        # find the VPCs that match the peering config. Replace wildcards with real VPC names
+        source_endpoints = resolve_endpoint(unresolved_peering.source_endpoint)
+        target_endpoints = resolve_endpoint(unresolved_peering.target_endpoint)
+
+        # generate new connection lines by peering the cross product of every source and target endpoint
+        return {PeeringConnection(peering[0], peering[1])
+                for peering in product(source_endpoints, target_endpoints)
+                # Don't peer a VPC with itself
+                if not peering[0] == peering[1]}
+
+
+class PeeringEndpoint(object):
+    """
+    Represents one side of a PeeringConnection
+    """
+    def __init__(self, env_name, env_type, metanetwork, vpc=None):
+        self.name = env_name
+        self.type = env_type
+        self.metanetwork = metanetwork
+        self.vpc = vpc
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __str__(self):
+        return '%s:%s/%s' % (
+            self.name,
+            self.type,
+            self.metanetwork
+        )
+
+
+class PeeringConnection(object):
+    """
+    Represents a connection between two different VPCs
+    """
+    def __init__(self, source_endpoint, target_endpoint):
+        """
+        Args:
+            source_endpoint (PeeringEndpoint): source side of connection
+            target_endpoint (PeeringEndpoint): target side of connection
+        """
+        self.source_endpoint = source_endpoint
+        self.target_endpoint = target_endpoint
+
+    def contains_vpc_name(self, vpc_name):
+        """ Return true if the given vpc_name is the name of a VPC on one of the sides of the connection"""
+        return self.source_endpoint.name == vpc_name or self.target_endpoint.name == vpc_name
+
+    def contains_vpc_id(self, vpc_id):
+        """ Return true if the given vpc_id is the id of a VPC on one of the sides of the connection"""
+        return self.source_endpoint.vpc['VpcId'] == vpc_id or self.target_endpoint.vpc == vpc_id
+
+    @staticmethod
+    def from_peering_line(line):
+        """ Parse a peering connection config line into a PeeringConnection object """
+        endpoints = line.split(' ')
+        if not len(endpoints) == 2:
+            raise VPCConfigError('Invalid peering config "%s". Peering config must be of the format '
+                                 'vpc_name[:vpc_type]/metanetwork vpc_name[:vpc_type]/metanetwork' % line)
+
+        def get_peering_endpoint(endpoint):
+            """ Get a PeeringEndpoint from one of the sides of a peering config """
+            vpc_name = endpoint.split('/')[0].split(':')[0].strip()
+
+            # get type from `name[:type]/metanetwork`, defaulting to name if type is omitted
+            vpc_type = endpoint.split('/')[0].split(':')[-1].strip()
+
+            # get metanetwork from `name[:type]/metanetwork`
+            metanetwork = endpoint.split('/')[1].strip()
+
+            return PeeringEndpoint(vpc_name, vpc_type, metanetwork)
+
+        source_peering = get_peering_endpoint(endpoints[0])
+        target_peering = get_peering_endpoint(endpoints[1])
+
+        return PeeringConnection(source_peering, target_peering)
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        # use a immutable set because regular sets aren't hashable
+        return hash(ImmutableSet([self.source_endpoint, self.target_endpoint]))
+
+    def __str__(self):
+        return str(self.source_endpoint) + ' ' + str(self.target_endpoint)
+
+    def __repr__(self):
+        return str(self)

--- a/disco_aws_automation/network_helper.py
+++ b/disco_aws_automation/network_helper.py
@@ -1,8 +1,10 @@
 """
 This module has utility functions for working with networks
 """
+import random
 
 from math import ceil, log
+from netaddr import IPNetwork, IPSet
 
 
 def calc_subnet_offset(num_subnets):
@@ -16,3 +18,26 @@ def calc_subnet_offset(num_subnets):
 
     """
     return int(ceil(log(num_subnets, 2)))
+
+
+def get_random_free_subnet(network_cidr, network_size, occupied_network_cidrs):
+    """
+    Pick a random available subnet from a bigger network
+    Args:
+        network_cidr (str): CIDR string describing a network
+        network_size (int): The number of bits for the CIDR of the subnet
+        occupied_network_cidrs (List[str]): List of CIDR strings describing existing networks
+                                            to avoid overlapping with
+
+    Returns str: The CIDR of a randomly chosen subnet that doesn't intersect with
+                 the ip ranges of any of the given other networks
+    """
+    possible_subnets = IPNetwork(network_cidr).subnet(int(network_size))
+    occupied_networks = [IPSet(IPNetwork(cidr)) for cidr in occupied_network_cidrs]
+
+    # find the subnets that don't overlap with any other networks
+    available_subnets = [subnet for subnet in possible_subnets
+                         if all([IPSet(subnet).isdisjoint(occupied_network)
+                                 for occupied_network in occupied_networks])]
+
+    return random.choice(available_subnets) if available_subnets else None

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/helpers/matchers.py
+++ b/test/helpers/matchers.py
@@ -1,9 +1,20 @@
 """
-Some helpers for matching values in unit tests
+Collection of classes to help matching values in unit tests
 """
 
 
 class MatchAnything(object):
     """Helper class to use with assertions that can match any value"""
+
     def __eq__(self, other):
         return True
+
+
+class MatchClass(object):
+    """Helper class to use with assertions that matches values that are instances of a class"""
+
+    def __init__(self, clazz):
+        self.clazz = clazz
+
+    def __eq__(self, other):
+        return isinstance(other, self.clazz)

--- a/test/unit/test_disco_vpc.py
+++ b/test/unit/test_disco_vpc.py
@@ -3,7 +3,6 @@
 import unittest
 
 from mock import MagicMock, patch, PropertyMock, call
-from netaddr import IPSet
 
 from disco_aws_automation import DiscoVPC
 from test.helpers.patch_disco_aws import get_mock_config
@@ -11,21 +10,6 @@ from test.helpers.patch_disco_aws import get_mock_config
 
 class DiscoVPCTests(unittest.TestCase):
     """Test DiscoVPC"""
-
-    def test_get_random_free_subnet(self):
-        """Test getting getting a random subnet from a network"""
-        subnet = DiscoVPC.get_random_free_subnet('10.0.0.0/28', 30, [])
-
-        possible_subnets = ['10.0.0.0/30', '10.0.0.4/30', '10.0.0.8/30', '10.0.0.12/30']
-        self.assertIn(str(subnet), possible_subnets)
-
-    def test_get_random_free_subnet_returns_none(self):
-        """Test that None is returned if no subnets are available"""
-        used_subnets = ['10.0.0.0/30', '10.0.0.4/32', '10.0.0.8/30', '10.0.0.12/30']
-
-        subnet = DiscoVPC.get_random_free_subnet('10.0.0.0/28', 30, used_subnets)
-        IPSet(subnet)
-        self.assertIsNone(subnet)
 
     # pylint: disable=unused-argument
     @patch('disco_aws_automation.disco_vpc.DiscoVPCEndpoints')

--- a/test/unit/test_disco_vpc_peerings.py
+++ b/test/unit/test_disco_vpc_peerings.py
@@ -1,85 +1,36 @@
 """Tests of disco_vpc_peerings"""
-
 import unittest
-from mock import MagicMock, call, patch, PropertyMock
 
-from disco_aws_automation.disco_vpc import DiscoVPC
-from disco_aws_automation.disco_vpc_peerings import DiscoVPCPeerings
+import boto3
+from mock import MagicMock, patch
+from moto import mock_ec2
+
+from disco_aws_automation import DiscoVPC
+from disco_aws_automation.disco_vpc_peerings import DiscoVPCPeerings, PeeringConnection
 
 from test.helpers.patch_disco_aws import get_mock_config
-
-
-# pylint: disable=unused-argument
-@patch('disco_aws_automation.disco_vpc.DiscoVPC.config', new_callable=PropertyMock)
-@patch('boto3.client')
-def _get_vpc_mock(boto3_client_mock=None, config_mock=None):
-
-    config_mock.return_value = get_mock_config({
-        'envtype:sandbox': {
-            'ip_space': '10.0.0.0/24',
-            'vpc_cidr_size': '26',
-            'intranet_cidr': 'auto',
-            'tunnel_cidr': 'auto',
-            'dmz_cidr': 'auto',
-            'maintenance_cidr': 'auto',
-            'ntp_server': '10.0.0.5'
-        }
-    })
-
-    client_mock = MagicMock()
-    client_mock.describe_dhcp_options.return_value = {'DhcpOptions': [MagicMock()]}
-    boto3_client_mock.return_value = client_mock
-
-    ret = DiscoVPC('mock-vpc-1', 'sandbox',
-                   {'CidrBlock': '10.0.0.0/26', 'VpcId': 'mock_vpc_1_id'})
-    return ret
-
-
-# pylint: disable=C0103,dangerous-default-value
-def _describe_vpcs_mock(VpcIds=[], Filters=[]):
-    vpc1 = {'Vpcs': [{'VpcId': 'mock_vpc_1_id',
-                      'Tags': [{'Key': 'Name', 'Value': 'mock-vpc-1'},
-                               {'Key': 'type', 'Value': 'sandbox'}]}]}
-    vpc2 = {'Vpcs': [{'VpcId': 'mock_vpc_2_id',
-                      'Tags': [{'Key': 'Name', 'Value': 'mock-vpc-2'},
-                               {'Key': 'type', 'Value': 'sandbox'}]}]}
-    vpc3 = {'Vpcs': [{'VpcId': 'mock_vpc_3_id',
-                      'Tags': [{'Key': 'Name', 'Value': 'mock-vpc-3'},
-                               {'Key': 'type', 'Value': 'sandbox'}]}]}
-
-    ret = None
-    if Filters:
-        for vpc_filter in Filters:
-            if vpc_filter['Name'] == 'tag-value':
-                if vpc_filter['Values'][0] == 'mock-vpc-1':
-                    ret = vpc1
-                elif vpc_filter['Values'][0] == 'mock-vpc-2':
-                    ret = vpc2
-                elif vpc_filter['Values'][0] == 'mock-vpc-3':
-                    ret = vpc3
-    else:
-        for vpc_id in VpcIds:
-            if vpc_id == 'mock_vpc_1_id':
-                ret = vpc1
-            elif vpc_id == 'mock_vpc_2_id':
-                ret = vpc2
-            elif vpc_id == 'mock_vpc_3_id':
-                ret = vpc3
-
-    return ret
 
 
 class DiscoVPCPeeringsTests(unittest.TestCase):
     """Test DiscoVPCPeerings"""
 
+    @patch("disco_aws_automation.disco_vpc.DiscoSNS", MagicMock())
+    @patch("disco_aws_automation.disco_vpc.DiscoRDS", MagicMock())
+    @patch("disco_aws_automation.disco_vpc.DiscoVPCEndpoints", MagicMock())
     def setUp(self):
-        self.mock_vpc = _get_vpc_mock()
-        self.disco_vpc_peerings = DiscoVPCPeerings(self.mock_vpc, self.mock_vpc.boto3_ec2)
+        mock_ec2().start()
 
-    @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork')
+        self.disco_vpc1 = DiscoVPC('mock-vpc-1', 'sandbox')
+        self.disco_vpc2 = DiscoVPC('mock-vpc-2', 'sandbox')
+        self.disco_vpc3 = DiscoVPC('mock-vpc-3', 'sandbox')
+
+        self.client = boto3.client('ec2')
+
+        self.disco_vpc_peerings = DiscoVPCPeerings()
+
+    @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork.create_peering_route')
     @patch('disco_aws_automation.disco_vpc_peerings.read_config')
-    @patch('boto3.client')
-    def test_update_peering_connections(self, boto3_client_mock, config_mock, meta_network_mock):
+    def test_update_peering_connections(self, config_mock, create_peering_route_mock):
         """ Verify new peering connections are created properly """
 
         config_mock.return_value = get_mock_config({
@@ -88,127 +39,61 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
             }
         })
 
-        client_mock = MagicMock()
-        client_mock.describe_vpc_peering_connections.return_value = {'VpcPeeringConnections': []}
-        client_mock.create_vpc_peering_connection.return_value = {
-            'VpcPeeringConnection': {'VpcPeeringConnectionId': 'mock_vpc_peering_id'}}
-        client_mock.describe_vpcs.side_effect = _describe_vpcs_mock
-        boto3_client_mock.return_value = client_mock
-
-        network_1_mock = MagicMock()
-        network_2_mock = MagicMock()
-
-        def _mock_meta_network(network, vpc):
-            if vpc.vpc['VpcId'] == 'mock_vpc_1_id':
-                return network_1_mock
-            else:
-                return network_2_mock
-        meta_network_mock.side_effect = _mock_meta_network
         # End setting up test
 
         # Calling method under test
-        self.disco_vpc_peerings.update_peering_connections()
-
-        # Verifying correct behavior
-        client_mock.create_vpc_peering_connection.assert_called_once_with(
-            PeerVpcId='mock_vpc_2_id', VpcId='mock_vpc_1_id')
-        client_mock.accept_vpc_peering_connection.assert_called_once_with(
-            VpcPeeringConnectionId='mock_vpc_peering_id')
-        network_1_mock.create_peering_route.assert_called_once_with(
-            'mock_vpc_peering_id', str(network_2_mock.network_cidr))
-        network_2_mock.create_peering_route.assert_called_once_with(
-            'mock_vpc_peering_id', str(network_1_mock.network_cidr))
-
-    @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork')
-    @patch('disco_aws_automation.disco_vpc_peerings.read_config')
-    @patch('boto3.client')
-    def test_update_peerings_with_existing_ones(
-            self, boto3_client_mock, config_mock, meta_network_mock):
-        """ Verify new peering connections are created properly while there are existing ones """
-
-        config_mock.return_value = get_mock_config({
-            'peerings': {
-                'connection_1': 'mock-vpc-1:sandbox/intranet mock-vpc-2:sandbox/intranet',
-                'connection_2': 'mock-vpc-1:sandbox/intranet mock-vpc-3:sandbox/intranet'
-            }
-        })
-
-        # pylint: disable=C0103
-        def _describe_vpc_peering_connections_mock(Filters):
-            count = 0
-            for peering_filter in Filters:
-                if (peering_filter['Name'] == 'accepter-vpc-info.vpc-id' and
-                        peering_filter['Values'][0] == 'mock_vpc_1_id') or \
-                    (peering_filter['Name'] == 'requester-vpc-info.vpc-id' and
-                     peering_filter['Values'][0] == 'mock_vpc_2_id'):
-                    count += 1
-
-            if count == 2 or \
-                    (len(Filters) == 1 and
-                     Filters[0]['Name'] == 'accepter-vpc-info.vpc-id' and
-                     Filters[0]['Values'][0] == 'mock_vpc_1_id'):
-                return {'VpcPeeringConnections': [
-                    {'Status': {'Code': 'active'},
-                     'VpcPeeringConnectionId': 'mock_vpc_peering_id_existing',
-                     'AccepterVpcInfo': {'VpcId': 'mock_vpc_1_id'},
-                     'RequesterVpcInfo': {'VpcId': 'mock_vpc_2_id'}}]}
-            else:
-                return {'VpcPeeringConnections': []}
-
-        network_1_mock = MagicMock()
-        network_1_mock.network_cidr = '10.0.23.23/23'
-        network_1_mock.name = 'intranet'
-        network_2_mock = MagicMock()
-        network_2_mock.network_cidr = '10.0.123.123/23'
-        network_2_mock.name = 'intranet'
-        network_3_mock = MagicMock()
-        network_3_mock.network_cidr = '10.2.123.123/23'
-        network_3_mock.name = 'intranet'
-
-        def _mock_meta_network(network, vpc):
-            if vpc.vpc['VpcId'] == 'mock_vpc_1_id':
-                return network_1_mock
-            elif vpc.vpc['VpcId'] == 'mock_vpc_2_id':
-                return network_2_mock
-            elif vpc.vpc['VpcId'] == 'mock_vpc_3_id':
-                return network_3_mock
-            return None
-
-        client_mock = MagicMock()
-        client_mock.describe_vpc_peering_connections.side_effect = _describe_vpc_peering_connections_mock
-        client_mock.create_vpc_peering_connection.return_value = {
-            'VpcPeeringConnection': {'VpcPeeringConnectionId': 'mock_vpc_peering_id_new'}}
-        client_mock.describe_vpcs.side_effect = _describe_vpcs_mock
-        self.mock_vpc.boto3_ec2.describe_vpcs.side_effect = _describe_vpcs_mock
-        self.mock_vpc.boto3_ec2.describe_route_tables.return_value = {
-            'RouteTables': [{'Tags': [{'Key': 'Name', 'Value': 'mock-vpc-1_intranet'}],
-                             'Routes': [{'VpcPeeringConnectionId': 'mock_vpc_peering_id_existing',
-                                         'DestinationCidrBlock': network_2_mock.network_cidr}]},
-                            {'Tags': [{'Key': 'Name', 'Value': 'mock-vpc-2_intranet'}],
-                             'Routes': [{'VpcPeeringConnectionId': 'mock_vpc_peering_id_existing',
-                                         'DestinationCidrBlock': network_1_mock.network_cidr}]}]}
-        boto3_client_mock.return_value = client_mock
-
-        meta_network_mock.side_effect = _mock_meta_network
-        # End setting up test
-
-        # Calling method under test
-        self.disco_vpc_peerings.update_peering_connections()
+        self.disco_vpc_peerings.update_peering_connections(self.disco_vpc1)
 
         # Asserting correct behavior
-        client_mock.create_vpc_peering_connection.assert_called_once_with(
-            PeerVpcId='mock_vpc_3_id', VpcId='mock_vpc_1_id')
-        client_mock.accept_vpc_peering_connection.assert_called_once_with(
-            VpcPeeringConnectionId='mock_vpc_peering_id_new')
-        expected_calls_network_1 = [call('mock_vpc_peering_id_new',
-                                         str(network_3_mock.network_cidr)),
-                                    call('mock_vpc_peering_id_existing',
-                                         str(network_2_mock.network_cidr))]
-        network_1_mock.create_peering_route.assert_has_calls(
-            expected_calls_network_1)
 
-        network_2_mock.create_peering_route.assert_called_once_with(
-            'mock_vpc_peering_id_existing', str(network_1_mock.network_cidr))
+        peeerings = self.client.describe_vpc_peering_connections().get('VpcPeeringConnections')
 
-        network_3_mock.create_peering_route.assert_called_once_with(
-            'mock_vpc_peering_id_new', str(network_1_mock.network_cidr))
+        self.assertEqual(1, len(peeerings))
+
+        peering_id = peeerings[0]['VpcPeeringConnectionId']
+
+        self.assertEqual(self.disco_vpc1.get_vpc_id(), peeerings[0]['RequesterVpcInfo']['VpcId'])
+        self.assertEqual(self.disco_vpc2.get_vpc_id(), peeerings[0]['AccepterVpcInfo']['VpcId'])
+
+        # create_peering_route should have been called twice, once for each VPC
+        create_peering_route_mock.assert_called_with(peering_id, '10.101.0.0/20')
+        self.assertEqual(2, create_peering_route_mock.call_count)
+
+    def test_parse_peering_connection(self):
+        """test parsing a peering connection line with wildcards"""
+        actual = self.disco_vpc_peerings._resolve_peering_connection_line(
+            'mock-vpc-1:sandbox/intranet mock-vpc-3:sandbox/intranet'
+        )
+
+        expected = [
+            PeeringConnection.from_peering_line('mock-vpc-1:sandbox/intranet mock-vpc-3:sandbox/intranet'),
+        ]
+
+        self.assertItemsEqual(actual, expected)
+
+    def test_parse_peering_connection_wildcards(self):
+        """test parsing a peering connection line with wildcards"""
+        actual = self.disco_vpc_peerings._resolve_peering_connection_line(
+            '*:sandbox/intranet mock-vpc-3:sandbox/intranet'
+        )
+
+        expected = [
+            PeeringConnection.from_peering_line('mock-vpc-1:sandbox/intranet mock-vpc-3:sandbox/intranet'),
+            PeeringConnection.from_peering_line('mock-vpc-2:sandbox/intranet mock-vpc-3:sandbox/intranet')
+        ]
+
+        self.assertItemsEqual(actual, expected)
+
+    def test_parse_peering_double_wildcards(self):
+        """test parsing a peering connection line with wildcards on both sides"""
+        actual = self.disco_vpc_peerings._resolve_peering_connection_line(
+            '*:sandbox/intranet *:sandbox/intranet'
+        )
+
+        expected = [
+            PeeringConnection.from_peering_line('mock-vpc-1:sandbox/intranet mock-vpc-2:sandbox/intranet'),
+            PeeringConnection.from_peering_line('mock-vpc-1:sandbox/intranet mock-vpc-3:sandbox/intranet'),
+            PeeringConnection.from_peering_line('mock-vpc-2:sandbox/intranet mock-vpc-3:sandbox/intranet')
+        ]
+
+        self.assertItemsEqual(actual, expected)

--- a/test/unit/test_disco_vpc_sg_rules.py
+++ b/test/unit/test_disco_vpc_sg_rules.py
@@ -19,7 +19,7 @@ from test.helpers.patch_disco_aws import TEST_ENV_NAME, get_mock_config
 @patch('boto3.client')
 @patch('boto3.resource')
 @patch('disco_aws_automation.disco_vpc.DiscoMetaNetwork')
-@patch('disco_aws_automation.disco_vpc.DiscoVPC.get_random_free_subnet')
+@patch('disco_aws_automation.disco_vpc.get_random_free_subnet')
 def _get_vpc_mock(random_subnet_mock=None, meta_network_mock=None, boto3_resource_mock=None,
                   boto3_client_mock=None, config_mock=None,
                   gateways_mock=None, sns_mock=None, endpoints_mock=None, rds_mock=None):


### PR DESCRIPTION
Replaces https://github.com/amplifylitco/asiaq/pull/49

This adds support for the following peering syntax. The below configuration would automatically peer any VPC of type `sandbox` with `ci`. 

``` ini
[peerings]
connection_1=*:sandbox/intranet ci/intranet
```


Wildcards can be on both sides. The following would peer every sandbox with every other sandbox.
``` ini
[peerings]
connection_1=*:sandbox/intranet *:sandbox/intranet
```



