### PR TITLE
Bug fix on disco_bake.py

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -687,7 +687,7 @@ class DiscoBake(object):
             amis = self.get_amis(filters=filters)
             logger.debug("AMI search for %s found %s", filters, amis)
             amis = self.ami_filter(amis, stage, product_line)
-            stages = [val.strip() for val in stage.split(",")]
+            stages = [val.strip() for val in stage.split(",")] if stage else []
             return self._latest_best_stage_ami(stages, amis)
         else:
             raise ValueError("Must specify either hostclass or AMI")

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
In the find_ami(...) method, making sure `stage` is not `None` before calling split method on it.