### PR TITLE
Spotinst api exception

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -71,7 +71,8 @@ class DiscoElastigroup(BaseGroup):
         if response.status_code == 200:
             return response
         else:
-            raise Exception('Error communicating with Spotinst API: {}'.format(path))
+            # raise Exception('Error communicating with Spotinst API: {}'.format(path))
+            logger.info('Error communicating with Spotinst API: %s', path)
 
     def _get_new_groupname(self, hostclass):
         """Returns a new elastigroup name when given a hostclass"""

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
test-and-promote jobs have been failing because of exception raised for Spotinst miscommunication. Currently there are no Spoinst tokens configured for users or Jenkins servers, so jobs are failing. Converting the exception to a simple log for now.