### PR TITLE
Add support for multiple instance listeners in an ELB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1845,8 +1845,8 @@ Options:
 -   `elb` Create an ELB for this hostclass
 -   `elb_meta_network` [Optional] Meta network to run ELB in, defaults to same meta network as instances
 -   `elb_health_check_url` [Default /] The heartbeat end-point to test instance health
--   `elb_instance_port` [Default=80] The port number that your services are running on
--   `elb_instance_protocol` [Default inferred from port] HTTP | HTTPS | SSL | TCP
+-   `elb_instance_port` [Default=80] A comma separated list of port numbers that your services are running on
+-   `elb_instance_protocol` [Default inferred from port] A comma separated list of instance protocols.  The protocols should be in the same order as the instance ports. HTTP | HTTPS | SSL | TCP
 -   `elb_port` [Default=80] Comma separated list of port numbers to expose in the ELB.
 -   `elb_protocol` [Default inferred from port] Comma separated list of protocols to expose from ELB. The protocols should be in the same order as the ELB ports. HTTP | HTTPS | SSL | TCP
 -   `elb_public` [Default no] yes | no Should the ELB have a publicly routable IP

--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,7 @@ Options:
 -   `domain_name` Top level domain name to use as a suffix for all ELB domain names
 -   `elb` Create an ELB for this hostclass
 -   `elb_meta_network` [Optional] Meta network to run ELB in, defaults to same meta network as instances
--   `elb_health_check_url` [Default /] The heartbeat end-point to test instance health
+-   `elb_health_check_url` [Default /] The heartbeat end-point to test instance health.  Note that if you have multiple port mappings, the health check will use the first mapping using HTTP(S) on the instance side.  If there are no HTTP(S) mappings, the health check will use the first mapping.
 -   `elb_instance_port` [Default inferred from protocol] A comma separated list of port numbers that your services are running on
 -   `elb_instance_protocol` [Default inferred from port] A comma separated list of instance protocols.  The protocols should be in the same order as the instance ports. HTTP | HTTPS | SSL | TCP
 -   `elb_port` [Default inferred from protocol] Comma separated list of port numbers to expose in the ELB.

--- a/README.md
+++ b/README.md
@@ -1845,9 +1845,9 @@ Options:
 -   `elb` Create an ELB for this hostclass
 -   `elb_meta_network` [Optional] Meta network to run ELB in, defaults to same meta network as instances
 -   `elb_health_check_url` [Default /] The heartbeat end-point to test instance health
--   `elb_instance_port` [Default=80] A comma separated list of port numbers that your services are running on
+-   `elb_instance_port` [Default inferred from protocol] A comma separated list of port numbers that your services are running on
 -   `elb_instance_protocol` [Default inferred from port] A comma separated list of instance protocols.  The protocols should be in the same order as the instance ports. HTTP | HTTPS | SSL | TCP
--   `elb_port` [Default=80] Comma separated list of port numbers to expose in the ELB.
+-   `elb_port` [Default inferred from protocol] Comma separated list of port numbers to expose in the ELB.
 -   `elb_protocol` [Default inferred from port] Comma separated list of protocols to expose from ELB. The protocols should be in the same order as the ELB ports. HTTP | HTTPS | SSL | TCP
 -   `elb_public` [Default no] yes | no Should the ELB have a publicly routable IP
 -   `elb_sticky_app_cookie` [Optional] Enable sticky sessions by setting the session cookie of your application

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -349,10 +349,12 @@ class DiscoAWS(object):
 
                 return values.split(',') if values else []
 
-            elb_ports = map(
-                int,
-                list_from_hostclass_option('elb_port')
-            )
+            elb_ports = [
+                int(port)
+                for port in list_from_hostclass_option(
+                    'elb_port'
+                )
+            ]
             elb_protocols = list_from_hostclass_option('elb_protocol')
             elb_protocols = [protocol.strip() for protocol in elb_protocols]
             elb_ports, elb_protocols = unzip(
@@ -364,12 +366,12 @@ class DiscoAWS(object):
                 ) or [(80, 'HTTP')]
             )
 
