### PR TITLE
Clone rds snapshots

### DIFF
--- a/bin/disco_rds.py
+++ b/bin/disco_rds.py
@@ -69,6 +69,8 @@ def get_parser():
                               help='Name of the database to clone', type=str)
     parser_clone.add_argument('--source-env', dest='source_env', required=True,
                               help='Name of environment of source database', type=str)
+    parser_clone.add_argument('--snapshot', dest='snapshot', required=False,
+                              help='Snapshot to use.  If not provided, use latest.', type=str)
     return parser
 
 
@@ -107,7 +109,7 @@ def run():
     elif args.mode == "cleanup_snapshots":
         rds.cleanup_snapshots(args.days)
     elif args.mode == "clone":
-        rds.clone(args.source_env, args.source_db)
+        rds.clone(args.source_env, args.source_db, snapshot=args.snapshot)
 
 
 if __name__ == "__main__":

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -448,7 +448,7 @@ class RDS(threading.Thread):
         if snapshot:
             custom_snapshot = snapshot
         else:
-            custom_snapshot = self.get_latest_snapshot(source_db_identifier);
+            custom_snapshot = self.get_latest_snapshot(source_db_identifier)
         self.create_db_instance(instance_params, custom_snapshot)
 
         # Create/Update CloudWatch Alarms for this instance

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -414,7 +414,7 @@ class RDS(threading.Thread):
         # Create a DNS record for this instance
         self.setup_dns(instance_identifier)
 
-    def clone(self, source_vpc, source_db):
+    def clone(self, source_vpc, source_db, snapshot):
         """
         Clone the database in source_vpc into the current vpc. The vpc name of the current
         database would be the same as the source database.
@@ -445,8 +445,11 @@ class RDS(threading.Thread):
         # create a parameter group using the parameters of the source db
         self.recreate_db_parameter_group(source_vpc, source_db, group_name, group_family)
 
-        self.create_db_instance(instance_params,
-                                custom_snapshot=self.get_latest_snapshot(source_db_identifier))
+        if snapshot:
+            custom_snapshot = snapshot
+        else:
+            custom_snapshot = self.get_latest_snapshot(source_db_identifier);
+        self.create_db_instance(instance_params, custom_snapshot)
 
         # Create/Update CloudWatch Alarms for this instance
         self.spinup_alarms(source_db)

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -665,7 +665,7 @@ class DiscoRDS(object):
         except botocore.exceptions.ClientError:
             return None
 
-    def clone(self, source_vpc, source_db):
+    def clone(self, source_vpc, source_db, snapshot):
         """
         Spinup a copy of a given database into the current environment
 
@@ -689,4 +689,4 @@ class DiscoRDS(object):
                   rds_security_group_id,
                   subnet_ids, self.domain_name)
 
-        rds.clone(source_vpc, source_db)
+        rds.clone(source_vpc, source_db, snapshot)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.1.24"
+__version__ = "1.1.25"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Support a --snapshot argument that can be passed to disco_rds.py to specify mounting a particular db snapshot rather than the latest snapshot for a given environment.

The immediate use case for this is to support setting up a sandbox that needs an older DB shapshot for testing purposes, one that more closely resembles the state of staging and production than the latest CI snapshot does.  (The reason the CI txdb does not match staging/production has to do with the particular case and can't be avoided for now.)