### PR TITLE
Allow Excluding AMIs From Cleanup

### DIFF
--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -92,6 +92,8 @@ def get_parser():
                                     help='Restrict to this productline', default=None)
     parser_cleanupamis.add_argument('--dryrun', dest='dryrun', action='store_const', const=True,
                                     default=False, help='Print out amis to be deleted without deleting them')
+    parser_cleanupamis.add_argument('--exclude-amis', dest='exclude_amis', type=str, default='',
+                                    help="A comma seperated list of AMIs to not delete")
 
     parser_bake = subparsers.add_parser('bake', help="Create an ami",
                                         description="Phase1 AMI is created if hostclass is omited. "
@@ -179,7 +181,16 @@ def run():
         bakery.delete_ami(args.ami)
     elif args.mode == "cleanupamis":
         bakery = DiscoBake()
-        bakery.cleanup_amis(args.hostclass, args.product_line, args.stage, args.days, args.count, args.dryrun)
+        exclude_amis = args.exclude_amis.split(',')
+        bakery.cleanup_amis(
+            args.hostclass,
+            args.product_line,
+            args.stage,
+            args.days,
+            args.count,
+            args.dryrun,
+            exclude_amis
+        )
 
 if __name__ == "__main__":
     run_gracefully(run)

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -515,7 +515,7 @@ class DiscoBake(object):
         amis = self.connection.get_all_images(owners=['self'], filters=filters)
 
         if excluded_amis:
-            amis = [ami for ami in amis if ami.name not in excluded_amis]
+            amis = [ami for ami in amis if ami.id not in excluded_amis]
 
         ami_map = defaultdict(list)
         for ami in amis:

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -487,7 +487,8 @@ class DiscoBake(object):
         return self.connection.get_all_images(
             image_ids=image_ids, owners=trusted_accounts, filters=filters)
 
-    def cleanup_amis(self, restrict_hostclass, product_line, stage, min_age, min_count, dry_run):
+    def cleanup_amis(self, restrict_hostclass, product_line, stage, min_age, min_count, dry_run,
+                     excluded_amis):
         """
         Deletes oldest AMIs so long as they are older than min_age and there
         are at least min_count AMIs remaining in the hostclass.
@@ -497,6 +498,8 @@ class DiscoBake(object):
 
         If product_line is not None, then this will only iterate over amis tagged
         with that specific productline.
+
+        If excluded_amis has any items, they are excluded from deletion.
 
         """
         # Pylint complains that this function has one too many local variables.  But deleting any
@@ -510,6 +513,10 @@ class DiscoBake(object):
             filters["tag:productline"] = product_line
 
         amis = self.connection.get_all_images(owners=['self'], filters=filters)
+
+        if excluded_amis:
+            amis = [ami for ami in amis if ami.name not in excluded_amis]
+
         ami_map = defaultdict(list)
         for ami in amis:
             if AMI_NAME_PATTERN.match(ami.name):

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -512,7 +512,7 @@ class DiscoBake(object):
         if product_line:
             filters["tag:productline"] = product_line
 
-        amis = self.connection.get_all_images(owners=['self'], filters=filters)
+        amis = self.get_amis(filters=filters)
 
         if excluded_amis:
             amis = [ami for ami in amis if ami.id not in excluded_amis]

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -482,13 +482,13 @@ class DiscoBake(object):
             amis, key=DiscoBake._ami_sort_key, reverse=True)
         return set(amis_sorted_by_creation_time_desc[max_count:])
 
-    def get_amis(self, image_ids=None, filters=None):
+    def get_amis(self, image_ids=None, filters=None, owners=None):
         """
         Returns images owned by a trusted account (including ourselves)
         """
         trusted_accounts = list(set(self.option_default("trusted_account_ids", "").split()) | set(['self']))
         return self.connection.get_all_images(
-            image_ids=image_ids, owners=trusted_accounts, filters=filters)
+            image_ids=image_ids, owners=owners or trusted_accounts, filters=filters)
 
     def cleanup_amis(self, restrict_hostclass, product_line, stage, min_age, min_count, dry_run,
                      excluded_amis):
@@ -515,7 +515,7 @@ class DiscoBake(object):
         if product_line:
             filters["tag:productline"] = product_line
 
-        amis = self.get_amis(filters=filters)
+        amis = self.get_amis(filters=filters, owners=['self'])
 
         if excluded_amis:
             amis = [ami for ami in amis if ami.id not in excluded_amis]

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.14"
+__version__ = "1.1.15"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_bake.py
+++ b/test/unit/test_disco_bake.py
@@ -13,7 +13,7 @@ from disco_aws_automation import DiscoBake, AMIError
 class DiscoBakeTests(TestCase):
     '''Test DiscoBake class'''
 
-    def mock_ami(self, name, stage=None, product_line=None, state=u'available'):
+    def mock_ami(self, name, stage=None, product_line=None, state=u'available', block_device_mapping=None):
         '''Create a mock AMI'''
         def _mock_get(tag_name, default=None):
             if tag_name == "productline":
