### PR TITLE
Rr as882 clean rds subnet grp 020117

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -601,7 +601,8 @@ class DiscoRDS(object):
                 try:
                     throttled_call(self.client.delete_db_subnet_group, DBSubnetGroupName=db_subnet_group_name)
                 except Exception as err:
-                    logger.debug("Unable to delete subnet group '%s': %s", db_subnet_group_name, repr(err))
+                    logger.exception("Unable to delete subnet group '%s': %s", db_subnet_group_name,
+                                     repr(err))
 
                 throttled_call(
                     self.client.delete_db_instance,

--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -583,11 +583,14 @@ class DiscoRDS(object):
         """ Delete an RDS instance/cluster. Final snapshot is automatically taken. """
         logger.info("Deleting RDS cluster %s", instance_identifier)
 
+        db_instance = throttled_call(
+            self.client.describe_db_instances,
+            DBInstanceIdentifier=instance_identifier
+        )["DBInstances"][0]
+        db_subnet_group_name = db_instance["DBSubnetGroup"]["DBSubnetGroupName"]
+
         if skip_final_snapshot:
-            allocated_storage = throttled_call(
-                self.client.describe_db_instances,
-                DBInstanceIdentifier=instance_identifier
-            )["DBInstances"][0]["AllocatedStorage"]
+            allocated_storage = db_instance["AllocatedStorage"]
 
             ansi_color_red = "\033[91m"
             ansi_color_none = "\033[0m"
@@ -595,6 +598,11 @@ class DiscoRDS(object):
                   " will be dropped and no backup taken. Data will be irrecoverable." + ansi_color_none)
             response = raw_input("Confirm by typing the amount of allocated storage that will be dropped: ")
             if response == str(allocated_storage):
+                try:
+                    throttled_call(self.client.delete_db_subnet_group, DBSubnetGroupName=db_subnet_group_name)
+                except Exception as err:
+                    logger.debug("Unable to delete subnet group '%s': %s", db_subnet_group_name, repr(err))
+
                 throttled_call(
                     self.client.delete_db_instance,
                     DBInstanceIdentifier=instance_identifier,
@@ -609,6 +617,7 @@ class DiscoRDS(object):
             final_snapshot = "%s-final-snapshot" % instance_identifier
             try:
                 throttled_call(self.client.delete_db_snapshot, DBSnapshotIdentifier=final_snapshot)
+                throttled_call(self.client.delete_db_subnet_group, DBSubnetGroupName=db_subnet_group_name)
             except botocore.exceptions.ClientError:
                 pass
             keep_trying(

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.7"
+__version__ = "1.2.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.4"
+__version__ = "1.2.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -298,3 +298,9 @@ class DiscoRDSTests(unittest.TestCase):
         sg_group_id = self.rds.get_rds_security_group_id()
 
         self.assertEqual(MOCK_SG_GROUP_ID, sg_group_id)
+
+    def test_delete_db_instance(self):
+        """Test delete db instance"""
+        self.rds.delete_db_instance("id_1", True)
+        self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
+

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -329,8 +329,8 @@ class DiscoRDSTests(unittest.TestCase):
         }
         with patch('__builtin__.raw_input', return_value='100GB'):
             self.assertRaises(SystemExit, self.rds.delete_db_instance, "unittestenv-db-name", True)
-            assert not self.rds.client.delete_db_subnet_group.called
-            assert not self.rds.client.delete_db_instance.called
+            self.assertFalse(self.rds.client.delete_db_subnet_group.called)
+            self.assertFalse(self.rds.client.delete_db_instance.called)
 
     def test_delete_db_instance_no_snapshot(self):
         """Test delete db instance no snapshot"""

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -299,8 +299,55 @@ class DiscoRDSTests(unittest.TestCase):
 
         self.assertEqual(MOCK_SG_GROUP_ID, sg_group_id)
 
-    def test_delete_db_instance(self):
-        """Test delete db instance"""
-        self.rds.delete_db_instance("id_1", True)
-        self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
+    def test_delete_db_instance_with_snapshot(self):
+        """Test delete db instance with snapshot"""
+        self.rds.client.describe_db_instances.return_value = {
+            'DBInstances': [{
+                'DBInstanceIdentifier': 'unittestenv-db-name',
+                'AllocatedStorage': '500GB',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            }]
+        }
+        with patch('__builtin__.raw_input', return_value='500GB'):
+            self.rds.delete_db_instance("unittestenv-db-name", True)
+            self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
+            self.rds.client.delete_db_instance.assert_called_with(DBInstanceIdentifier="unittestenv-db-name",
+                                                                  SkipFinalSnapshot=True)
 
+    def test_delete_db_instance_err_size(self):
+        """Test delete db instance with snapshot but incorrect size provided"""
+        self.rds.client.describe_db_instances.return_value = {
+            'DBInstances': [{
+                'DBInstanceIdentifier': 'unittestenv-db-name',
+                'AllocatedStorage': '500GB',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            }]
+        }
+        with patch('__builtin__.raw_input', return_value='100GB'):
+            self.assertRaises(SystemExit, self.rds.delete_db_instance, "unittestenv-db-name", True)
+            assert not self.rds.client.delete_db_subnet_group.called
+            assert not self.rds.client.delete_db_instance.called
+
+    def test_delete_db_instance_no_snapshot(self):
+        """Test delete db instance no snapshot"""
+        self.rds.client.describe_db_instances.return_value = {
+            'DBInstances': [{
+                'DBInstanceIdentifier': 'unittestenv-db-name',
+                'AllocatedStorage': '500GB',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            }]
+        }
+        with patch('__builtin__.raw_input', return_value='500GB'):
+            self.rds.delete_db_instance("unittestenv-db-name", False)
+            self.rds.client.delete_db_snapshot.assert_called_with(
+                DBSnapshotIdentifier="unittestenv-db-name-final-snapshot")
+            self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
+            self.rds.client.delete_db_instance.assert_called_with(
+                DBInstanceIdentifier="unittestenv-db-name",
+                FinalDBSnapshotIdentifier="unittestenv-db-name-final-snapshot")

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -343,11 +343,60 @@ class DiscoRDSTests(unittest.TestCase):
                 }
             }]
         }
