### PR TITLE
Dynamodb backup VPC specificity

### DIFF
--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -123,7 +123,8 @@ class DynamoDbBackupCommand(CliCommand):
             parser.add_argument("table_name")
             parser.add_argument("--force-reload", action='store_true',
                                 help="Force recreation of the pipeline content")
-            parser.add_argument("--metanetwork", metavar="NAME", help="Metanetwork in which to launch pipeline assets")
+            parser.add_argument("--metanetwork", metavar="NAME",
+                                help="Metanetwork in which to launch pipeline assets")
 
         restore_parser.add_argument("--from", dest="backup_dir",
                                     help="Previous backup to restore from (default: latest)")

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -201,13 +201,14 @@ class DataPipelineCommand(CliCommand):
         for record in found:
             output = [record._id, record._name]
             if self.args.health:
-                output.append(record.health)
+                output.append(record.health or "N/A")
             if self.args.state:
                 output.append(record.pipeline_state)
             if self.args.create_date:
                 output.append(record.create_date.astimezone(user_tz).isoformat())
             if self.args.last_run:
-                output.append(record.last_run.astimezone(user_tz).isoformat())
+                last_run = record.last_run
+                output.append(last_run.astimezone(user_tz).isoformat() if last_run else "NEVER")
             if self.args.desc:
                 output.append(record._description or "")
 

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -60,12 +60,18 @@ class AsiaqDataPipeline(object):
     @property
     def last_run(self):
         "Return a UTC datetime for the last time this pipeline was run (and if it fails...?)"
-        return self._date_metadata_field(DataPipelineMetadata.LAST_RUN)
+        try:
+            return self._date_metadata_field(DataPipelineMetadata.LAST_RUN)
+        except KeyError:
+            return None
 
     @property
     def health(self):
         """Return the health code (e.g. "HEALTHY", we hope) for this pipeline."""
-        return self._metadata_field(DataPipelineMetadata.HEALTH)
+        try:
+            return self._metadata_field(DataPipelineMetadata.HEALTH)
+        except KeyError:
+            return None
 
     @property
     def pipeline_state(self):
@@ -108,8 +114,7 @@ class AsiaqDataPipeline(object):
         for field_definition in self._metadata:
             if field_definition['key'] == field_name:
                 return field_definition['stringValue']
-        raise DataPipelineStateException("Field '%s' was not found in pipeline '%s'"
-                                         % (field_name, self._name))
+        raise KeyError("Field '%s' was not found in pipeline '%s'" % (field_name, self._name))
 
     def _date_metadata_field(self, field_name, with_timezone=True):
         timestamp = self._metadata_field(field_name)

--- a/disco_aws_automation/disco_dynamodb.py
+++ b/disco_aws_automation/disco_dynamodb.py
@@ -188,7 +188,7 @@ class AsiaqDynamoDbBackupManager(object):
             self._s3_bucket_name = bucket_name
         return self._s3_bucket_name
 
-    def create_backup(self, table_name, start=True):
+    def create_backup(self, table_name, start=True, force_update=False):
         """
         Create a backup pipeline for the given table, and start it running (unless the
         'start' argument is False).
@@ -200,7 +200,8 @@ class AsiaqDynamoDbBackupManager(object):
         pipeline = self._mgr.fetch_or_create(self.BACKUP_PIPELINE_TEMPLATE, pipeline_name=pipeline_name,
                                              tags=tags,
                                              pipeline_description=pipeline_description,
-                                             log_location=self._s3_url("logs"))
+                                             log_location=self._s3_url("logs"),
+                                             force_update=force_update)
         if start:
             param_values = self._get_table_params(table_name)
             param_values['myOutputS3Loc'] = self._s3_url(env, table_name)

--- a/disco_aws_automation/disco_subnet.py
+++ b/disco_aws_automation/disco_subnet.py
@@ -101,6 +101,11 @@ class DiscoSubnet(object):
                                        'tag:meta_network': [self.metanetwork.name]})
         }
 
+    @property
+    def subnet_id(self):
+        """Returns AWS subnet ID"""
+        return self._subnet_dict['SubnetId']
+
     def recreate_route_table(self):
         """ Re-create the route table with all the routes from the current route table """
         new_route_table = self._create_route_table()

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -43,7 +43,7 @@ class ProgrammerError(Exception):
 
 
 class AsiaqConfigError(EasyExit):
-    "An exception that results from a config file not being found (no stack trace needed)."
+    "An exception that results from a configuration problem (file or value not found; no stack trace needed)."
     pass
 
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.13"
+__version__ = "1.1.14"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.14"
+__version__ = "1.1.15"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_datapipeline.py
+++ b/test/unit/test_disco_datapipeline.py
@@ -88,6 +88,7 @@ class DataPipelineTest(TestCase):
         self.assertFalse(pipeline._tags)
         self.assertFalse(pipeline.is_persisted())
         self.assertTrue(pipeline.has_content())
+
         def _find_default(objects):
             for obj in objects:
                 if obj['id'] == 'Default':


### PR DESCRIPTION
Made the ddb_backup command able to take a metanetwork as an optional argument, so it can find a subnet that it makes sense to launch pipeline assets into, and able to force-update existing pipelines so that we can fix things if those subnets change.

After returning from vacation, also added status/last-run/creation-date printing to the datapipeline list command.