### PR TITLE
Add tagging for RDS instances

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -269,7 +269,7 @@ class RDS(threading.Thread):
             {'Key': 'environment', 'Value': env_name},
             {'Key': 'db-name', 'Value': database_name},
             {'Key': 'productline', 'Value': self.config_with_default(self.config_rds, section,
-                                                                     'productline',
+                                                                     'product_line',
                                                                      'unknown')}
         ]
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.9"
+__version__ = "1.1.10"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -83,7 +83,7 @@ class RDSTests(unittest.TestCase):
                     'db_instance_class': 'db.m4.2xlarge',
                     'engine_version': '12.1.0.2.v2',
                     'master_username': 'foo',
-                    'productline': 'mock_productline'
+                    'product_line': 'mock_productline'
                 },
                 'some-env-db-name-with-windows': {
                     'engine': 'oracle',
@@ -93,7 +93,7 @@ class RDSTests(unittest.TestCase):
                     'master_username': 'foo',
                     'preferred_backup_window': MOCK_BACKUP_WINDOW,
                     'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
-                    'productline': 'mock_productline'
+                    'product_line': 'mock_productline'
                 }
             })
 
@@ -140,7 +140,7 @@ class RDSTests(unittest.TestCase):
                 'db_instance_class': 'db.m4.2xlarge',
                 'engine_version': '12.1.0.2.v2',
                 'master_username': 'foo',
-                'productline': 'mock_productline'
+                'product_line': 'mock_productline'
             },
             'some-env-db-name-with-windows': {
                 'engine': 'oracle',
@@ -150,7 +150,7 @@ class RDSTests(unittest.TestCase):
                 'master_username': 'foo',
                 'preferred_backup_window': MOCK_BACKUP_WINDOW,
                 'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
-                'productline': 'mock_productline'
+                'product_line': 'mock_productline'
             }
         })
 
@@ -218,7 +218,7 @@ class RDSTests(unittest.TestCase):
                 'db_instance_class': 'db.m4.2xlarge',
                 'engine_version': '12.1.0.2.v2',
                 'master_username': 'foo',
-                'productline': 'mock_productline'
+                'product_line': 'mock_productline'
             }
         })
 
@@ -278,7 +278,7 @@ class DiscoRDSTests(unittest.TestCase):
                     'db_instance_class': 'db.m4.2xlarge',
                     'engine_version': '12.1.0.2.v2',
                     'master_username': 'foo',
-                    'productline': 'mock_productline'
+                    'product_line': 'mock_productline'
                 },
                 'some-env-db-name-with-windows': {
                     'engine': 'oracle',
@@ -288,7 +288,7 @@ class DiscoRDSTests(unittest.TestCase):
                     'master_username': 'foo',
                     'preferred_backup_window': MOCK_BACKUP_WINDOW,
                     'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
-                    'productline': 'mock_productline'
+                    'product_line': 'mock_productline'
                 }
             })
             self.rds.domain_name = 'example.com'

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -82,7 +82,8 @@ class RDSTests(unittest.TestCase):
                     'allocated_storage': '100',
                     'db_instance_class': 'db.m4.2xlarge',
                     'engine_version': '12.1.0.2.v2',
-                    'master_username': 'foo'
+                    'master_username': 'foo',
+                    'productline': 'mock_productline'
                 },
                 'some-env-db-name-with-windows': {
                     'engine': 'oracle',
@@ -91,7 +92,8 @@ class RDSTests(unittest.TestCase):
                     'engine_version': '12.1.0.2.v2',
                     'master_username': 'foo',
                     'preferred_backup_window': MOCK_BACKUP_WINDOW,
-                    'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW
+                    'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
+                    'productline': 'mock_productline'
                 }
             })
 
@@ -137,7 +139,8 @@ class RDSTests(unittest.TestCase):
                 'allocated_storage': '100',
                 'db_instance_class': 'db.m4.2xlarge',
                 'engine_version': '12.1.0.2.v2',
-                'master_username': 'foo'
+                'master_username': 'foo',
+                'productline': 'mock_productline'
             },
             'some-env-db-name-with-windows': {
                 'engine': 'oracle',
@@ -146,7 +149,8 @@ class RDSTests(unittest.TestCase):
                 'engine_version': '12.1.0.2.v2',
                 'master_username': 'foo',
                 'preferred_backup_window': MOCK_BACKUP_WINDOW,
-                'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW
+                'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
+                'productline': 'mock_productline'
             }
         })
 
@@ -177,7 +181,13 @@ class RDSTests(unittest.TestCase):
             LicenseModel='bring-your-own-license',
             MultiAZ=True,
             Port=1521,
-            PubliclyAccessible=False)
+            PubliclyAccessible=False,
+            Tags=[
+                {'Key': 'environment', 'Value': 'some-env'},
+                {'Key': 'db-name', 'Value': 'db-name'},
+                {'Key': 'productline', 'Value': 'mock_productline'}
+            ]
+        )
 
         self.rds.client.create_db_parameter_group.assert_called_once_with(
             DBParameterGroupName='unittestenv-db-name',
@@ -207,7 +217,8 @@ class RDSTests(unittest.TestCase):
                 'allocated_storage': '100',
                 'db_instance_class': 'db.m4.2xlarge',
                 'engine_version': '12.1.0.2.v2',
-                'master_username': 'foo'
+                'master_username': 'foo',
+                'productline': 'mock_productline'
             }
         })
 
@@ -266,7 +277,8 @@ class DiscoRDSTests(unittest.TestCase):
                     'allocated_storage': '100',
                     'db_instance_class': 'db.m4.2xlarge',
                     'engine_version': '12.1.0.2.v2',
-                    'master_username': 'foo'
+                    'master_username': 'foo',
+                    'productline': 'mock_productline'
                 },
                 'some-env-db-name-with-windows': {
                     'engine': 'oracle',
@@ -275,7 +287,8 @@ class DiscoRDSTests(unittest.TestCase):
                     'engine_version': '12.1.0.2.v2',
                     'master_username': 'foo',
                     'preferred_backup_window': MOCK_BACKUP_WINDOW,
-                    'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW
+                    'preferred_maintenance_window': MOCK_MAINTENANCE_WINDOW,
+                    'productline': 'mock_productline'
                 }
             })
             self.rds.domain_name = 'example.com'


### PR DESCRIPTION
This change would add environment, db-name, and  productline tags for RDS instances.

Config changes are here: https://github.com/amplifylitco/asiaq_astro_config/pull/1120