-        with patch('__builtin__.raw_input', return_value='500GB'):
-            self.rds.delete_db_instance("unittestenv-db-name", False)
-            self.rds.client.delete_db_snapshot.assert_called_with(
-                DBSnapshotIdentifier="unittestenv-db-name-final-snapshot")
-            self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
-            self.rds.client.delete_db_instance.assert_called_with(
-                DBInstanceIdentifier="unittestenv-db-name",
-                FinalDBSnapshotIdentifier="unittestenv-db-name-final-snapshot")
+        self.rds.delete_db_instance("unittestenv-db-name", False)
+        self.rds.client.delete_db_snapshot.assert_called_with(
+            DBSnapshotIdentifier="unittestenv-db-name-final-snapshot")
+        self.rds.client.delete_db_subnet_group.assert_called_with(DBSubnetGroupName="group_name")
+        self.rds.client.delete_db_instance.assert_called_with(
+            DBInstanceIdentifier="unittestenv-db-name",
+            FinalDBSnapshotIdentifier="unittestenv-db-name-final-snapshot")
+
+    def test_delete_all_db_instances(self):
+        """Test delete all db instance"""
+        self.rds.get_db_instances = MagicMock()
+        self.rds._wait_for_db_instance_deletions = MagicMock()
+
+        self.rds.get_db_instances.return_value = [
+            {
+                'DBInstanceIdentifier': 'unittestenv-db-name1',
+                'DBInstanceStatus': 'available',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            },
+            {
+                'DBInstanceIdentifier': 'unittestenv-db-name2',
+                'DBInstanceStatus': 'available',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            }
+        ]
+
+        self.rds.delete_db_instance = MagicMock()
+        self.rds.delete_all_db_instances()
+        self.rds.delete_db_instance.assert_has_calls(self.rds.delete_db_instance('unittestenv-db-name1'),
+                                                     self.rds.delete_db_instance('unittestenv-db-name2'))
+
+    def test_delete_all_db_instances_err_status(self):
+        """Test delete all db instance invalid Status"""
+        self.rds.get_db_instances = MagicMock()
+        self.rds.get_db_instances.return_value = [
+            {
+                'DBInstanceIdentifier': 'unittestenv-db-name1',
+                'DBInstanceStatus': 'available',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            },
+            {
+                'DBInstanceIdentifier': 'unittestenv-db-name2',
+                'DBInstanceStatus': 'invalid',
+                'DBSubnetGroup': {
+                    'DBSubnetGroupName': 'group_name'
+                }
+            }
+        ]
+        self.rds.delete_db_instance = MagicMock()
+        self.assertRaises(RDSEnvironmentError, self.rds.delete_all_db_instances)
+        assert not self.rds.delete_db_instance.called

--- a/test/unit/test_disco_rds.py
+++ b/test/unit/test_disco_rds.py
@@ -399,4 +399,4 @@ class DiscoRDSTests(unittest.TestCase):
         ]
         self.rds.delete_db_instance = MagicMock()
         self.assertRaises(RDSEnvironmentError, self.rds.delete_all_db_instances)
-        assert not self.rds.delete_db_instance.called
+        self.assertFalse(self.rds.delete_db_instance.called)


### PR DESCRIPTION
Deleting any RDS subnet group associated when an RDS is deleted or when a VPC is deleted.
In the case of an RDS deletion, the `delete_db_instance` function is now calling  calling `delete_db_subnet_group`
For the VPC deletion, the current code is invoking `rds.delete_all_db_instances` which invokes 
`delete_db_instance` for each instance so the change mentioned above will take care of removing the  RDS subnet group when deleting a VPC.