### PR TITLE
Botocore Version Bump

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.19"
+__version__ = "1.1.20"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 boto>=2.38.0,<3
 boto3>=1.4.0,<2
-botocore>=1.4.50,<1.5
+botocore>=1.4.50,<1.6.0
 docopt>=0.6.1,<1
 passlib>=1.6.1,<2
 pytz>=2014.7


### PR DESCRIPTION
A specified version of botocore was pinned to get around some issues
with sandboxes. Now boto3 requires a more recent version of botocore, so
increasing the upper pin of botocore to what boto3 requires.