### PR TITLE
Restore old ELB configuration behavior

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.0"
+__version__ = "1.2.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The old ELB configuration would replicate the instance (internal)
listener configuration when given multiple ELB (external) listeners.
While this behavior is a bit counter-intuitive when supporting both
multiple instance and ELB listeners, we've decided to restore it to
avoid breaking user configuration.

The new behavior is:
1.  If there's one instance listener, replicate it to match the number
of ELB listeners
2.  Otherwise set instance = ELB in the case of a mismatched number of
instance and ELB listeners

This commit also restores the ability to use lowercase protocol names.