### PR TITLE
Reserve ENI used by hostclasses during VPC creation

### DIFF
--- a/bin/disco_vpc_ui.py
+++ b/bin/disco_vpc_ui.py
@@ -28,6 +28,9 @@ def parse_arguments():
                                help='What to call the new environment.')
     parser_create.add_argument('--type', dest='vpc_type', required=True,
                                help='What type of environment to create (as defined in config).')
+    parser_create.add_argument('--skip-enis', dest='skip_enis', action='store_const',
+                               const=True, default=False,
+                               help="Skip pre-allocating ENIs with static IPs used by hostclasses.")
 
     parser_destroy = subparsers.add_parser(
         'destroy', help='Delete environment releasing all non-persistent resources.')
@@ -82,7 +85,7 @@ def create_vpc_command(args):
         print("VPC with same name already exists.")
         sys.exit(1)
     else:
-        vpc = DiscoVPC(args.vpc_name, args.vpc_type)
+        vpc = DiscoVPC(args.vpc_name, args.vpc_type, skip_enis_pre_allocate=args.skip_enis)
         print("VPC {0}({1}) has been created".format(args.vpc_name, vpc.get_vpc_id()))
 
 

--- a/disco_aws_automation/disco_config.py
+++ b/disco_aws_automation/disco_config.py
@@ -129,3 +129,8 @@ class AsiaqConfig(ConfigParser):
         if bucket_suffix:
             bucket_parts.append(bucket_suffix)
         return separator.join(bucket_parts)
+
+    def get_hostclasses_from_section_names(self):
+        """Returns list of section names that represent hostclasses"""
+        return [section for section in self.sections()
+                if section.startswith("mhc")]

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -23,6 +23,7 @@ from .disco_config import normalize_path
 from .disco_alarm import DiscoAlarm
 from .disco_alarm_config import DiscoAlarmsConfig
 from .disco_autoscale import DiscoAutoscale
+from .disco_config import read_config
 from .disco_constants import CREDENTIAL_BUCKET_TEMPLATE, NETWORKS, VPC_CONFIG_FILE
 from .disco_elasticache import DiscoElastiCache
 from .disco_elb import DiscoELB
@@ -35,7 +36,7 @@ from .disco_vpc_gateways import DiscoVPCGateways
 from .disco_vpc_peerings import DiscoVPCPeerings
 from .disco_vpc_sg_rules import DiscoVPCSecurityGroupRules
 from .resource_helper import (tag2dict, create_filters, keep_trying, throttled_call)
-from .exceptions import (VPCConfigError, VPCEnvironmentError)
+from .exceptions import (IPRangeError, VPCConfigError, VPCEnvironmentError)
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +49,13 @@ class DiscoVPC(object):
     """
 
     def __init__(self, environment_name, environment_type, vpc=None,
-                 config_file=None, boto3_ec2=None, defer_creation=False):
+                 config_file=None, boto3_ec2=None, defer_creation=False,
+                 aws_config=None, skip_enis_pre_allocate=False):
         self.config_file = config_file or VPC_CONFIG_FILE
 
         self.environment_name = environment_name
         self.environment_type = environment_type
+        self.skip_enis_pre_allocate = skip_enis_pre_allocate
 
         # Lazily initialized
         self._config = None
@@ -60,6 +63,7 @@ class DiscoVPC(object):
         self._networks = None
         self._alarms_config = None
         self._disco_vpc_endpoints = None
+        self._aws_config = aws_config
 
         if boto3_ec2:
             self.boto3_ec2 = boto3_ec2
@@ -82,6 +86,13 @@ class DiscoVPC(object):
             self.vpc = vpc
         elif not defer_creation:
             self.create()
+
+    @property
+    def aws_config(self):
+        "Auto-populate and return an AsiaqConfig for the standard configuration file."
+        if not self._aws_config:
+            self._aws_config = read_config(environment=self.environment_name)
+        return self._aws_config
 
     @property
     def config(self):
@@ -253,6 +264,28 @@ class DiscoVPC(object):
 
         return metanetworks
 
+    def _reserve_hostclass_ip_addresses(self):
+        """
+        Reserves static ip addresses used by hostclasses by pre-creating the ENIs,
+        so that these IPs won't be occupied by AWS services, such as RDS, ElastiCache, etc.
+        """
+        for hostclass in self.aws_config.get_hostclasses_from_section_names():
+            ip_address = self.aws_config.get_asiaq_option(
+                "ip_address", section=hostclass, required=False)
+            if ip_address:
+                meta_network = self.networks[
+                    self.aws_config.get_asiaq_option("meta_network", section=hostclass)]
+
+                if ip_address.startswith("-") or ip_address.startswith("+"):
+                    try:
+                        ip_address = str(meta_network.ip_by_offset(ip_address))
+                    except IPRangeError as exc:
+                        logger.warn("Failed to reserve IP address (%s) for hostclass (%s) due "
+                                    "to IPRangeError: %s", ip_address, hostclass, exc.message)
+                        continue
+
+                meta_network.get_interface(ip_address)
+
     def find_instance_route_table(self, instance):
         """ Return route tables corresponding to instance """
         rt_filters = self.vpc_filters()
@@ -417,6 +450,8 @@ class DiscoVPC(object):
                        VpcId=self.vpc['VpcId'], EnableDnsHostnames={'Value': True})
 
         self._networks = self._create_new_meta_networks()
+        if not self.skip_enis_pre_allocate:
+            self._reserve_hostclass_ip_addresses()
 
         self._update_dhcp_options()
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.13"
+__version__ = "1.1.14"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.14"
+__version__ = "1.1.15"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/helpers/patch_disco_aws.py
+++ b/test/helpers/patch_disco_aws.py
@@ -55,7 +55,8 @@ def get_default_config_dict():
                           "zookeeper_hostclass": "mhczookeeper",
                           "logger_hostclass": "mhclogger",
                           "logforwarder_hostclass": "mhclogforwarder",
-                          "default_smoketest_termination": "True"},
+                          "default_smoketest_termination": "True",
+                          "default_environment": "auto-vpc-type"},
             "mhczookeeper": {"ip_address": "10.0.0.1"}}
 
 


### PR DESCRIPTION
Some AWS resources (Elasticache, RDS, Lambda, EC2 instances, etc) can allocate ENIs in a VPC. This causes a problem if a EC2 instance spins up later that is configured to use that static IP. This mostly happens during CI spinup when everything is spinning up at the same time and its possible for a resource to grab a ENI before a EC2 instance gets it.

This PR intends to fix this by changing the VPC spinup process to create ENIs preemptively before spinning up any other resources. This should cause AWS to use some other IP address when spinning up EC, RDS, etc.