### PR TITLE
Enable creation of custom DNS aliases for ELBs.

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -324,6 +324,7 @@ class DiscoAWS(object):
                 instance_protocol=instance_protocol, instance_port=instance_port,
                 elb_protocols=elb_protocol, elb_ports=elb_port,
                 elb_public=is_truthy(self.hostclass_option_default(hostclass, "elb_public", "no")),
+                elb_dns_alias=self.hostclass_option_default(hostclass, "elb_dns_alias"),
                 sticky_app_cookie=self.hostclass_option_default(hostclass, "elb_sticky_app_cookie", None),
                 idle_timeout=int(self.hostclass_option_default(hostclass, "elb_idle_timeout", 300)),
                 connection_draining_timeout=int(self.hostclass_option_default(hostclass,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -364,6 +364,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -411,6 +412,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -459,6 +461,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -505,6 +508,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -551,6 +555,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -598,6 +603,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -641,6 +647,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',
@@ -687,6 +694,7 @@ class DiscoAWSTests(TestCase):
             ),
             security_groups=['sg-1234abcd'], elb_public=False,
             sticky_app_cookie=None, subnets=['s-1234abcd', 's-1234abcd', 's-1234abcd'],
+            elb_dns_alias=None,
             connection_draining_timeout=300, idle_timeout=300, testing=False,
             tags={
                 'environment': 'unittestenv',


### PR DESCRIPTION
Relevant to [AS-699](https://amplify-litco.atlassian.net/browse/AS-699): allow specifying a short DNS alias (e.g. "python-repo") as a configuration parameter, to enable ELBs to be aliased to less implementation-dependent names (e.g. "python-repo.aws.wgen.net").