@@ -26,6 +26,7 @@ class DiscoBakeTests(TestCase):
         ami.tags = MagicMock(get=_mock_get)
         ami.id = 'ami-' + ''.join(random.choice("0123456789abcdef") for _ in range(8))
         ami.state = state
+        ami.block_device_mapping = block_device_mapping or {}
         return ami
 
     def add_ami(self, name, stage, product_line=None, state=u'available'):
@@ -45,11 +46,11 @@ class DiscoBakeTests(TestCase):
         self._bake.get_ami_creation_time = DiscoBake.extract_ami_creation_time_from_ami_name
         self._amis = []
         self._amis_by_name = {}
-        self.add_ami('mhcfoo 1', 'untested', 'astro', 'unavailable')
-        self.add_ami('mhcbar 2', 'tested')
-        self.add_ami('mhcfoo 4', 'tested', 'astro')
-        self.add_ami('mhcfoo 5', 'failed')
-        self.add_ami('mhcbar 1', 'tested', 'someone_else', 'unavailable')
+        self.add_ami('mhcfoo 0000000001', 'untested', 'astro', 'unavailable')
+        self.add_ami('mhcbar 0000000002', 'tested')
+        self.add_ami('mhcfoo 0000000004', 'tested', 'astro')
+        self.add_ami('mhcfoo 0000000005', 'failed')
+        self.add_ami('mhcbar 0000000001', 'tested', 'someone_else', 'unavailable')
         self._bake.get_amis = MagicMock(return_value=self._amis)
 
     def test_get_phase1_ami_id_success(self):
@@ -76,28 +77,51 @@ class DiscoBakeTests(TestCase):
         '''Test that list amis can filter by product line successfully'''
         self.assertEqual(
             self._bake.list_amis(product_line="astro"), [
-                self._amis_by_name["mhcfoo 1"],
-                self._amis_by_name["mhcfoo 4"]])
+                self._amis_by_name["mhcfoo 0000000001"],
+                self._amis_by_name["mhcfoo 0000000004"]])
 
     def test_list_amis_by_stage(self):
         '''Test that list amis can filter by stage successfully'''
         self.assertEqual(self._bake.list_amis(stage="failed"),
-                         [self._amis_by_name["mhcfoo 5"]])
+                         [self._amis_by_name["mhcfoo 0000000005"]])
 
     def test_list_amis_by_state(self):
         '''Test that list amis can filter by state successfully'''
         self.assertEqual(self._bake.list_amis(state="unavailable"),
-                         [self._amis_by_name["mhcfoo 1"],
-                          self._amis_by_name["mhcbar 1"]])
+                         [self._amis_by_name["mhcfoo 0000000001"],
+                          self._amis_by_name["mhcbar 0000000001"]])
 
     def test_list_amis_by_hostclass(self):
         '''Test that list amis can filter by hostclass successfully'''
         self.assertEqual(self._bake.list_amis(hostclass="mhcfoo"),
-                         [self._amis_by_name["mhcfoo 1"],
-                          self._amis_by_name["mhcfoo 4"],
-                          self._amis_by_name["mhcfoo 5"]])
+                         [self._amis_by_name["mhcfoo 0000000001"],
+                          self._amis_by_name["mhcfoo 0000000004"],
+                          self._amis_by_name["mhcfoo 0000000005"]])
 
     def test_list_amis_by_productline_and_stage(self):
         '''Test that list amis can filter by productline and stage successfully'''
         self.assertEqual(self._bake.list_amis(stage="tested", product_line="someone_else"),
-                         [self._amis_by_name["mhcbar 1"]])
+                         [self._amis_by_name["mhcbar 0000000001"]])
+
+    def test_cleanup_amis(self):
+        '''Test that cleanup deletes AMIs'''
+        self._bake.cleanup_amis(None, None, 'tested', -1, 0, False, None)
+
+        for ami in self._amis:
+            print ami.name, ami.id, ami.tags.get('stage'), ami.deregister.called
+
+        self.assertTrue(self._amis_by_name["mhcbar 0000000001"].deregister.called)
+        self.assertTrue(self._amis_by_name["mhcbar 0000000002"].deregister.called)
+        self.assertTrue(self._amis_by_name["mhcfoo 0000000004"].deregister.called)
+
+    def test_cleanup_amis_exclude(self):
+        '''Test that cleanup ignores excluded AMIs'''
+        self._bake.cleanup_amis(None, None, 'tested', -1, 0, False,
+                                [self._amis_by_name["mhcbar 0000000002"].id])
+
+        for ami in self._amis:
+            print ami.name, ami.id, ami.tags.get('stage'), ami.deregister.called
+
+        self.assertTrue(self._amis_by_name["mhcbar 0000000001"].deregister.called)
+        self.assertFalse(self._amis_by_name["mhcbar 0000000002"].deregister.called)
+        self.assertTrue(self._amis_by_name["mhcfoo 0000000004"].deregister.called)


### PR DESCRIPTION
Added a new cli option to `disco_bake.py cleanupamis` named
`--exclude-amis`. This option takes a comma seperated list of AMIs that
should be excluded from deletion by the `cleanupamis` command. This is
needed in order to support blacklisting of AMIs that should not be
deleted because they are in use in production.