### PR TITLE
Al1007 disco deploy spotinst

### DIFF
--- a/bin/disco_deploy.py
+++ b/bin/disco_deploy.py
@@ -52,7 +52,7 @@ import sys
 
 from docopt import docopt
 
-from disco_aws_automation import DiscoAWS, DiscoAutoscale, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
+from disco_aws_automation import DiscoAWS, DiscoGroup, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
@@ -91,7 +91,7 @@ def run():
     vpc = DiscoVPC.fetch_environment(environment_name=env)
 
     deploy = DiscoDeploy(
-        aws, test_aws, DiscoBake(config, aws.connection), DiscoAutoscale(env), DiscoELB(vpc),
+        aws, test_aws, DiscoBake(config, aws.connection), DiscoGroup(env), DiscoELB(vpc),
         pipeline_definition=pipeline_definition,
         ami=args.get("--ami"), hostclass=args.get("--hostclass"),
         allow_any_hostclass=args["--allow-any-hostclass"])

--- a/disco_aws_automation/__init__.py
+++ b/disco_aws_automation/__init__.py
@@ -1,6 +1,7 @@
-''' For package documentation, see README '''
+""" For package documentation, see README """
 
 from .disco_acm import DiscoACM
+from .disco_group import DiscoGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
 from .disco_aws import DiscoAWS

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -1,0 +1,68 @@
+"""Base Group (abstract)"""
+import logging
+
+from abc import ABCMeta, abstractmethod
+
+from botocore.exceptions import WaiterError
+import boto3
+
+from .resource_helper import throttled_call
+
+logger = logging.getLogger(__name__)
+
+
+class BaseGroup(object):
+    """Abstract class definition for AWS groups"""
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self._boto3_ec = None
+
+    @abstractmethod
+    def get_existing_group(self, hostclass, group_name, throw_on_two_groups):
+        """Get list of group objects for a hostclass"""
+        return
+
+    @abstractmethod
+    def get_existing_groups(self, hostclass, group_name):
+        """Get list of all group objects for a hostclass"""
+        return
+
+    @abstractmethod
+    def get_instances(self, hostclass=None, group_name=None):
+        """Get list of instances in groups"""
+        return
+
+    @abstractmethod
+    def delete_groups(self, hostclass, group_name, force):
+        """Delete groups of a hostclass"""
+        return
+
+    @abstractmethod
+    def scaledown_groups(self, hostclass, group_name, wait, noerror):
+        """Scale down number of instances in a group"""
+        return
+
+    @property
+    def boto3_ec(self):
+        """Lazily create boto3 ec2 connection"""
+        if not self._boto3_ec:
+            self._boto3_ec = boto3.client('ec2')
+        return self._boto3_ec
+
+    def wait_instance_termination(self, group_name=None, group=None, noerror=False):
+        """Wait for instance to be terminated during scaledown"""
+        waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
+        instance_ids = [inst['id'] for inst in self.get_instances(group_name=group_name)]
+
+        try:
+            logger.info("Waiting for scaledown of group %s", group['name'])
+            waiter.wait(InstanceIds=instance_ids)
+        except WaiterError:
+            if noerror:
+                logger.exception("Unable to wait for scaling down of %s", group_name)
+                return False
+            else:
+                raise
+
+        return True

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -96,8 +96,7 @@ class DiscoAutoscale(object):
         next_token = None
         while True:
             instances = throttled_call(
-                self.connection.get_all_autoscaling_instances,
-                instance_ids=None, next_token=next_token)
+                self.connection.get_all_autoscaling_instances, next_token=next_token)
             for instance in self._filter_instance_by_environment(instances):
                 filters = [
                     not hostclass or self.get_hostclass(instance.group_name) == hostclass,

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -9,9 +9,9 @@ import boto.ec2.autoscale
 import boto.ec2.autoscale.launchconfig
 import boto.ec2.autoscale.group
 from boto.exception import BotoServerError
-from botocore.exceptions import WaiterError
 import boto3
 
+from .base_group import BaseGroup
 from .resource_helper import throttled_call
 from .exceptions import TooManyAutoscalingGroups
 
@@ -21,15 +21,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_TERMINATION_POLICIES = ["OldestLaunchConfiguration"]
 
 
-class DiscoAutoscale(object):
+class DiscoAutoscale(BaseGroup):
     """Class orchestrating autoscaling"""
 
-    def __init__(self, environment_name, autoscaling_connection=None, boto3_autoscaling_connection=None,
-                 boto3_ec_connection=None):
+    def __init__(self, environment_name, autoscaling_connection=None, boto3_autoscaling_connection=None):
         self.environment_name = environment_name
         self._connection = autoscaling_connection or None  # lazily initialized
         self._boto3_autoscale = boto3_autoscaling_connection or None  # lazily initialized
-        self._boto3_ec = boto3_ec_connection or None  # lazily initialized
+        super(DiscoAutoscale, self).__init__()
 
     @property
     def connection(self):
@@ -44,13 +43,6 @@ class DiscoAutoscale(object):
         if not self._boto3_autoscale:
             self._boto3_autoscale = boto3.client('autoscaling')
         return self._boto3_autoscale
-
-    @property
-    def boto3_ec(self):
-        """Lazily create boto3 ec2 connection"""
-        if not self._boto3_ec:
-            self._boto3_ec = boto3.client('ec2')
-        return self._boto3_ec
 
     def get_new_groupname(self, hostclass):
         """Returns a new autoscaling group name when given a hostclass"""
@@ -181,19 +173,7 @@ class DiscoAutoscale(object):
             throttled_call(group.update)
 
             if wait:
-                waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
-                instance_ids = [inst.instance_id for inst in self.get_instances(group_name=group_name)]
-
-                try:
-                    logger.info("Waiting for scaledown of group %s", group.name)
-                    waiter.wait(InstanceIds=instance_ids)
-                except WaiterError:
-                    if noerror:
-                        logger.exception("Unable to wait for scaling down of %s", group_name)
-                        return False
-                    else:
-                        raise
-            return True
+                self.wait_instance_termination(group_name=group_name, group=group, noerror=noerror)
 
     @staticmethod
     def create_autoscale_tags(group_name, tags):

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -17,6 +17,7 @@ from boto.exception import EC2ResponseError
 from .disco_log_metrics import DiscoLogMetrics
 from .disco_elb import DiscoELB, DiscoELBPortConfig
 from .disco_alarm import DiscoAlarm
+from .disco_group import DiscoGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
 from .disco_aws_util import (
@@ -61,7 +62,8 @@ class DiscoAWS(object):
     # Too many arguments, but we want to mock a lot of things out, so...
     # pylint: disable=too-many-arguments
     def __init__(self, config, environment_name=None, boto2_conn=None, vpc=None, remote_exec=None,
-                 storage=None, autoscale=None, elastigroup=None, elb=None, log_metrics=None, alarms=None):
+                 storage=None, discogroup=None, autoscale=None, elastigroup=None, elb=None,
+                 log_metrics=None, alarms=None):
 
         if not environment_name and not vpc:
             raise ProgrammerError("Either 'vpc' or 'environment_name' must always be specified.")
@@ -75,6 +77,7 @@ class DiscoAWS(object):
         self._vpc = vpc or None  # lazily initialized
         self._disco_remote_exec = remote_exec or None  # lazily initialized
         self._disco_storage = storage or None  # lazily initialized
+        self._discogroup = discogroup or None  # lazily initialized
         self._autoscale = autoscale or None  # lazily initialized
         self._elastigroup = elastigroup or None  # lazily initialized
         self._elb = elb or None  # lazily initialized
@@ -94,6 +97,13 @@ class DiscoAWS(object):
         if not self._disco_storage:
             self._disco_storage = DiscoStorage(self.environment_name, self.connection)
         return self._disco_storage
+
+    @property
+    def discogroup(self):
+        """Lazily creates disco group object"""
+        if not self._discogroup:
+            self._discogroup = DiscoGroup(environment_name=self.environment_name)
+        return self._discogroup
 
     @property
     def autoscale(self):
@@ -457,7 +467,8 @@ class DiscoAWS(object):
             "hostclass": hostclass,
             "no_destroy": no_destroy,
             "group_name": group['name'],
-            "chaos": chaos
+            "chaos": chaos,
+            "spotinst": is_truthy(str(spotinst) or self.config('spotinst', hostclass))
         }
 
     def stop(self, instances):
