### PR TITLE
Added correlation ID and instance profiles to bakes.

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.16"
+__version__ = "1.1.17"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Added a correlation ID (a UUID) to the arguments passed to the init script, so
that we can have an instance report information about itself that can be associated
with the bake job.

Added an option to set an instance profile at bake time, in case we ever want to use
this correlation ID to report information at bake time through an IAM-protected API.