### PR TITLE
Centralize config magic

### DIFF
--- a/disco_aws_automation/disco_alarm_config.py
+++ b/disco_aws_automation/disco_alarm_config.py
@@ -4,7 +4,6 @@ Parse disco_aws alarm configuration.
 
 import logging
 import copy
-from ConfigParser import ConfigParser
 
 from boto.ec2.cloudwatch import MetricAlarm
 
@@ -195,11 +194,7 @@ class DiscoAlarmsConfig(object):
     """
 
     def __init__(self, environment, config_file=None, autoscale=None, elasticsearch=None):
-        if config_file:
-            self.config = ConfigParser()
-            self.config.read(config_file)
-        else:
-            self.config = read_config(DEFAULT_CONFIG_FILE)
+        self.config = read_config(config_file=(config_file or DEFAULT_CONFIG_FILE), environment=environment)
         self.environment = environment
         self.elasticsearch = elasticsearch or None
         self._autoscale = autoscale or None  # laziliy intialized

--- a/disco_aws_automation/disco_config.py
+++ b/disco_aws_automation/disco_config.py
@@ -4,10 +4,11 @@ Package for reading configurations out of standard locations.
 
 import os
 import os.path
-from ConfigParser import ConfigParser
+from ConfigParser import ConfigParser, NoOptionError
 from logging import getLogger
 
-from .exceptions import AsiaqConfigError
+from .exceptions import AsiaqConfigError, ProgrammerError
+from .disco_constants import DEFAULT_CONFIG_SECTION  # this should not be a shared constant, eventually
 
 ASIAQ_CONFIG = os.getenv("ASIAQ_CONFIG", ".")
 DEFAULT_CONFIG_FILE = "disco_aws.ini"
@@ -28,7 +29,7 @@ def read_config(*path_components, **kwargs):
         all_components.append(kwargs['config_file'])
     real_config_file = normalize_path(all_components or DEFAULT_CONFIG_FILE)
     _LOG.debug("Reading config file %s", real_config_file)
-    config = ConfigParser()
+    config = AsiaqConfig(environment=kwargs.get('environment'))
     config.read(real_config_file)
     return config
 
@@ -59,3 +60,72 @@ def open_normalized(*path_components, **kwargs):
     """
     real_path = normalize_path(path_components)
     return open(real_path, **kwargs)
+
+
+class AsiaqConfig(ConfigParser):
+    """
+    Wrap configuration-reading shortcuts around the ConfigParser object.
+
+    All methods accept an "environment" parameter, but recommended usage is to pass in the
+    desired environment name at construction time, rather than at call time.
+    """
+
+    S3_BUCKET_BASE_OPTION = 's3_bucket_base'
+    S3_BUCKET_SUFFIX_OPTION = 's3_bucket_suffix'
+    DEFAULT_ENVIRONMENT_OPTION = 'default_environment'
+
+    def __init__(self, environment=None):
+        ConfigParser.__init__(self)  # ConfigParser is an old-style class
+        self._real_environment = environment
+
+    @property
+    def environment(self):
+        """
+        The environment name passed in at construction, or the default value for this config file.
+
+        Lazily populated since the config file has not yet been read at initialization time.
+        """
+        if not self._real_environment:
+            self._real_environment = self.get(DEFAULT_CONFIG_SECTION, self.DEFAULT_ENVIRONMENT_OPTION)
+        return self._real_environment
+
+    def get_asiaq_option(self, option, section=DEFAULT_CONFIG_SECTION, environment=None,
+                         required=True, default=None):
+        """
+        Get a value from the config, checking first for an environment-specific value, then
+        a generic value, then an env-specific default value in the default section, then a
+        non-env-specific default value in the default section.
+
+        In the case where none of these options has been set, if the "required" option is False,
+        return the value of the "default" option; otherwise, raise NoOptionError.
+        """
+        if required and (default is not None):
+            raise ProgrammerError("Using the 'default' option when 'required' is True makes no sense.")
+        if not environment:
+            environment = self.environment
+        env_option = "{0}@{1}".format(option, environment)
+        default_option = "default_{0}".format(option)
+        default_env_option = "default_{0}".format(env_option)
+
+        if self.has_option(section, env_option):
+            return self.get(section, env_option)
+        if self.has_option(section, option):
+            return self.get(section, option)
+        elif self.has_option(DEFAULT_CONFIG_SECTION, default_env_option):
+            return self.get(DEFAULT_CONFIG_SECTION, default_env_option)
+        elif self.has_option(DEFAULT_CONFIG_SECTION, default_option):
+            return self.get(DEFAULT_CONFIG_SECTION, default_option)
+
+        if required:
+            raise NoOptionError(option, section)
+        return default
+
+    def get_asiaq_s3_bucket_name(self, bucket_tag, environment=None, separator='--'):
+        """Construct a standardized bucket name based on configured prefix and suffix values."""
+        bucket_base = self.get_asiaq_option(self.S3_BUCKET_BASE_OPTION, environment=environment)
+        bucket_suffix = self.get_asiaq_option(self.S3_BUCKET_SUFFIX_OPTION, required=False,
+                                              environment=environment)
+        bucket_parts = [bucket_base, bucket_tag]
+        if bucket_suffix:
+            bucket_parts.append(bucket_suffix)
+        return separator.join(bucket_parts)