@@ -715,13 +726,19 @@ class DiscoAWS(object):
                 for (hostclass, termination_policies, hdict) in hostclass_iter]
 
             if metadata[0]:
+                for _hc in metadata:
+                    if _hc.get('spotinst'):
+                        self.elastigroup.wait_for_instance_id(_hc['group_name'])
                 self.smoketest(self.wait_for_autoscaling_instances(
                     [_hc for _hc in metadata if _hc["hostclass"] in flammable]))
 
     @staticmethod
     def _instance_count_lt_min_size(group, all_instances):
-        group_instances = [_i for _i in all_instances if _i.group_name == group.name]
-        return len(group_instances) < group.min_size
+        group_instances = [_i for _i in all_instances if _i['group_name'] == group['name']]
+        if group.get('id'):
+            return len(group_instances) < group['capacity']['minimum']
+        else:
+            return len(group_instances) < group['min_size']
 
     def wait_for_autoscaling_instances(self, metadata_list, timeout=AUTOSCALE_TIMEOUT):
         """
@@ -730,11 +747,11 @@ class DiscoAWS(object):
         start_time = time.time()
         max_time = start_time + timeout
 
-        name_to_group = {group.name: group for group in self.autoscale.get_existing_groups()}
+        name_to_group = {group['name']: group for group in self.discogroup.get_existing_groups()}
         yet_to_scale = group_names = set([meta["group_name"] for meta in metadata_list])
 
         while True:
-            auto_instances = self.autoscale.get_instances()
+            auto_instances = self.discogroup.get_instances()
             logger.debug("yet_to_scale: %s", yet_to_scale)
             yet_to_scale = [gname for gname in yet_to_scale
                             if DiscoAWS._instance_count_lt_min_size(name_to_group[gname], auto_instances)]
@@ -752,8 +769,8 @@ class DiscoAWS(object):
             logger.info("Waited for %s autoscaling groups to reach min_size in %s seconds",
                         len(metadata_list), int(0.5 + time.time() - start_time))
 
-        instance_ids = [instance.instance_id for instance in auto_instances
-                        if instance.group_name in group_names]
+        instance_ids = [instance['instance_id'] for instance in auto_instances
+                        if instance['group_name'] in group_names]
 
         return self.instances(instance_ids=instance_ids) if instance_ids else []
 
@@ -766,7 +783,6 @@ class DiscoAWS(object):
         start_time = time.time()
         max_time = start_time + timeout
 
-        instances = []
         while time.time() < max_time:
             instances = self.instances_from_amis([ami_id], launch_time=launch_time, group_name=group_name)
             if len(instances) >= min_count:

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -35,7 +35,7 @@ class DiscoDeploy(object):
     '''DiscoDeploy takes care of testing, promoting and deploying the latests AMIs'''
 
     # pylint: disable=too-many-arguments
-    def __init__(self, aws, test_aws, bake, autoscale, elb, pipeline_definition,
+    def __init__(self, aws, test_aws, bake, discogroup, elb, pipeline_definition,
                  ami=None, hostclass=None, allow_any_hostclass=False, config=None):
         '''
         Constructor for DiscoDeploy
@@ -56,7 +56,7 @@ class DiscoDeploy(object):
         self._disco_aws = aws
         self._test_aws = test_aws
         self._disco_bake = bake
-        self._disco_autoscale = autoscale
+        self._disco_group = discogroup
         self._disco_elb = elb
         self._all_stage_amis = None
         self._hostclasses = self._get_hostclasses_from_pipeline_definition(pipeline_definition)
@@ -288,7 +288,7 @@ class DiscoDeploy(object):
             # Create scheduled actions on the ASG.
             self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
         else:
-            self._disco_autoscale.delete_groups(hostclass=hostclass, force=True)
+            self._disco_group.delete_groups(hostclass=hostclass, force=True)
 
         if ami_test_failed:
             raise RuntimeError("Smoke test for non-deploy Hostclass %s AMI %s failed", hostclass, ami.id)
@@ -303,7 +303,7 @@ class DiscoDeploy(object):
         :return: List of instances
         '''
         hostclass = DiscoBake.ami_hostclass(self._disco_bake.connection.get_image(new_ami_id))
-        all_ids = [inst.instance_id for inst in self._disco_autoscale.get_instances(hostclass=hostclass)]
+        all_ids = [inst['instance_id'] for inst in self._disco_group.get_instances(hostclass=hostclass)]
         all_instances = self._disco_aws.instances(instance_ids=all_ids)
         return [inst for inst in all_instances
                 if (inst.image_id != new_ami_id) or
@@ -319,7 +319,7 @@ class DiscoDeploy(object):
         :return: List of instances
         '''
         hostclass = DiscoBake.ami_hostclass(self._disco_bake.connection.get_image(new_ami_id))
-        all_ids = [inst.instance_id for inst in self._disco_autoscale.get_instances(hostclass=hostclass)]
+        all_ids = [inst['instance_id'] for inst in self._disco_group.get_instances(hostclass=hostclass)]
         all_instances = self._disco_aws.instances(filters={"image_id": [new_ami_id]}, instance_ids=all_ids)
         return [inst for inst in all_instances
                 if not launch_time or get_instance_launch_time(inst) >= launch_time]
@@ -484,32 +484,32 @@ class DiscoDeploy(object):
             logger.exception("Spinning up a new autoscaling group failed")
 
             # Try to grab the new group. If it exists, we get a group. If not, we get a `None`.
-            new_group = self._disco_autoscale.get_existing_group(hostclass=hostclass,
-                                                                 throw_on_two_groups=False)
+            new_group = self._disco_group.get_existing_group(hostclass=hostclass,
+                                                             throw_on_two_groups=False)
 
             # It's possible that we might have ended up grabbing the old group instead of the new group we
             # just made. So check that the group we just got isn't the same as the group that already exists.
-            old_group_is_not_new_group = new_group and old_group and old_group.name != new_group.name
+            old_group_is_not_new_group = new_group and old_group and old_group['name'] != new_group['name']
 
             # If we did get a new group and its not the same as the old group (or no old group exists), let's
             # tear down the new testing group and its ELB if it exists.
             if new_group and (not old_group or old_group_is_not_new_group):
                 logger.info('Destroying the testing group')
                 # Destroy the testing ASG
-                self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                self._disco_group.delete_groups(group_name=new_group['name'], force=True)
                 if uses_elb:
                     # Destroy the testing ELB
                     self._disco_elb.delete_elb(hostclass, testing=True)
             raise RuntimeError("Spinning up a new autoscaling group failed")
 
-        new_group = self._disco_autoscale.get_existing_group(hostclass=hostclass, throw_on_two_groups=False)
+        new_group = self._disco_group.get_existing_group(hostclass=hostclass, throw_on_two_groups=False)
 
-        if old_group and old_group.name == new_group.name:
+        if old_group and old_group['name'] == new_group['name']:
             raise RuntimeError("Old group and new group should not be the same.")
 
         try:
             smoke_tests = self.wait_for_smoketests(ami.id, new_group_config["desired_size"] or 1,
-                                                   group_name=new_group.name)
+                                                   group_name=new_group['name'])
             if smoke_tests and run_tests:
                 # If smoke tests passed and we should run integration tests, run them
                 integration_tests = self.run_integration_tests(ami, wait_for_elb=uses_elb)
@@ -520,16 +520,16 @@ class DiscoDeploy(object):
                 # If testing passed, mark AMI as tested
                 self._promote_ami(ami, "tested")
                 # Get list of instances in group
-                group_instance_ids = [inst.instance_id for inst in
-                                      self._disco_autoscale.get_instances(group_name=new_group.name)]
+                group_instance_ids = [inst['instance_id'] for inst in
+                                      self._disco_group.get_instances(group_name=new_group['name'])]
                 if not group_instance_ids:
-                    raise RuntimeError("Could not find any instances in new group %s", new_group.name)
+                    raise RuntimeError("Could not find any instances in new group %s", new_group['name'])
                 group_instances = self._disco_aws.instances(instance_ids=group_instance_ids)
                 # If we are actually deploying and are able to leave testing mode
                 if deployable and self._set_testing_mode(hostclass, group_instances, False):
-                    logger.info("Successfully left testing mode for group %s", new_group.name)
+                    logger.info("Successfully left testing mode for group %s", new_group['name'])
                     # Update ASG to exit testing mode and attach to the normal ELB if applicable.
-                    self._disco_aws.spinup([new_group_config], group_name=new_group.name)
+                    self._disco_aws.spinup([new_group_config], group_name=new_group['name'])
 
                     if uses_elb:
                         try:
@@ -539,22 +539,22 @@ class DiscoDeploy(object):
                         except TimeoutError:
                             logger.exception("Waiting for health of instances attached to ELB timed out")
                             # Destroy the testing ASG
-                            self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                            self._disco_group.delete_groups(group_name=new_group['name'], force=True)
                             if uses_elb:
                                 # Destroy the testing ELB
                                 self._disco_elb.delete_elb(hostclass, testing=True)
                             raise
 
                     # Create scheduled actions on the new ASG now that we will likely keep it.
-                    self._create_scaling_schedule(pipeline_dict, group_name=new_group.name)
+                    self._create_scaling_schedule(pipeline_dict, group_name=new_group['name'])
 
                     # we can destroy the old group
                     if old_group:
                         # Empty the original ASG for connection draining purposes
-                        self._disco_autoscale.scaledown_groups(group_name=old_group.name, wait=True,
-                                                               noerror=True)
+                        self._disco_group.scaledown_groups(group_name=old_group['name'], wait=True,
+                                                           noerror=True)
                         # Destroy the original ASG
-                        self._disco_autoscale.delete_groups(group_name=old_group.name, force=True)
+                        self._disco_group.delete_groups(group_name=old_group['name'], force=True)
                     if uses_elb:
                         # Destroy the testing ELB
                         self._disco_elb.delete_elb(hostclass, testing=True)
@@ -562,14 +562,14 @@ class DiscoDeploy(object):
                 else:
                     # Otherwise, we need to keep the old group and destroy the new one
                     if deployable:
-                        reason = "Unable to exit testing mode for group {}".format(new_group.name)
+                        reason = "Unable to exit testing mode for group {}".format(new_group['name'])
                     else:
                         reason = "{} is not deployable".format(hostclass)
 
                     logger.error("%s, destroying new autoscaling group", reason)
 
                     # Destroy the testing ASG
-                    self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                    self._disco_group.delete_groups(group_name=new_group['name'], force=True)
 
                     if uses_elb:
                         # Destroy the testing ELB
@@ -578,7 +578,7 @@ class DiscoDeploy(object):
                     # If the hostclass isn't deployable and an old group exists, we should update the old
                     # group so that new instances from that old group are spun up with the newly tested AMI.
                     if not deployable and old_group:
-                        self._disco_aws.spinup([new_group_config], group_name=old_group.name)
+                        self._disco_aws.spinup([new_group_config], group_name=old_group['name'])
 
                     # If deployable was False, return True, otherwise we're here because testing mode broke,
                     # so return False
@@ -591,7 +591,7 @@ class DiscoDeploy(object):
             logger.exception("Failed to run integration test")
 
         # Destroy the testing ASG
-        self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups(group_name=new_group['name'], force=True)
         if uses_elb:
             # Destroy the testing ELB
             self._disco_elb.delete_elb(hostclass, testing=True)
@@ -625,9 +625,9 @@ class DiscoDeploy(object):
         # If there is an already existing ASG, use its sizing. Otherwise, use the pipeline's sizing or a
         # reasonable default.
         if old_group:
-            desired_size = old_group.desired_capacity
-            max_size = old_group.max_size
-            min_size = old_group.min_size
+            desired_size = old_group.get('desired_capacity') or old_group['capacity']['target']
+            max_size = old_group.get('max_size') or old_group['capacity']['maximum']
+            min_size = old_group.get('min_size') or old_group['capacity']['minimum']
         else:
             # The 'or 1' is because some people set their desired size to 0 in their pipeline.
             desired_size = int(size_as_maximum_int_or_none(
@@ -742,7 +742,7 @@ class DiscoDeploy(object):
         logger.info("testing %s %s", ami.id, ami.name)
         hostclass = DiscoBake.ami_hostclass(ami)
         pipeline_hostclass_dict = self._hostclasses.get(hostclass)
-        group = self._disco_autoscale.get_existing_group(hostclass)
+        group = self._disco_group.get_existing_group(hostclass)
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 
@@ -812,7 +812,7 @@ class DiscoDeploy(object):
         if not pipeline_dict:
             raise RuntimeError("Pipeline Dictionary is not defined.")
 
-        group = self._disco_autoscale.get_existing_group(hostclass)
+        group = self._disco_group.get_existing_group(hostclass)
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -245,7 +245,7 @@ class DiscoElastigroup(object):
 
     def wait_for_instance_id(self, group_name):
         """Wait for instance id(s) of an elastigroup to become available"""
-        while not all([_i['instance_id'] for _i in self.get_instances(group_name=group_name)]):
+        while not all([instance['instance_id'] for instance in self.get_instances(group_name=group_name)]):
             logger.info('Waiting for instance id(s) of %s to become available', group_name)
             time.sleep(10)
 

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -71,7 +71,7 @@ class DiscoElastigroup(BaseGroup):
         if response.status_code == 200:
             return response
         else:
-            raise Exception('Error communicating with Spotinst API')
+            raise Exception('Error communicating with Spotinst API: {}'.format(path))
 
     def _get_new_groupname(self, hostclass):
         """Returns a new elastigroup name when given a hostclass"""

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -19,6 +19,11 @@ class BaseGroup(object):
         return
 
     @abstractmethod
+    def get_existing_groups(self, hostclass, group_name):
+        """Get list of all group objects for a hostclass"""
+        return
+
+    @abstractmethod
     def get_instances(self, hostclass, group_name):
         """Get list of instances in groups"""
         return
@@ -63,12 +68,17 @@ class DiscoGroup(BaseGroup):
         else:
             logger.info('No group found')
 
+    def get_existing_groups(self, hostclass=None, group_name=None):
+        asg_groups = self._autoscale.get_existing_groups()
+        asg_groups = [group.__dict__ for group in asg_groups]
+        spot_groups = self._elastigroup.get_existing_groups()
+        return asg_groups + spot_groups
+
     def get_instances(self, hostclass=None, group_name=None):
         asg_instances = self._autoscale.get_instances(hostclass=hostclass, group_name=group_name)
-        asg_instance_ids = [{'instance_id': inst.instance_id} for inst in asg_instances]
+        asg_instances = [instance.__dict__ for instance in asg_instances]
         spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
-        spot_instance_ids = [{'instance_id': inst['instanceId']} for inst in spot_instances]
-        return asg_instance_ids + spot_instance_ids
+        return asg_instances + spot_instances
 
     def delete_groups(self, hostclass=None, group_name=None, force=False):
         self._autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -1,42 +1,11 @@
 """Contains DiscoGroup class that is above all other group classes used"""
 import logging
 
-from abc import ABCMeta, abstractmethod
-
+from .base_group import BaseGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
 
 logger = logging.getLogger(__name__)
-
-
-class BaseGroup(object):
-    """Abstract class definition for AWS groups"""
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def get_existing_group(self, hostclass, group_name, throw_on_two_groups):
-        """Get list of group objects for a hostclass"""
-        return
-
-    @abstractmethod
-    def get_existing_groups(self, hostclass, group_name):
-        """Get list of all group objects for a hostclass"""
-        return
-
-    @abstractmethod
-    def get_instances(self, hostclass, group_name):
-        """Get list of instances in groups"""
-        return
-
-    @abstractmethod
-    def delete_groups(self, hostclass, group_name, force):
-        """Delete groups of a hostclass"""
-        return
-
-    @abstractmethod
-    def scaledown_groups(self, hostclass, group_name, wait, noerror):
-        """Scale down number of instances in a group"""
-        return
 
 
 class DiscoGroup(BaseGroup):
@@ -47,6 +16,7 @@ class DiscoGroup(BaseGroup):
         self.environment_name = environment_name
         self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
         self._elastigroup = DiscoElastigroup(environment_name=self.environment_name)
+        super(DiscoGroup, self).__init__()
 
     def get_existing_group(self, hostclass=None, group_name=None, throw_on_two_groups=True):
         asg_group = self._autoscale.get_existing_group(

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -1,0 +1,89 @@
+"""Contains DiscoGroup class that is above all other group classes used"""
+import logging
+
+from abc import ABCMeta, abstractmethod
+
+from .disco_autoscale import DiscoAutoscale
+from .disco_elastigroup import DiscoElastigroup
+
+logger = logging.getLogger(__name__)
+
+
+class BaseGroup(object):
+    """Abstract class definition for AWS groups"""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def get_existing_group(self, hostclass, group_name, throw_on_two_groups):
+        """Get list of group objects for a hostclass"""
+        return
+
+    @abstractmethod
+    def get_instances(self, hostclass, group_name):
+        """Get list of instances in groups"""
+        return
+
+    @abstractmethod
+    def delete_groups(self, hostclass, group_name, force):
+        """Delete groups of a hostclass"""
+        return
+
+    @abstractmethod
+    def scaledown_groups(self, hostclass, group_name, wait, noerror):
+        """Scale down number of instances in a group"""
+        return
+
+
+class DiscoGroup(BaseGroup):
+    """Implementation of DiscoGroup regardless of the type of group"""
+
+    def __init__(self, environment_name):
+        """Implementation of BaseGroup in AWS"""
+        self.environment_name = environment_name
+        self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
+        self._elastigroup = DiscoElastigroup(environment_name=self.environment_name)
+
+    def get_existing_group(self, hostclass=None, group_name=None, throw_on_two_groups=True):
+        asg_group = self._autoscale.get_existing_group(
+            hostclass=hostclass,
+            group_name=group_name,
+            throw_on_two_groups=throw_on_two_groups
+        )
+        spot_group = self._elastigroup.get_existing_group(
+            hostclass=hostclass,
+            group_name=group_name,
+            throw_on_two_groups=throw_on_two_groups
+        )
+        if asg_group and spot_group:
+            return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
+        elif asg_group:
+            return asg_group.__dict__
+        elif spot_group:
+            return spot_group
+        else:
+            logger.info('No group found')
+
+    def get_instances(self, hostclass=None, group_name=None):
+        asg_instances = self._autoscale.get_instances(hostclass=hostclass, group_name=group_name)
+        asg_instance_ids = [{'instance_id': inst.instance_id} for inst in asg_instances]
+        spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
+        spot_instance_ids = [{'instance_id': inst['instanceId']} for inst in spot_instances]
+        return asg_instance_ids + spot_instance_ids
+
+    def delete_groups(self, hostclass=None, group_name=None, force=False):
+        self._autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+        self._elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+
+    def scaledown_groups(self, hostclass=None, group_name=None, wait=False, noerror=False):
+        self._autoscale.scaledown_groups(
+            hostclass=hostclass,
+            group_name=group_name,
+            wait=wait,
+            noerror=noerror
+        )
+        self._elastigroup.scaledown_groups(
+            hostclass=hostclass,
+            group_name=group_name,
+            wait=wait,
+            noerror=noerror
+        )

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 import boto.ec2.instance
 from mock import MagicMock, create_autospec, call, ANY
 
-from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoAutoscale, DiscoBake, DiscoELB
+from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoGroup, DiscoBake, DiscoELB
 from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN, DEPLOYMENT_STRATEGY_CLASSIC
 from disco_aws_automation.exceptions import (
     TimeoutError,
@@ -154,18 +154,18 @@ class DiscoDeployTests(TestCase):
 
     def setUp(self):
         self._environment_name = "foo"
-        self._disco_autoscale = create_autospec(DiscoAutoscale, instance=True)
+        self._disco_group = create_autospec(DiscoGroup, instance=True)
         self._disco_elb = create_autospec(DiscoELB, instance=True)
         self._disco_aws = create_autospec(DiscoAWS, instance=True)
         self._test_aws = self._disco_aws
         self._existing_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.return_value = self._existing_group
+        self._disco_group.get_existing_group.return_value = self._existing_group.__dict__
         self._disco_bake = MagicMock()
         self._disco_bake.promote_ami = MagicMock()
         self._disco_bake.ami_stages = MagicMock(return_value=['untested', 'failed', 'tested'])
         self._disco_bake.get_ami_creation_time = DiscoBake.extract_ami_creation_time_from_ami_name
         self._ci_deploy = DiscoDeploy(
-            self._disco_aws, self._test_aws, self._disco_bake, self._disco_autoscale, self._disco_elb,
+            self._disco_aws, self._test_aws, self._disco_bake, self._disco_group, self._disco_elb,
             pipeline_definition=MOCK_PIPELINE_DEFINITION,
             ami=None, hostclass=None, allow_any_hostclass=False,
             config=get_mock_config(MOCK_CONFIG_DEFINITON))
@@ -480,9 +480,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -495,7 +495,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 2, 'max_size': 2,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_nodeploy_works(self):
@@ -506,9 +506,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcbluegreennondeployable")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -517,7 +517,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1, 'max_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreennondeployable'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_not_called()
 
     def test_bg_deploy_works_with_original_group(self):
@@ -529,9 +529,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -544,7 +544,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=old_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=old_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_bad_new_group_name(self):
@@ -553,7 +553,7 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.return_value = group
+        self._disco_group.get_existing_group.return_value = group.__dict__
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
 
     def test_bg_deploy_with_failing_tests(self):
@@ -565,14 +565,14 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=False)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'failed')
         self._disco_aws.spinup.assert_called_once_with([{
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_when_unable_to_test(self):
@@ -584,14 +584,14 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(side_effect=IntegrationTestError)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_aws.spinup.assert_called_once_with([{
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_bake.promote_ami.assert_not_called()
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_failing_elbs(self):
@@ -604,10 +604,10 @@ class DiscoDeployTests(TestCase):
         self._disco_elb.wait_for_instance_health_state.side_effect = TimeoutError
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
         instance_ids = [inst.instance_id for inst in instances]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertRaises(TimeoutError, self._ci_deploy.test_ami, ami, dry_run=False)
@@ -622,7 +622,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_bad_testing_mode(self):
@@ -634,9 +634,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
@@ -646,7 +646,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_with_hc_not_in_pl_and_no_group(self):
@@ -657,9 +657,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -671,7 +671,7 @@ class DiscoDeployTests(TestCase):
             [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
               'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
               'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_hc_not_in_pl_and_group(self):
         '''Blue/green is non-deployable if hostclass is not in pipeline, dies, and updates existing group'''
@@ -682,9 +682,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcfoo", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -699,7 +699,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 2,
                     'integration_test': None, 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
                     'hostclass': 'mhcfoo'}], group_name=old_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with old group'''
@@ -711,7 +711,7 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.spinup.side_effect = Exception
         old_group = self.mock_group("mhcbluegreen")
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -719,7 +719,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no old group'''
@@ -730,7 +730,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -738,7 +738,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_groups(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no groups'''
@@ -748,7 +748,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
-        self._disco_autoscale.get_existing_group.side_effect = [None, None]
+        self._disco_group.get_existing_group.side_effect = [None, None]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -756,7 +756,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_with_error_and_og_and_no_ng(self):
         '''Blue/green can handle an an exception when spinning up the new ASG w/ old group and no new group'''
@@ -767,7 +767,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
         old_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, None]
         self.assertRaises(Exception, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -775,7 +775,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_with_too_many_autoscaling_groups(self):
         '''Blue/green can handle too many autoscaling groups error when spinning up a new ASG'''
@@ -786,7 +786,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = TooManyAutoscalingGroups
         old_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, None]
         self.assertRaises(TooManyAutoscalingGroups, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -794,7 +794,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_timed_autoscaling(self):
         '''Blue/green can handle creating timed autoscaling actions'''
@@ -804,9 +804,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhctimedautoscale")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -837,9 +837,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhctimedautoscale", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhctimedautoscale")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -869,9 +869,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhctimedautoscalenodeploy")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -949,7 +949,7 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.spinup.assert_called_once_with(
             [{'ami': 'ami-12345678', 'sequence': 1, 'min_size': 0, 'desired_size': 1,
               'smoke_test': 'no', 'max_size': 1, 'hostclass': 'mhcnewscarey'}], testing=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(hostclass='mhcnewscarey', force=True)
+        self._disco_group.delete_groups.assert_called_once_with(hostclass='mhcnewscarey', force=True)
 
     def test_nodeploy_ami_failure(self):
         '''No deploy instances are failed and not promoted when smoketest fails'''
@@ -1324,7 +1324,7 @@ class DiscoDeployTests(TestCase):
                 ami,
                 pipeline_dict=None,
                 dry_run=False,
-                old_group=self._existing_group
+                old_group=self._existing_group.__dict__
             )
         ])
 
@@ -1338,11 +1338,11 @@ class DiscoDeployTests(TestCase):
     def test_update_ami_not_in_autoscale_deploy(self):
         '''Test update_ami handling new deployable hostclass'''
         ami = self.mock_ami("mhcsmokey 1")
-        self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
+        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_tested_ami = MagicMock(return_value=True)
         self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
                                                      deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcsmokey")
+        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcsmokey")
         self._ci_deploy.handle_tested_ami.assert_called_with(
             ami,
             pipeline_dict={
@@ -1360,12 +1360,12 @@ class DiscoDeployTests(TestCase):
         '''Test update_ami handling new non-deployable hostclass'''
         ami = self.mock_ami("mhcscarey 1")
         self._ci_deploy.is_deployable = MagicMock(return_value=False)
-        self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
+        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_nodeploy_ami = MagicMock(return_value=True)
         self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
                                                      deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self.assertEqual(self._ci_deploy.is_deployable.call_count, 1)
-        self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcscarey")
+        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcscarey")
         self._ci_deploy.handle_nodeploy_ami.assert_called_with(
             ami,
             pipeline_dict={

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -57,6 +57,7 @@ class DiscoElastigroupTests(TestCase):
     def test_delete_groups_bad_hostclass(self):
         """Verifies elastigroup not deleted for bad hostclass"""
         self.elastigroup._delete_group = MagicMock()
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.delete_groups(hostclass="mhcfoo")
 
@@ -65,6 +66,7 @@ class DiscoElastigroupTests(TestCase):
     def test_delete_groups_bad_groupname(self):
         """Verifies elastigroup not deleted for bad group name"""
         self.elastigroup._delete_group = MagicMock()
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.delete_groups(group_name='moon_mhcfoo_12345678')
 

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -2,7 +2,6 @@
 Tests of disco_elastigroup
 """
 import random
