### PR TITLE
Fix Disco Deploy Handling of Zero Sized Pipelines

### DIFF
--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -631,16 +631,16 @@ class DiscoDeploy(object):
         else:
             # The 'or 1' is because some people set their desired size to 0 in their pipeline.
             desired_size = int(size_as_maximum_int_or_none(
-                pipeline_dict.get("desired_size", 1) or 1
-            ))
+                pipeline_dict.get("desired_size", 1)
+            )) or 1
             min_size = int(size_as_minimum_int_or_none(
                 pipeline_dict.get("min_size", 0)
             ))
             # The 'or' on max_size is here for the same reason. So if it's 0, just set it to desired_size so
             # its a valid entry...
             max_size = int(size_as_maximum_int_or_none(
-                pipeline_dict.get("max_size", desired_size) or desired_size
-            ))
+                pipeline_dict.get("max_size", desired_size)
+            )) or desired_size
 
         new_config["desired_size"] = desired_size
         new_config["min_size"] = min_size

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -27,43 +27,43 @@ from test.helpers.patch_disco_aws import get_mock_config
 MOCK_PIPELINE_DEFINITION = [
     {
         'hostclass': 'mhcintegrated',
-        'min_size': 1,
-        'desired_size': 1,
+        'min_size': "1",
+        'desired_size': "1",
         'integration_test': 'foo_service',
         'deployable': 'yes'
     },
     {
         'hostclass': 'mhcbluegreen',
-        'min_size': 2,
-        'desired_size': 2,
+        'min_size': "2",
+        'desired_size': "2",
         'integration_test': 'blue_green_service',
         'deployable': 'yes'
     },
     {
         'hostclass': 'mhcbluegreennondeployable',
-        'min_size': 1,
-        'desired_size': 1,
+        'min_size': "1",
+        'desired_size': "1",
         'integration_test': 'blue_green_service',
         'deployable': 'no'
     },
     {
         'hostclass': 'mhcsmokey',
-        'min_size': 2,
-        'desired_size': 2,
+        'min_size': "2",
+        'desired_size': "2",
         'integration_test': None,
         'deployable': 'yes'
     },
     {
         'hostclass': 'mhcscarey',
-        'min_size': 1,
-        'desired_size': 1,
+        'min_size': "1",
+        'desired_size': "1",
         'integration_test': None,
         'deployable': 'no'
     },
     {
         'hostclass': 'mhcfoo',
-        'min_size': 1,
-        'desired_size': 1,
+        'min_size': "1",
+        'desired_size': "1",
         'integration_test': None,
         'deployable': 'no'
     },
@@ -1346,10 +1346,10 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.handle_tested_ami.assert_called_with(
             ami,
             pipeline_dict={
-                'min_size': 2,
+                'min_size': '2',
                 'integration_test': None,
                 'deployable': 'yes',
-                'desired_size': 2,
+                'desired_size': '2',
                 'hostclass': 'mhcsmokey'
             },
             dry_run=False,
@@ -1369,10 +1369,10 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.handle_nodeploy_ami.assert_called_with(
             ami,
             pipeline_dict={
-                'min_size': 1,
+                'min_size': '1',
                 'integration_test': None,
                 'deployable': 'no',
-                'desired_size': 1,
+                'desired_size': '1',
                 'hostclass': 'mhcscarey'
             },
             dry_run=False,
@@ -1481,3 +1481,19 @@ class DiscoDeployTests(TestCase):
         actual_hostclass = self._ci_deploy.hostclass_option("hostclass_being_tested",
                                                             "test_hostclass")
         self.assertEqual(expected_hostclass, actual_hostclass)
+
+    def test_correct_zero_pipeline_sizing(self):
+        '''Tests that get deploy sizing corrects zero pipeline sizing'''
+        post_deploy_pipeline = self._ci_deploy._generate_post_deploy_pipeline(
+            pipeline_dict={
+                'desired_size': "0",
+                'min_size': "0",
+                'max_size': "0",
+            },
+            old_group=None,
+            ami=MagicMock(id='ami-1234567890')
+        )
+
+        self.assertEqual(post_deploy_pipeline['desired_size'], 1)
+        self.assertEqual(post_deploy_pipeline['min_size'], 0)
+        self.assertEqual(post_deploy_pipeline['max_size'], 1)


### PR DESCRIPTION
So, turns out types are important.

In our unit tests, the mock pipelines have used integers as the type for
the values of the ASG sizes. However, in real life, those are strings.
There was an or statement that was intended to catch things like a zero
size in a pipeline and correct that to a more reasonable default value.
However, that doesn't work because `"0"` is a truthy value and not a
falsey value, so the or was never triggered.

This change moves the or to after the input is converted to an integer,
so that if the input from the pipeline is a `0` it will correctly
evalute to falsey and be replaced with a `1`.

Also updated our unit tests so that our mock pipelines correctly use
strings as the type of the sizing variables, and added an explicit unit
test for this case.