--- a/disco_aws_automation/disco_elasticache.py
+++ b/disco_aws_automation/disco_elasticache.py
@@ -5,13 +5,12 @@ Only Redis on Elasticache is supported at the moment
 import getpass
 import logging
 import hashlib
-from ConfigParser import ConfigParser
 
 import boto3
 import botocore
 from semantic_version import Spec, Version
 
-from .disco_config import normalize_path
+from .disco_config import read_config
 from .disco_route53 import DiscoRoute53
 from .exceptions import CommandError
 from .resource_helper import throttled_call
@@ -42,11 +41,9 @@ class DiscoElastiCache(object):
         """lazy load config"""
         if not self._config:
             try:
-                config = ConfigParser()
-                config.read(normalize_path(self.config_file))
-                self._config = config
+                self._config = read_config(self.config_file)
             except Exception:
-                return None
+                raise
         return self._config
 
     def list(self):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/sample_configuration/disco_aws.ini
+++ b/sample_configuration/disco_aws.ini
@@ -27,6 +27,12 @@ default_domain_name=dev.sample_project.net
 default_domain_name@staging=staging.sample_project.net
 default_domain_name@production=production.sample_project.net
 default_product_line=teamname
+
+s3_bucket_base=asiaq-data-storage-sample-project
+s3_bucket_suffix=dev
+s3_bucket_suffix@staging=prod
+s3_bucket_suffix@production=prod
+
 default_ami_available_wait_time=600
 
 [test]

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,5 +8,5 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-moto>=0.4.25
+moto>=0.4.30
 six>=1.7.3

--- a/test/unit/test_disco_config.py
+++ b/test/unit/test_disco_config.py
@@ -43,11 +43,11 @@ class TestNormalizePath(TestCase):
 
 
 @patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
+@patch('disco_aws_automation.disco_config.AsiaqConfig')
 class TestReadConfig(TestCase):
     """Tests for the read_config utility function."""
 
     @patch('os.path.exists', Mock(return_value=True))
-    @patch('disco_aws_automation.disco_config.ConfigParser')
     def test__no_arg__default_behavior(self, configparser_constructor):
         "Default argument for read_config works"
         parser = Mock()
@@ -57,7 +57,6 @@ class TestReadConfig(TestCase):
         parser.read.assert_called_once_with("FAKE_CONFIG_DIR/disco_aws.ini")
 
     @patch('os.path.exists', Mock(return_value=True))
-    @patch('disco_aws_automation.disco_config.ConfigParser')
     def test__named_arg__expected_behavior(self, configparser_constructor):
         "Keyword argument for read_config works"
         parser = Mock()
@@ -67,7 +66,6 @@ class TestReadConfig(TestCase):
         parser.read.assert_called_once_with("FAKE_CONFIG_DIR/Foobar")
 
     @patch('os.path.exists', Mock(return_value=True))
