### PR TITLE
Catch BotoServerError errors polling AWS calls

### DIFF
--- a/disco_aws_automation/resource_helper.py
+++ b/disco_aws_automation/resource_helper.py
@@ -124,7 +124,7 @@ def wait_for_state(resource, state, timeout=15 * 60, state_attr='state'):
                 raise ExpectedTimeoutError(
                     "{0} entered state {1} after {2}s waiting for state {3}"
                     .format(resource, current_state, time_passed, state))
-        except EC2ResponseError:
+        except (EC2ResponseError, BotoServerError):
             pass  # These are most likely transient, we will timeout if they are not
 
         if time_passed >= timeout:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.19"
+__version__ = "1.1.20"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
AWS can throw `BotoServerError` when we are being throttled so catch those errors so that we can retry the request after waiting for a period