### PR TITLE
Changed method of retrieving the account id in DiscoElastigroup

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -58,7 +58,7 @@ class DiscoElastigroup(object):
     def account_id(self):
         """Account id of the current IAM user"""
         if not self._account_id:
-            self._account_id = boto3.resource('iam').CurrentUser().arn.split(':')[4]
+            self._account_id = boto3.client('sts').get_caller_identity().get('Account')
         return self._account_id
 
     def _get_new_groupname(self, hostclass):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The old way does not work when running from Jenkins, since there is no user to retrieve the arn for.