-    @patch('disco_aws_automation.disco_config.ConfigParser')
     def test__arglist__expected_behavior(self, configparser_constructor):
         "Unnamed argument list for read_config works"
         parser = Mock()
@@ -77,7 +75,6 @@ class TestReadConfig(TestCase):
         parser.read.assert_called_once_with("FAKE_CONFIG_DIR/foo/bar")
 
     @patch('os.path.exists', Mock(return_value=True))
-    @patch('disco_aws_automation.disco_config.ConfigParser')
     def test__arg_combo__named_arg_last(self, configparser_constructor):
         "Combined keyword and listed args for read_config work"
         parser = Mock()

--- a/test/unit/test_disco_config.py
+++ b/test/unit/test_disco_config.py
@@ -1,9 +1,12 @@
 """Tests for disco_config utilities."""
 
 from unittest import TestCase
+from copy import deepcopy
+from ConfigParser import NoOptionError
 from mock import patch, Mock
 
 from disco_aws_automation import disco_config, exceptions
+from test.helpers.patch_disco_aws import MockAsiaqConfig
 
 
 @patch("disco_aws_automation.disco_config.ASIAQ_CONFIG", "FAKE_CONFIG_DIR")
@@ -97,3 +100,121 @@ class TestOpenNormalized(TestCase):
         found = disco_config.open_normalized("path", "to", "file", mode="moody")
         self.assertIs(expected, found)
         open_mock.assert_called_once_with("FAKE_CONFIG_DIR/path/to/file", mode="moody")