-import json
 
 from unittest import TestCase
 
@@ -129,10 +128,12 @@ class DiscoElastigroupTests(TestCase):
         """Verifies new elastigroup is created"""
         self.elastigroup._create_az_subnets_dict = MagicMock()
         self.elastigroup._create_elastigroup_config = MagicMock(return_value=dict())
+        self.elastigroup.get_existing_group = MagicMock(return_value=None)
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.update_group(hostclass="mhcfoo")
 
-        self.elastigroup.session.post.assert_called_once_with(SPOTINST_API, data=json.dumps({}))
+        self.elastigroup._spotinst_call.assert_called_once_with(data={}, method='post')
 
     def test_update_existing_group(self):
         """Verifies existing elastigroup is updated"""
@@ -150,8 +151,9 @@ class DiscoElastigroupTests(TestCase):
         self.elastigroup._create_az_subnets_dict = MagicMock()
         self.elastigroup._create_elastigroup_config = MagicMock(return_value=mock_group_config)
         self.elastigroup.get_existing_group = MagicMock(return_value=mock_group)
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.update_group(hostclass="mhcfoo")
 
-        self.elastigroup.session.put.assert_called_once_with(SPOTINST_API + mock_group['id'],
-                                                             data=json.dumps(mock_group_config))
+        self.elastigroup._spotinst_call.assert_called_once_with(path='/' + mock_group['id'],
+                                                                data=mock_group_config, method='put')

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -76,7 +76,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group = self.mock_elastigroup(hostclass='mhcfoo')
 
         self.elastigroup._delete_group = MagicMock()
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group])
 
         self.elastigroup.delete_groups(hostclass='mhcfoo')
 
@@ -87,7 +87,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group = self.mock_elastigroup(hostclass='mhcfoo')
 
         self.elastigroup._delete_group = MagicMock()
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group])
 
         self.elastigroup.delete_groups(group_name=mock_group['name'])
 
@@ -98,7 +98,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group1 = self.mock_elastigroup(hostclass="mhcfoo")
         mock_group2 = self.mock_elastigroup(hostclass="mhcbar")
 
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group1, mock_group2])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group1, mock_group2])
         self.elastigroup._get_group_instances = MagicMock(return_value=['instance1', 'instance2'])
 
         actual_listings = self.elastigroup.list_groups()


### PR DESCRIPTION
* Added DiscoGroup class and BaseGroup abstract class
* Added DiscoElastigroup methods used in DiscoDeploy
* Added DiscoGroup package
* Replaced DiscoAutocale with DiscoGroup in bin/disco_deploy.py
* Changed to use DiscoGroup methods in disco_deploy
* Added wait time method to wait for elastigroups instance ID to be available
* Added DiscoGroup in disco_aws.py
* Modified disco_deploy unit tests to use DiscoGroup
* Bumped up asiaq version