-            instance_ports = map(
-                int,
-                list_from_hostclass_option(
+            instance_ports = [
+                int(port)
+                for port in list_from_hostclass_option(
                     'elb_instance_port',
                 )
-            )
+            ]
             instance_protocols = list_from_hostclass_option(
                 'elb_instance_protocol'
             )

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -316,7 +316,7 @@ class DiscoAWS(object):
                 """
                 Return the default port for the protocol
                 """
-                return {'HTTP': 80, 'HTTPS': 443}.get(protocol)
+                return {'HTTP': 80, 'HTTPS': 443}[protocol]
 
             def unzip(things):
                 """

--- a/disco_aws_automation/disco_elb.py
+++ b/disco_aws_automation/disco_elb.py
@@ -261,7 +261,12 @@ class DiscoELB(object):
 
         for protocol, port in zip(instance_protocols, instance_ports):
             self._setup_health_check(
-                elb_id, health_check_url, protocol, port, elb_name)
+                elb_id,
+                health_check_url,
+                protocol,
+                port,
+                elb_name
+            )
         self._setup_sticky_cookies(elb_id, elb_ports, sticky_app_cookie, elb_name)
         self._update_elb_attributes(
             elb_id,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.4"
+__version__ = "1.2.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -10,7 +10,8 @@ from mock import MagicMock, call, patch, create_autospec
 from moto import mock_elb
 
 from disco_aws_automation import DiscoAWS
-from disco_aws_automation.exceptions import TimeoutError, SmokeTestError
+from disco_aws_automation.exceptions import TimeoutError, SmokeTestError, AsiaqConfigError
+from disco_aws_automation.disco_elb import DiscoELBPortConfig, DiscoELBPortMapping
 
 from test.helpers.patch_disco_aws import (patch_disco_aws,
                                           get_default_config_dict,
@@ -354,12 +355,13 @@ class DiscoAWSTests(TestCase):
         aws.elb.delete_elb.assert_not_called()
         aws.elb.get_or_create_elb.assert_called_once_with(
             'mhcelb',
-            elb_ports=(80,),
             health_check_url='/foo',
             hosted_zone_name='example.com',
-            instance_ports=(80,),
-            elb_protocols=('HTTP',),
-            instance_protocols=('HTTP',),
+            port_config=DiscoELBPortConfig(
+                [
+                    DiscoELBPortMapping(80, 'HTTP', 80, 'HTTP'),
+                ]
+            ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False,
@@ -399,12 +401,14 @@ class DiscoAWSTests(TestCase):
         aws.elb.delete_elb.assert_not_called()
         aws.elb.get_or_create_elb.assert_called_once_with(
             'mhcelb',
-            elb_ports=(443, 443),
             health_check_url='/foo',
             hosted_zone_name='example.com',
-            instance_ports=(80, 80),
-            elb_protocols=('HTTPS', 'HTTPS'),
-            instance_protocols=('HTTP', 'HTTP'),
+            port_config=DiscoELBPortConfig(
+                [
+                    DiscoELBPortMapping(80, 'HTTP', 443, 'HTTPS'),
+                    DiscoELBPortMapping(80, 'HTTP', 443, 'HTTPS')
+                ]
+            ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False,
@@ -444,12 +448,15 @@ class DiscoAWSTests(TestCase):
         aws.elb.delete_elb.assert_not_called()
         aws.elb.get_or_create_elb.assert_called_once_with(
             'mhcelb',
-            elb_ports=(443, 443, 27017),
             health_check_url='/foo',
             hosted_zone_name='example.com',
-            instance_ports=(80, 80, 27017),
-            elb_protocols=('HTTPS', 'HTTPS', 'TCP'),
-            instance_protocols=('HTTP', 'HTTP', 'TCP'),
+            port_config=DiscoELBPortConfig(
+                [
+                    DiscoELBPortMapping(80, 'HTTP', 443, 'HTTPS'),
+                    DiscoELBPortMapping(80, 'HTTP', 443, 'HTTPS'),
+                    DiscoELBPortMapping(27017, 'TCP', 27017, 'TCP')
+                ]
+            ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False,
@@ -489,12 +496,13 @@ class DiscoAWSTests(TestCase):
         aws.elb.delete_elb.assert_not_called()
         aws.elb.get_or_create_elb.assert_called_once_with(
             'mhcelb',
-            elb_ports=(443,),
             health_check_url='/foo',
             hosted_zone_name='example.com',
-            instance_ports=(80,),
-            elb_protocols=('HTTPS',),
-            instance_protocols=('HTTP',),
+            port_config=DiscoELBPortConfig(
+                [
+                    DiscoELBPortMapping(80, 'HTTP', 443, 'HTTPS'),
+                ]
+            ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
             connection_draining_timeout=300, idle_timeout=300, testing=False,
@@ -507,6 +515,30 @@ class DiscoAWSTests(TestCase):
             cross_zone_load_balancing=True,
             cert_name=None
         )
+
+    @mock_elb
+    @patch_disco_aws
+    def test_update_elb_mismatch(self, mock_config, **kwargs):
+        """
+        update_elb raises when given mismatched numbers of instance and ELB ports
+        """
+        overrides = {
+            'elb_instance_port': '80',
+            'elb_instance_protocol': 'HTTP',
+            'elb_port': '443, 80',
+            'elb_protocol': 'HTTPS, HTTP'
+        }
+        aws = DiscoAWS(
+            config=self._get_elb_config(overrides),
+            environment_name=TEST_ENV_NAME,
+            elb=MagicMock()
+        )
+        aws.elb.get_or_create_elb = MagicMock(return_value=MagicMock())
+        aws.get_meta_network_by_name = _get_meta_network_mock()
+        aws.elb.delete_elb = MagicMock()
+
+        with self.assertRaises(AsiaqConfigError):
+            aws.update_elb("mhcelb", update_autoscaling=False)
 
     @patch_disco_aws
     def test_create_userdata_with_eip(self, **kwargs):

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -415,6 +415,50 @@ class DiscoAWSTests(TestCase):
             cert_name=None
         )
 
+    @mock_elb
+    @patch_disco_aws
+    def test_update_elb_no_defaults(self, mock_config, **kwargs):
+        """
+        update_elb calls get_or_create_elb with port and protocol values
+        """
+        overrides = {
+            'elb_instance_port': '80, 80, 27017',
+            'elb_instance_protocol': 'HTTP, HTTP, TCP',
+            'elb_port': '443, 443, 27017',
+            'elb_protocol': 'HTTPS, HTTPS, TCP'
+        }
+        aws = DiscoAWS(
+            config=self._get_elb_config(overrides),
+            environment_name=TEST_ENV_NAME,
+            elb=MagicMock()
+        )
+        aws.elb.get_or_create_elb = MagicMock(return_value=MagicMock())
+        aws.get_meta_network_by_name = _get_meta_network_mock()
+        aws.elb.delete_elb = MagicMock()
+
+        aws.update_elb("mhcelb", update_autoscaling=False)
+
+        aws.elb.delete_elb.assert_not_called()
+        aws.elb.get_or_create_elb.assert_called_once_with(
+            'mhcelb',
+            elb_ports=(443, 443, 27017),
+            health_check_url='/foo',
+            hosted_zone_name='example.com',
+            instance_ports=(80, 80, 27017),
+            elb_protocols=('HTTPS', 'HTTPS', 'TCP'),
+            instance_protocols=('HTTP', 'HTTP', 'TCP'),
+            security_groups=['sg-1234abcd'], elb_public=False,
+            sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            connection_draining_timeout=300, idle_timeout=300, testing=False,
+            tags={
+                'environment': 'unittestenv',
+                'hostclass': 'mhcelb',
+                'is_testing': '0'
+            },
+            cross_zone_load_balancing=True,
+            cert_name=None
+        )
+
     @patch_disco_aws
     def test_create_userdata_with_eip(self, **kwargs):
         """

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -366,7 +366,8 @@ class DiscoAWSTests(TestCase):
             tags={
                 'environment': 'unittestenv',
                 'hostclass': 'mhcelb',
-                'is_testing': '0'
+                'is_testing': '0',
+                'productline': 'mock_productline'
             },
             cross_zone_load_balancing=True,
             cert_name=None
@@ -410,7 +411,8 @@ class DiscoAWSTests(TestCase):
             tags={
                 'environment': 'unittestenv',
                 'hostclass': 'mhcelb',
-                'is_testing': '0'
+                'is_testing': '0',
+                'productline': 'mock_productline'
             },
             cross_zone_load_balancing=True,
             cert_name=None
@@ -454,7 +456,8 @@ class DiscoAWSTests(TestCase):
             tags={
                 'environment': 'unittestenv',
                 'hostclass': 'mhcelb',
-                'is_testing': '0'
+                'is_testing': '0',
+                'productline': 'mock_productline'
             },
             cross_zone_load_balancing=True,
             cert_name=None


### PR DESCRIPTION
disco_elb now supports multiple instance ports and protocols so you can
expose more than one service running on the same host.  Note that I've left the configuration options the same for backwards compatibility.