+
+
+class TestAsiaqConfig(TestCase):
+    """Tests for the AsiaqConfig object."""
+    # allow long method names
+    # pylint: disable=invalid-name
+    BASE_CONFIG_DICT = {
+        disco_config.DEFAULT_CONFIG_SECTION: {
+            'default_environment': 'fake-build',
+            'default_unused_option': 'fall-all-the-way-back',
+        },
+        'mhcfoobar': {
+            'easy_option': 'easy_answer',
+            'envy_option': 'fallback_answer',
+            'envy_option@fake-build': 'default_env_answer',
+            'envy_option@ci': 'ci_answer'
+        }
+    }
+
+    S3_BUCKET_CONFIG = {
+        's3_bucket_base': 'bucket-base',
+        's3_bucket_suffix': 'blah',
+        's3_bucket_suffix@production': 'danger'
+    }
+
+    def test__get_asiaq_option__no_env_options(self):
+        "Option exists in desired section: found it"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals('easy_answer', config.get_asiaq_option(option='easy_option', section='mhcfoobar'))
+
+    def test__get_asiaq_option__default_env(self):
+        "Env-specific option with default environment"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals('default_env_answer',
+                          config.get_asiaq_option(option='envy_option', section='mhcfoobar'))
+
+    def test__get_asiaq_option__env_in_constructor(self):
+        "Env-specific option with environment passed in at construction time"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT), environment='ci')
+        self.assertEquals('ci_answer',
+                          config.get_asiaq_option('envy_option', section='mhcfoobar'))
+
+    def test__get_asiaq_option__env_in_call(self):
+        "Env-specific option with environment passed in at call time"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals('ci_answer',
+                          config.get_asiaq_option('envy_option', section='mhcfoobar', environment='ci'))
+
+    def test__get_asiaq_option__bad_env_in_call(self):
+        "Env-specific option with unused environment passed in at call time"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals('fallback_answer',
+                          config.get_asiaq_option('envy_option', section='mhcfoobar', environment='nope'))
+
+    def test__get_asiaq_option__default_section(self):
+        "Option found in defaults as fallback"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals('fall-all-the-way-back', config.get_asiaq_option('unused_option'))
+        self.assertEquals('fall-all-the-way-back',
+                          config.get_asiaq_option('unused_option', section='mhcfoobar'))
+
+    def test__get_asiaq_option__missing__exception(self):
+        "Missing option with required=True"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertRaises(NoOptionError,
+                          config.get_asiaq_option, 'nobody-cares-about-this', section='mhcfoobar')
+
+    def test__get_asiaq_option__missing_not_required__default(self):
+        "Missing option with required=False and default"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertEquals("passed-in-default",
+                          config.get_asiaq_option('nobody-cares-about-this', section='mhcfoobar',
+                                                  required=False, default="passed-in-default"))
+
+    def test__get_asiaq_option__missing_not_required_no_default__none(self):
+        "Missing option with required=False and default"
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertIsNone(config.get_asiaq_option('nobody-cares-about-this',
+                                                  section='mhcfoobar', required=False))
+
+    def test__get_asiaq_option__nonsense_args__error(self):
+        "Invalid arguments to get_asiaq_option produce an error."
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertRaises(exceptions.ProgrammerError, config.get_asiaq_option, 'immaterial',
+                          required=True, default=12345)
+
+    def test__get_asiaq_s3_bucket_name__no_prefix__error(self):
+        "Missing bucket prefix should make bucket-name method raise an exception."
+        config = MockAsiaqConfig(deepcopy(self.BASE_CONFIG_DICT))
+        self.assertRaises(NoOptionError, config.get_asiaq_s3_bucket_name, 'foobar')
+
+    def test__get_asiaq_s3_bucket_name__no_suffix(self):
+        "Missing suffix should not produce a problem for the bucket-name method."
+        config_dict = deepcopy(self.BASE_CONFIG_DICT)
+        config_dict[disco_config.DEFAULT_CONFIG_SECTION]['s3_bucket_base'] = 'bucket-base'
+        config = MockAsiaqConfig(config_dict)
+        self.assertEquals("bucket-base--foobar", config.get_asiaq_s3_bucket_name('foobar'))
+
+    def test__get_asiaq_s3_bucket_name__defaults(self):
+        "Base behavior of get_asiaq_s3_bucket_name works as expected."
+        config_dict = deepcopy(self.BASE_CONFIG_DICT)
+        config_dict[disco_config.DEFAULT_CONFIG_SECTION].update(self.S3_BUCKET_CONFIG)
+        config = MockAsiaqConfig(config_dict)
+        self.assertEquals("bucket-base--foobar--blah", config.get_asiaq_s3_bucket_name('foobar'))
+
+    def test__get_asiaq_s3_bucket_name__real_env_specified(self):
+        "Environment-specific behavior of get_asiaq_s3_bucket_name with a configured env works as expected"
+        config_dict = deepcopy(self.BASE_CONFIG_DICT)
+        config_dict[disco_config.DEFAULT_CONFIG_SECTION].update(self.S3_BUCKET_CONFIG)
+        config = MockAsiaqConfig(config_dict, environment="production")
+        self.assertEquals("bucket-base--foobar--danger", config.get_asiaq_s3_bucket_name('foobar'))
+
+    def test__get_asiaq_s3_bucket_name__bad_env_specified(self):
+        "Environment-specific behavior of get_asiaq_s3_bucket_name with a nonsense env works as expected"
+        config_dict = deepcopy(self.BASE_CONFIG_DICT)
+        config_dict[disco_config.DEFAULT_CONFIG_SECTION].update(self.S3_BUCKET_CONFIG)
+        config = MockAsiaqConfig(config_dict, environment="nope")
+        self.assertEquals("bucket-base--foobar--blah", config.get_asiaq_s3_bucket_name('foobar'))

--- a/test/unit/test_disco_elasticsearch.py
+++ b/test/unit/test_disco_elasticsearch.py
@@ -13,6 +13,7 @@ from test.helpers.patch_disco_aws import get_mock_config
 MOCK_AWS_CONFIG_DEFINITION = {
     "disco_aws": {
         "default_domain_name": "aws.example.com",
+        "default_environment": "fake-ci",
     }
 }
 


### PR DESCRIPTION
Removed duplicative environment-specific option-finding code out of disco_ssm and disco_elasticache, and put it into a new subclass of ConfigParser, which disco_config.read_config will now return in place of ConfigParser.

In parallel, updated test-patching code to use a subclass of the new ConfigParser subclass, so that tests and live code are reading off the same hymnal.

For sneaky reasons related to why this seemed like a good idea in the first place, also added a new method for templating s3 bucket names.