### PR TITLE
AL-952 Default to Blue/Green Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ reports
 # Pycharm
 .idea/*
 .ropeproject/
+*.iml

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -792,9 +792,15 @@ class DiscoDeploy(object):
         if deployment_strategy:
             desired_deployment_strategy = deployment_strategy
         else:
-            desired_deployment_strategy = self.hostclass_option_default(
-                hostclass, 'deployment_strategy',
-                DEPLOYMENT_STRATEGY_CLASSIC
+            desired_deployment_strategy = self.hostclass_option_default(hostclass, 'deployment_strategy',
+                                                                        DEPLOYMENT_STRATEGY_BLUE_GREEN)
+
+        if desired_deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
+            logger.warning(
+                "Classic deployment will be removed in a future version of Asiaq."
+                "Please switch to Blue/Green deployment by setting `deployment_strategy=%s` under your "
+                "hostclass' section in disco_aws.ini",
+                DEPLOYMENT_STRATEGY_BLUE_GREEN
             )
 
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -723,7 +723,15 @@ class DiscoDeploy(object):
             desired_deployment_strategy = deployment_strategy
         else:
             desired_deployment_strategy = self.hostclass_option_default(hostclass, 'deployment_strategy',
-                                                                        DEPLOYMENT_STRATEGY_CLASSIC)
+                                                                        DEPLOYMENT_STRATEGY_BLUE_GREEN)
+
+        if desired_deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
+            logger.warning(
+                "Classic deployment will be removed in a future version of Asiaq."
+                "Please switch to Blue/Green deployment by setting `deployment_strategy=%s` under your "
+                "hostclass' section in disco_aws.ini",
+                desired_deployment_strategy
+            )
 
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:
             # We are only deployable in testing if we are in the pipeline. Otherwise assume that we aren't

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -730,7 +730,7 @@ class DiscoDeploy(object):
                 "Classic deployment will be removed in a future version of Asiaq."
                 "Please switch to Blue/Green deployment by setting `deployment_strategy=%s` under your "
                 "hostclass' section in disco_aws.ini",
-                desired_deployment_strategy
+                DEPLOYMENT_STRATEGY_BLUE_GREEN
             )
 
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.12"
+__version__ = "1.3.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -9,7 +9,7 @@ import boto.ec2.instance
 from mock import MagicMock, create_autospec, call
 
 from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoAutoscale, DiscoBake, DiscoELB
-from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN
+from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN, DEPLOYMENT_STRATEGY_CLASSIC
 from disco_aws_automation.exceptions import (
     TimeoutError,
     MaintenanceModeError,
@@ -890,7 +890,8 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcscarey 1 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
+                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, 1)
         self._disco_aws.spinup.assert_has_calls(
@@ -923,7 +924,8 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcscarey 1 2"
         ami.id = "ami-12345678"
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._disco_bake.promote_ami.assert_called_with(ami, 'failed')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, 1)
         self._disco_aws.spinup.assert_has_calls(
@@ -944,7 +946,8 @@ class DiscoDeployTests(TestCase):
         self._existing_group.max_size = 2
         self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
+                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, self._existing_group.desired_capacity)
         self._disco_aws.spinup.assert_has_calls(
@@ -964,7 +967,8 @@ class DiscoDeployTests(TestCase):
         self._existing_group.max_size = 2
         self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._disco_bake.promote_ami.assert_called_with(ami, 'failed')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, self._existing_group.desired_capacity)
         self._disco_aws.spinup.assert_has_calls(
@@ -984,7 +988,8 @@ class DiscoDeployTests(TestCase):
         self._existing_group.max_size = 2
         self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
+                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, self._existing_group.desired_capacity)
         self._disco_aws.spinup.assert_has_calls(
@@ -1011,7 +1016,8 @@ class DiscoDeployTests(TestCase):
         self._existing_group.max_size = 2
         self._existing_group.min_size = 2
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
+                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
         self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, self._existing_group.desired_capacity)
         self._disco_aws.spinup.assert_has_calls(
@@ -1080,7 +1086,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.get_host = MagicMock()
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(1, ''))
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._ci_deploy._get_old_instances.assert_called_with(ami.id)
         self._ci_deploy._disco_aws.terminate.assert_has_calls(
             [call([inst1]), call([inst2], use_autoscaling=True)])
@@ -1132,7 +1139,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
         self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
+                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._ci_deploy._get_old_instances.assert_called_with(ami.id)
         self._ci_deploy._disco_aws.terminate.assert_has_calls(
             [call([inst1], use_autoscaling=True)])
@@ -1148,7 +1156,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
         self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._ci_deploy._get_new_instances.assert_called_with(ami.id)
         self._ci_deploy._disco_aws.terminate.assert_has_calls(
             [call([inst2], use_autoscaling=True)])
@@ -1164,7 +1173,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(side_effect=[True, False])
         self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
         self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._ci_deploy._get_new_instances.assert_called_with(ami.id)
         self._ci_deploy._disco_aws.terminate.assert_has_calls(
             [call([inst2], use_autoscaling=True)])
@@ -1186,7 +1196,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
         self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
         self._ci_deploy._get_latest_other_image_id = MagicMock(return_value=ami1.id)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami2, dry_run=False)
+        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami2, dry_run=False,
+                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
         self._disco_aws.spinup.assert_has_calls(
             [
                 call([{'ami': ami2.id, 'sequence': 1, 'deployable': 'yes',
@@ -1201,7 +1212,11 @@ class DiscoDeployTests(TestCase):
         ami = self.mock_ami("mhcbar 1")
         self._existing_group.desired_capacity = 2
         self._ci_deploy.handle_nodeploy_ami = MagicMock()
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.test_ami(
+            ami,
+            dry_run=False,
+            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC
+        ))
         self._ci_deploy.handle_nodeploy_ami.assert_has_calls([
             call(
                 ami,

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -1238,7 +1238,8 @@ class DiscoDeployTests(TestCase):
         ami = self.mock_ami("mhcsmokey 1")
         self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_tested_ami = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
+                                                     deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcsmokey")
         self._ci_deploy.handle_tested_ami.assert_called_with(
             ami,
@@ -1259,7 +1260,8 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.is_deployable = MagicMock(return_value=False)
         self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_nodeploy_ami = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False))
+        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
+                                                     deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self.assertEqual(self._ci_deploy.is_deployable.call_count, 1)
         self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcscarey")
         self._ci_deploy.handle_nodeploy_ami.assert_called_with(


### PR DESCRIPTION
As part of the effort to simplify Asiaq, we want to remove the classic
deployment strategy. As the first step to doing this, we are making
Blue/Green the default deployment strategy of Asiaq. Additionally, a
warning will now be printed if you continue to use classic deployment.

This change should  not cause any issues for users already using
blue/green deployment. Users already using classic deployment should
also not have any problems. There may be some issues with users using
both classic deployment and integration tests.