### PR TITLE
AL-793 Make Disco IAM Delete Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1523,30 +1523,31 @@ The IAM configuration is made up of several directories:
     Groups based (IAM Users) on policy `.iam` files.
 -   **s3**: Specifies policies for buckets.
 
-There are several policy types: - **.iam**: These are the IAM policies
-themselves. They say what can be done to what resources from which
-locations. - **.tr** These determine the trust relationship between
-accounts. - **.acp**: These are S3 Access Control Lists. When IAM won't
-do what you need. - **.lifecycle** These determine when S3 buckets are
-sent to Glacier or expired. - **.logging** These determine whether and
-where S3 access logs are sent. - **.versioning** These determine whether
-versioning is enabled for an S3 bucket.
+There are several policy types:
+- **.iam**: These are the IAM policies themselves. They say what can be
+            done to what resources from which locations.
+- **.tr**: These determine the trust relationship between accounts.
+- **.acp**: These are S3 Access Control Lists. When IAM won't do what you need.
+- **.lifecycle**: These determine when S3 buckets are sent to Glacier or expired.
+- **.logging**: These determine whether and where S3 access logs are sent.
+- **.versioning**: These determine whether versioning is enabled for an S3 bucket.
 
 The syntax of the IAM policies is described in the [AWS IAM Policy
 Reference](http://docs.aws.amazon.com/IAM/latest/UserGuide/policy-reference.html).
 
 In the disco_aws.ini file there is an [iam] section. This contains up
-to six variables: - **saml_provider_name** Name of SAML Identity
-Assertion Provider (for SSO) - **saml_provider_url** URL of SAML
-Identity Assertion Provider (for SSO) - **role_prefix** This plus "_"
-is prepended to user groups and roles. - **policy_blacklist** This
-prevents a subset of the defined groups and roles from being created.
-This is used with ["@prod](mailto:"@prod)" to keep developer account
-policies from leaking into the production account. -
-**prune_empty_groups** When set to True any groups to which no user
-belongs are pruned. - **naked_roles** This specifies roles to which the
-role_prefix is not applied. This is used when policies need to have a
-specific name for cross account access. For example: SecurityMonkey.
+to six variables:
+- **saml_provider_name**: Name of SAML Identity Assertion Provider (for SSO)
+- **saml_provider_url**: URL of SAML Identity Assertion Provider (for SSO)
+- **role_prefix** This plus "_" is prepended to user groups and roles.
+- **policy_blacklist**: This prevents a subset of the defined groups
+and roles from being created. This is used with ["@prod](mailto:"@prod)"
+to keep developer account policies from leaking into the production account. 
+- **prune_empty_groups**: When set to True any groups to which no user
+belongs are pruned.
+- **naked_roles**: This specifies roles to which the role_prefix is not
+applied. This is used when policies need to have a specific name for
+cross account access. For example: SecurityMonkey.
 
 ### Commands for managing Access Control
 

--- a/disco_aws_automation/disco_iam.py
+++ b/disco_aws_automation/disco_iam.py
@@ -406,8 +406,8 @@ class DiscoIAM(object):
         deleted_roles = []
         for role in old_roles:
             if role not in updated_roles:
+                logger.debug("Cleaning up role: %s", role)
                 self.removerole(role)
-                logger.debug("Cleanup Role(%s)", role)
                 deleted_roles.append(role)
         return deleted_roles
 

--- a/disco_aws_automation/disco_iam.py
+++ b/disco_aws_automation/disco_iam.py
@@ -95,7 +95,10 @@ class DiscoIAM(object):
 
     def list_groups(self):
         '''Lists IAM User Groups'''
-        groups = throttled_call(self.connection.get_all_groups).list_groups_response.list_groups_result.groups
+        groups = throttled_call(
+            self.connection.get_all_groups,
+            max_items=500
+        ).list_groups_response.list_groups_result.groups
         return [
             group.group_name
             for group in groups
@@ -118,7 +121,8 @@ class DiscoIAM(object):
         '''Lists all policies attached to an IAM User Group'''
         return throttled_call(
             self.connection.get_all_group_policies,
-            group_name
+            group_name,
+            max_items=500
         ).list_group_policies_response.list_group_policies_result.policy_names
 
     def get_group_policy(self, group_name, policy_name):
@@ -152,7 +156,10 @@ class DiscoIAM(object):
 
     def list_users(self):
         '''List IAM Users'''
-        users = throttled_call(self.connection.get_all_users)
+        users = throttled_call(
+            self.connection.get_all_users,
+            max_items=500
+        )
         return [
             user.user_name
             for user in users.list_users_response.list_users_result.users
@@ -196,7 +203,11 @@ class DiscoIAM(object):
 
     def list_user_groups(self, user_name):
         '''Lists groups that IAM User is a member of'''
-        groups_response = throttled_call(self.connection.get_groups_for_user, user_name)
+        groups_response = throttled_call(
+            self.connection.get_groups_for_user,
+            user_name,
+            max_items=500
+        )
         groups = groups_response.list_groups_for_user_response.list_groups_for_user_result.groups
         return [group.group_name for group in groups]
 
@@ -308,7 +319,11 @@ class DiscoIAM(object):
 
     def listrolepolicies(self, role_name):
         '''Lists policies attached to an IAM Role'''
-        response = throttled_call(self.connection.list_role_policies, role_name)
+        response = throttled_call(
+            self.connection.list_role_policies,
+            role_name,
+            max_items=500
+        )
         return [
             policy_name
             for policy_name in response.list_role_policies_response.list_role_policies_result.policy_names

--- a/disco_aws_automation/disco_iam.py
+++ b/disco_aws_automation/disco_iam.py
@@ -459,6 +459,10 @@ class DiscoIAM(object):
 
         federated_roles, unfederated_roles = self._list_roles_by_type()
         existing_roles = set(federated_roles) | set(unfederated_roles)
+        non_instance_roles = [
+            role for role in existing_roles
+            if role.startswith(role_prefix)
+        ]
 
         try:
             federated_trust = self._get_federated_trust_relationship_json()
@@ -486,7 +490,7 @@ class DiscoIAM(object):
             self._prune_role_policies(role_name, keep_policy=policy)
             updated_roles.append(role_name)
 
-        deleted_roles = self._cleanup_roles(federated_roles, updated_roles)
+        deleted_roles = self._cleanup_roles(non_instance_roles, updated_roles)
         logger.debug("Updated federated user roles: %s.", updated_roles)
         logger.debug("Deleted federated user roles: %s.", deleted_roles)
         return (updated_roles, deleted_roles)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
There was a bug where Disco IAM would only ever try to delete federated roles. This has historically been an empty list, so Disco IAM would never delete any roles. Now, Disco IAM will generate a list of all roles that start with its prefix, and delete roles from that list if they no longer exist in the config.

This also means that Disco IAM should no longer try to manage roles that do not start with either `instance_` or the configured role prefix, which should mean that Cognito roles and other generated roles should no longer be blown away. That being said, those should really be in a config file somewhere...