### PR TITLE
Fix disco_iam.py List Roles Bug

### DIFF
--- a/disco_aws_automation/disco_iam.py
+++ b/disco_aws_automation/disco_iam.py
@@ -284,7 +284,10 @@ class DiscoIAM(object):
         """
         Return all roles with deserialized Assume Role Policy Document
         """
-        roles = throttled_call(self.connection.list_roles).list_roles_response.list_roles_result.roles
+        roles = throttled_call(
+            self.connection.list_roles,
+            max_items=500
+        ).list_roles_response.list_roles_result.roles
         for role in roles:
             role.assume_role_policy_document = AssumeRolePolicyDocument(role.assume_role_policy_document)
         return roles

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.2.11"
+__version__ = "1.2.12"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The default max items is 100. Let's bump that up to 500 so that this
works again. In the future, we should either write some function that
automatically paginates through the responses for boto, or we should
fast-track the effort to rewrite this module with boto3 and reuse the
existing max items function for that.