### PR TITLE
Move spotinst handling to discogroup

### DIFF
--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -10,7 +10,6 @@ import sys
 from collections import defaultdict
 
 from disco_aws_automation import DiscoGroup
-from disco_aws_automation import DiscoAutoscale
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
@@ -156,7 +155,6 @@ def run():
     environment_name = args.env or config.get("disco_aws", "default_environment")
 
     discogroup = DiscoGroup(environment_name)
-    autoscale = DiscoAutoscale(environment_name)
 
     # Autoscaling group commands
     if args.mode == "listgroups":
@@ -177,16 +175,16 @@ def run():
 
     # Launch Configuration commands
     elif args.mode == "listconfigs":
-        for config in autoscale.get_configs():
+        for config in discogroup.get_configs():
             print("{0:24} {1}".format(config.name, config.image_id))
     elif args.mode == "cleanconfigs":
-        autoscale.clean_configs()
+        discogroup.clean_configs()
     elif args.mode == "deleteconfig":
-        autoscale.delete_config(args.config)
+        discogroup.delete_config(args.config)
 
     # Scaling policy commands
     elif args.mode == "listpolicies":
-        policies = autoscale.list_policies(
+        policies = discogroup.list_policies(
             group_name=args.group_name,
             policy_types=args.policy_types,
             policy_names=args.policy_names
@@ -224,7 +222,7 @@ def run():
         else:
             parsed_steps = []
 
-        autoscale.create_policy(
+        discogroup.create_policy(
             group_name=args.group_name,
             policy_name=args.policy_name,
             policy_type=args.policy_type,
@@ -237,7 +235,7 @@ def run():
             estimated_instance_warmup=args.estimated_instance_warmup
         )
     elif args.mode == "deletepolicy":
-        autoscale.delete_policy(args.policy_name, args.group_name)
+        discogroup.delete_policy(args.policy_name, args.group_name)
 
     sys.exit(0)
 

--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -9,8 +9,8 @@ import sys
 
 from collections import defaultdict
 
+from disco_aws_automation import DiscoGroup
 from disco_aws_automation import DiscoAutoscale
-from disco_aws_automation import DiscoElastigroup
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
@@ -155,14 +155,13 @@ def run():
 
     environment_name = args.env or config.get("disco_aws", "default_environment")
 
+    discogroup = DiscoGroup(environment_name)
     autoscale = DiscoAutoscale(environment_name)
-    elastigroup = DiscoElastigroup(environment_name)
 
     # Autoscaling group commands
     if args.mode == "listgroups":
         format_str = "{0} {1:12} {2:3} {3:3} {4:3} {5:3} {6:4}"
-        groups = autoscale.list_groups() + elastigroup.list_groups()
-        groups.sort(key=lambda grp: grp['name'])
+        groups = discogroup.list_groups()
         if args.debug:
             print(format_str.format(
                 "Name".ljust(35 + len(environment_name)), "AMI", "min", "des", "max", "cnt", "type"))
@@ -172,11 +171,9 @@ def run():
                                      group['max_size'], group['group_cnt'], group['type']))
 
     elif args.mode == "cleangroups":
-        autoscale.delete_groups()
-        elastigroup.delete_groups()
+        discogroup.delete_groups()
     elif args.mode == "deletegroup":
-        autoscale.delete_groups(hostclass=args.hostclass, group_name=args.name, force=args.force)
-        elastigroup.delete_groups(hostclass=args.hostclass, group_name=args.name, force=args.force)
+        discogroup.delete_groups(hostclass=args.hostclass, group_name=args.name, force=args.force)
 
     # Launch Configuration commands
     elif args.mode == "listconfigs":

--- a/bin/disco_deploy.py
+++ b/bin/disco_deploy.py
@@ -52,7 +52,7 @@ import sys
 
 from docopt import docopt
 
-from disco_aws_automation import DiscoAWS, DiscoAutoscale, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
+from disco_aws_automation import DiscoAWS, DiscoGroup, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
@@ -91,7 +91,7 @@ def run():
     vpc = DiscoVPC.fetch_environment(environment_name=env)
 
     deploy = DiscoDeploy(
-        aws, test_aws, DiscoBake(config, aws.connection), DiscoAutoscale(env), DiscoELB(vpc),
+        aws, test_aws, DiscoBake(config, aws.connection), DiscoGroup(env), DiscoELB(vpc),
         pipeline_definition=pipeline_definition,
         ami=args.get("--ami"), hostclass=args.get("--hostclass"),
         allow_any_hostclass=args["--allow-any-hostclass"])

--- a/disco_aws_automation/__init__.py
+++ b/disco_aws_automation/__init__.py
@@ -1,6 +1,7 @@
-''' For package documentation, see README '''
+""" For package documentation, see README """
 
 from .disco_acm import DiscoACM
+from .disco_group import DiscoGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
 from .disco_aws import DiscoAWS

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -1,0 +1,68 @@
+"""Base Group (abstract)"""
+import logging
+
+from abc import ABCMeta, abstractmethod
+
+from botocore.exceptions import WaiterError
+import boto3
+
+from .resource_helper import throttled_call
+
+logger = logging.getLogger(__name__)
+
+
+class BaseGroup(object):
+    """Abstract class definition for AWS groups"""
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self._boto3_ec = None
+
+    @abstractmethod
+    def get_existing_group(self, hostclass, group_name, throw_on_two_groups):
+        """Get list of group objects for a hostclass"""
+        return
+
+    @abstractmethod
+    def get_existing_groups(self, hostclass, group_name):
+        """Get list of all group objects for a hostclass"""
+        return
+
+    @abstractmethod
+    def get_instances(self, hostclass=None, group_name=None):
+        """Get list of instances in groups"""
+        return
+
+    @abstractmethod
+    def delete_groups(self, hostclass, group_name, force):
+        """Delete groups of a hostclass"""
+        return
+
+    @abstractmethod
+    def scaledown_groups(self, hostclass, group_name, wait, noerror):
+        """Scale down number of instances in a group"""
+        return
+
+    @property
+    def boto3_ec(self):
+        """Lazily create boto3 ec2 connection"""
+        if not self._boto3_ec:
+            self._boto3_ec = boto3.client('ec2')
+        return self._boto3_ec
+
+    def wait_instance_termination(self, group_name=None, group=None, noerror=False):
+        """Wait for instance to be terminated during scaledown"""
+        waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
+        instance_ids = [inst['id'] for inst in self.get_instances(group_name=group_name)]
+
+        try:
+            logger.info("Waiting for scaledown of group %s", group['name'])
+            waiter.wait(InstanceIds=instance_ids)
+        except WaiterError:
+            if noerror:
+                logger.exception("Unable to wait for scaling down of %s", group_name)
+                return False
+            else:
+                raise
+
+        return True

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -29,6 +29,11 @@ class BaseGroup(object):
         return
 
     @abstractmethod
+    def list_groups(self):
+        """Returns list of objects for display purposes for all groups"""
+        return
+
+    @abstractmethod
     def get_instances(self, hostclass=None, group_name=None):
         """Get list of instances in groups"""
         return

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -137,7 +137,7 @@ class BaseGroup(object):
     def wait_instance_termination(self, group_name=None, group=None, noerror=False):
         """Wait for instance to be terminated during scaledown"""
         waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
-        instance_ids = [inst['id'] for inst in self.get_instances(group_name=group_name)]
+        instance_ids = [inst['instance_id'] for inst in self.get_instances(group_name=group_name)]
 
         try:
             logger.info("Waiting for scaledown of group %s", group['name'])

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -48,6 +48,85 @@ class BaseGroup(object):
         """Scale down number of instances in a group"""
         return
 
+    @abstractmethod
+    def terminate(self, instance_id, decrement_capacity=True):
+        """
+        Terminates an instance using the autoscaling API.
+
+        When decrement_capacity is True this allows us to avoid
+        autoscaling immediately replacing a terminated instance.
+        """
+        pass
+
+    @abstractmethod
+    def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):
+        """Deletes all recurring scheduled actions for a hostclass"""
+        pass
+
+    @abstractmethod
+    def create_recurring_group_action(self, recurrance, min_size=None, desired_capacity=None, max_size=None,
+                                      hostclass=None, group_name=None):
+        """Creates a recurring scheduled action for a hostclass"""
+        pass
+
+    @abstractmethod
+    def update_elb(self, elb_names, hostclass=None, group_name=None):
+        """Updates an existing autoscaling group to use a different set of load balancers"""
+        pass
+
+    @abstractmethod
+    def get_launch_config(self, hostclass=None, group_name=None):
+        """Create new launchconfig group name"""
+        pass
+
+    # pylint: disable=R0913, R0914
+    @abstractmethod
+    def update_group(self, hostclass, desired_size=None, min_size=None, max_size=None, instance_type=None,
+                     load_balancers=None, subnets=None, security_groups=None, instance_monitoring=None,
+                     ebs_optimized=None, image_id=None, key_name=None, associate_public_ip_address=None,
+                     user_data=None, tags=None, instance_profile_name=None, block_device_mappings=None,
+                     group_name=None, create_if_exists=False, termination_policies=None, spotinst=False):
+        """
+        Create a new autoscaling group or update an existing one
+        """
+        pass
+
+    @abstractmethod
+    def clean_configs(self):
+        """Delete unused Launch Configurations in current environment"""
+        pass
+
+    @abstractmethod
+    def get_configs(self, names=None):
+        """Returns Launch Configurations in current environment"""
+        pass
+
+    @abstractmethod
+    def delete_config(self, config_name):
+        """Delete a specific Launch Configuration"""
+        pass
+
+    @abstractmethod
+    def list_policies(self, group_name=None, policy_types=None, policy_names=None):
+        """Returns all autoscaling policies"""
+        pass
+
+    @abstractmethod
+    def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,
+                      min_adjustment_magnitude=None, scaling_adjustment=None, cooldown=600,
+                      metric_aggregation_type=None, step_adjustments=None, estimated_instance_warmup=None):
+        """
+        Creates a new autoscaling policy, or updates an existing one if the autoscaling group name and
+        policy name already exist. Handles the logic of constructing the correct autoscaling policy request,
+        because not all parameters are required.
+        """
+        pass
+
+    @abstractmethod
+    def delete_policy(self, policy_name, group_name):
+        """Deletes an autoscaling policy"""
+        pass
+
     @property
     def boto3_ec(self):
         """Lazily create boto3 ec2 connection"""

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -288,7 +288,7 @@ class DiscoAutoscale(BaseGroup):
                      load_balancers=None, subnets=None, security_groups=None, instance_monitoring=None,
                      ebs_optimized=None, image_id=None, key_name=None, associate_public_ip_address=None,
                      user_data=None, tags=None, instance_profile_name=None, block_device_mappings=None,
-                     group_name=None, create_if_exists=False, termination_policies=None):
+                     group_name=None, create_if_exists=False, termination_policies=None, spotinst=False):
         """
         Create a new autoscaling group or update an existing one
         """
@@ -296,6 +296,9 @@ class DiscoAutoscale(BaseGroup):
         # We need unused argument to match method in autoscale
         # pylint: disable=R0913, R0914
         # pylint: disable=unused-argument
+        if spotinst:
+            raise Exception('DiscoAutoscale cannot be used to create SpotInst groups')
+
         launch_config = self.get_config(
             name=self.get_launch_config_name(hostclass),
             image_id=image_id,

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -1,4 +1,4 @@
-'''Contains DiscoAutoscale class that orchestrates AWS Autoscaling'''
+"""Contains DiscoAutoscale class that orchestrates AWS Autoscaling"""
 import logging
 import random
 import time
@@ -9,9 +9,9 @@ import boto.ec2.autoscale
 import boto.ec2.autoscale.launchconfig
 import boto.ec2.autoscale.group
 from boto.exception import BotoServerError
-from botocore.exceptions import WaiterError
 import boto3
 
+from .base_group import BaseGroup
 from .resource_helper import throttled_call
 from .exceptions import TooManyAutoscalingGroups
 
@@ -21,39 +21,31 @@ logger = logging.getLogger(__name__)
 DEFAULT_TERMINATION_POLICIES = ["OldestLaunchConfiguration"]
 
 
-class DiscoAutoscale(object):
-    '''Class orchestrating autoscaling'''
+class DiscoAutoscale(BaseGroup):
+    """Class orchestrating autoscaling"""
 
-    def __init__(self, environment_name, autoscaling_connection=None, boto3_autoscaling_connection=None,
-                 boto3_ec_connection=None):
+    def __init__(self, environment_name, autoscaling_connection=None, boto3_autoscaling_connection=None):
         self.environment_name = environment_name
         self._connection = autoscaling_connection or None  # lazily initialized
         self._boto3_autoscale = boto3_autoscaling_connection or None  # lazily initialized
-        self._boto3_ec = boto3_ec_connection or None  # lazily initialized
+        super(DiscoAutoscale, self).__init__()
 
     @property
     def connection(self):
-        '''Lazily create boto autoscaling connection'''
+        """Lazily create boto autoscaling connection"""
         if not self._connection:
             self._connection = boto.ec2.autoscale.AutoScaleConnection(use_block_device_types=True)
         return self._connection
 
     @property
     def boto3_autoscale(self):
-        '''Lazily create boto3 autoscaling connection'''
+        """Lazily create boto3 autoscaling connection"""
         if not self._boto3_autoscale:
             self._boto3_autoscale = boto3.client('autoscaling')
         return self._boto3_autoscale
 
-    @property
-    def boto3_ec(self):
-        '''Lazily create boto3 ec2 connection'''
-        if not self._boto3_ec:
-            self._boto3_ec = boto3.client('ec2')
-        return self._boto3_ec
-
     def get_new_groupname(self, hostclass):
-        '''Returns a new autoscaling group name when given a hostclass'''
+        """Returns a new autoscaling group name when given a hostclass"""
         return self.environment_name + '_' + hostclass + "_" + str(int(time.time()))
 
     def get_launch_config_name(self, hostclass):
@@ -61,7 +53,7 @@ class DiscoAutoscale(object):
         return '{0}_{1}_{2}'.format(self.environment_name, hostclass, str(random.randrange(0, 9999999)))
 
     def _filter_by_environment(self, items):
-        '''Filters autoscaling groups and launch configs by environment'''
+        """Filters autoscaling groups and launch configs by environment"""
         return [
             item for item in items
             if item.name.startswith("{0}_".format(self.environment_name))
@@ -75,11 +67,11 @@ class DiscoAutoscale(object):
         ]
 
     def get_hostclass(self, groupname):
-        '''Returns the hostclass when given an autoscaling group name'''
+        """Returns the hostclass when given an autoscaling group name"""
         return groupname.split('_')[1]
 
     def _get_group_generator(self, group_names=None):
-        '''Yields groups in current environment'''
+        """Yields groups in current environment"""
         next_token = None
         while True:
             groups = throttled_call(self.connection.get_all_groups,
@@ -91,13 +83,12 @@ class DiscoAutoscale(object):
             if not next_token:
                 break
 
-    def _get_instance_generator(self, instance_ids=None, hostclass=None, group_name=None):
-        '''Yields autoscaled instances in current environment'''
+    def _get_instance_generator(self, hostclass=None, group_name=None):
+        """Yields autoscaled instances in current environment"""
         next_token = None
         while True:
             instances = throttled_call(
-                self.connection.get_all_autoscaling_instances,
-                instance_ids=instance_ids, next_token=next_token)
+                self.connection.get_all_autoscaling_instances, next_token=next_token)
             for instance in self._filter_instance_by_environment(instances):
                 filters = [
                     not hostclass or self.get_hostclass(instance.group_name) == hostclass,
@@ -108,13 +99,12 @@ class DiscoAutoscale(object):
             if not next_token:
                 break
 
-    def get_instances(self, instance_ids=None, hostclass=None, group_name=None):
-        '''Returns autoscaled instances in the current environment'''
-        return list(self._get_instance_generator(instance_ids=instance_ids, hostclass=hostclass,
-                                                 group_name=group_name))
+    def get_instances(self, hostclass=None, group_name=None):
+        """Returns autoscaled instances in the current environment"""
+        return list(self._get_instance_generator(hostclass=hostclass, group_name=group_name))
 
     def _get_config_generator(self, names=None):
-        '''Yields Launch Configurations in current environment'''
+        """Yields Launch Configurations in current environment"""
         next_token = None
         while True:
             configs = throttled_call(self.connection.get_all_launch_configurations,
@@ -126,11 +116,11 @@ class DiscoAutoscale(object):
                 break
 
     def get_configs(self, names=None):
-        '''Returns Launch Configurations in current environment'''
+        """Returns Launch Configurations in current environment"""
         return list(self._get_config_generator(names=names))
 
     def get_config(self, *args, **kwargs):
-        '''Returns a new launch configuration'''
+        """Returns a new launch configuration"""
         config = boto.ec2.autoscale.launchconfig.LaunchConfiguration(
             connection=self.connection, *args, **kwargs
         )
@@ -138,7 +128,7 @@ class DiscoAutoscale(object):
         return config
 
     def delete_config(self, config_name):
-        '''Delete a specific Launch Configuration'''
+        """Delete a specific Launch Configuration"""
         throttled_call(self.connection.delete_launch_configuration, config_name)
         logger.info("Deleting launch configuration %s", config_name)
 
@@ -183,23 +173,11 @@ class DiscoAutoscale(object):
             throttled_call(group.update)
 
             if wait:
-                waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
-                instance_ids = [inst.instance_id for inst in self.get_instances(group_name=group_name)]
-
-                try:
-                    logger.info("Waiting for scaledown of group %s", group.name)
-                    waiter.wait(InstanceIds=instance_ids)
-                except WaiterError:
-                    if noerror:
-                        logger.exception("Unable to wait for scaling down of %s", group_name)
-                        return False
-                    else:
-                        raise
-            return True
+                self.wait_instance_termination(group_name=group_name, group=group, noerror=noerror)
 
     @staticmethod
     def create_autoscale_tags(group_name, tags):
-        '''Given a python dictionary return list of boto autoscale Tag objects'''
+        """Given a python dictionary return list of boto autoscale Tag objects"""
         return [boto.ec2.autoscale.Tag(key=key, value=value, resource_id=group_name, propagate_at_launch=True)
                 for key, value in tags.iteritems()] if tags else None
 
@@ -575,7 +553,7 @@ class DiscoAutoscale(object):
             associate_public_ip_address=launch_config.associate_public_ip_address)
 
     def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
-        '''Updates all of a hostclasses existing autoscaling groups to use a different snapshot'''
+        """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
         launch_config = self.get_launch_config(hostclass=hostclass, group_name=group_name)
         if not launch_config:
             raise Exception("Can't locate hostclass {0}".format(hostclass or group_name))
@@ -596,7 +574,7 @@ class DiscoAutoscale(object):
                 snapshot_id)
 
     def update_elb(self, elb_names, hostclass=None, group_name=None):
-        '''Updates an existing autoscaling group to use a different set of load balancers'''
+        """Updates an existing autoscaling group to use a different set of load balancers"""
         group = self.get_existing_group(hostclass=hostclass, group_name=group_name)
 
         if not group:

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -19,7 +19,6 @@ from .disco_elb import DiscoELB, DiscoELBPortConfig
 from .disco_alarm import DiscoAlarm
 from .disco_group import DiscoGroup
 from .disco_autoscale import DiscoAutoscale
-from .disco_elastigroup import DiscoElastigroup
 from .disco_aws_util import (
     is_truthy,
     get_instance_launch_time,
@@ -62,7 +61,7 @@ class DiscoAWS(object):
     # Too many arguments, but we want to mock a lot of things out, so...
     # pylint: disable=too-many-arguments
     def __init__(self, config, environment_name=None, boto2_conn=None, vpc=None, remote_exec=None,
-                 storage=None, discogroup=None, autoscale=None, elastigroup=None, elb=None,
+                 storage=None, discogroup=None, autoscale=None, elb=None,
                  log_metrics=None, alarms=None):
 
         if not environment_name and not vpc:
@@ -79,7 +78,7 @@ class DiscoAWS(object):
         self._disco_storage = storage or None  # lazily initialized
         self._discogroup = discogroup or None  # lazily initialized
         self._autoscale = autoscale or None  # lazily initialized
-        self._elastigroup = elastigroup or None  # lazily initialized
+        # self._elastigroup = elastigroup or None  # lazily initialized
         self._elb = elb or None  # lazily initialized
         self._log_metrics = log_metrics or None  # lazily initialized
         self._alarms = alarms or None  # lazily initialized
@@ -111,13 +110,6 @@ class DiscoAWS(object):
         if not self._autoscale:
             self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
         return self._autoscale
-
-    @property
-    def elastigroup(self):
-        """Lazily creates disco elastigroup object"""
-        if not self._elastigroup:
-            self._elastigroup = DiscoElastigroup(environment_name=self.environment_name)
-        return self._elastigroup
 
     @property
     def log_metrics(self):

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -695,9 +695,6 @@ class DiscoAWS(object):
                 for (hostclass, termination_policies, hdict) in hostclass_iter]
 
             if metadata[0]:
-                for _hc in metadata:
-                    if _hc.get('spotinst'):
-                        self.elastigroup.wait_for_instance_id(_hc['group_name'])
                 self.smoketest(self.wait_for_autoscaling_instances(
                     [_hc for _hc in metadata if _hc["hostclass"] in flammable]))
 

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -17,6 +17,7 @@ from boto.exception import EC2ResponseError
 from .disco_log_metrics import DiscoLogMetrics
 from .disco_elb import DiscoELB, DiscoELBPortConfig
 from .disco_alarm import DiscoAlarm
+from .disco_group import DiscoGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
 from .disco_aws_util import (
@@ -61,7 +62,8 @@ class DiscoAWS(object):
     # Too many arguments, but we want to mock a lot of things out, so...
     # pylint: disable=too-many-arguments
     def __init__(self, config, environment_name=None, boto2_conn=None, vpc=None, remote_exec=None,
-                 storage=None, autoscale=None, elastigroup=None, elb=None, log_metrics=None, alarms=None):
+                 storage=None, discogroup=None, autoscale=None, elastigroup=None, elb=None,
+                 log_metrics=None, alarms=None):
 
         if not environment_name and not vpc:
             raise ProgrammerError("Either 'vpc' or 'environment_name' must always be specified.")
@@ -75,6 +77,7 @@ class DiscoAWS(object):
         self._vpc = vpc or None  # lazily initialized
         self._disco_remote_exec = remote_exec or None  # lazily initialized
         self._disco_storage = storage or None  # lazily initialized
+        self._discogroup = discogroup or None  # lazily initialized
         self._autoscale = autoscale or None  # lazily initialized
         self._elastigroup = elastigroup or None  # lazily initialized
         self._elb = elb or None  # lazily initialized
@@ -94,6 +97,13 @@ class DiscoAWS(object):
         if not self._disco_storage:
             self._disco_storage = DiscoStorage(self.environment_name, self.connection)
         return self._disco_storage
+
+    @property
+    def discogroup(self):
+        """Lazily creates disco group object"""
+        if not self._discogroup:
+            self._discogroup = DiscoGroup(environment_name=self.environment_name)
+        return self._discogroup
 
     @property
     def autoscale(self):
@@ -458,7 +468,8 @@ class DiscoAWS(object):
             "hostclass": hostclass,
             "no_destroy": no_destroy,
             "group_name": group['name'],
-            "chaos": chaos
+            "chaos": chaos,
+            "spotinst": is_truthy(str(spotinst) or self.config('spotinst', hostclass))
         }
 
     def stop(self, instances):
@@ -716,13 +727,19 @@ class DiscoAWS(object):
                 for (hostclass, termination_policies, hdict) in hostclass_iter]
 
             if metadata[0]:
+                for _hc in metadata:
+                    if _hc.get('spotinst'):
+                        self.elastigroup.wait_for_instance_id(_hc['group_name'])
                 self.smoketest(self.wait_for_autoscaling_instances(
                     [_hc for _hc in metadata if _hc["hostclass"] in flammable]))
 
     @staticmethod
     def _instance_count_lt_min_size(group, all_instances):
-        group_instances = [_i for _i in all_instances if _i.group_name == group.name]
-        return len(group_instances) < group.min_size
+        group_instances = [_i for _i in all_instances if _i['group_name'] == group['name']]
+        if group.get('id'):
+            return len(group_instances) < group['capacity']['minimum']
+        else:
+            return len(group_instances) < group['min_size']
 
     def wait_for_autoscaling_instances(self, metadata_list, timeout=AUTOSCALE_TIMEOUT):
         """
@@ -731,11 +748,11 @@ class DiscoAWS(object):
         start_time = time.time()
         max_time = start_time + timeout
 
-        name_to_group = {group.name: group for group in self.autoscale.get_existing_groups()}
+        name_to_group = {group['name']: group for group in self.discogroup.get_existing_groups()}
         yet_to_scale = group_names = set([meta["group_name"] for meta in metadata_list])
 
         while True:
-            auto_instances = self.autoscale.get_instances()
+            auto_instances = self.discogroup.get_instances()
             logger.debug("yet_to_scale: %s", yet_to_scale)
             yet_to_scale = [gname for gname in yet_to_scale
                             if DiscoAWS._instance_count_lt_min_size(name_to_group[gname], auto_instances)]
@@ -753,8 +770,8 @@ class DiscoAWS(object):
             logger.info("Waited for %s autoscaling groups to reach min_size in %s seconds",
                         len(metadata_list), int(0.5 + time.time() - start_time))
 
-        instance_ids = [instance.instance_id for instance in auto_instances
-                        if instance.group_name in group_names]
+        instance_ids = [instance['instance_id'] for instance in auto_instances
+                        if instance['group_name'] in group_names]
 
         return self.instances(instance_ids=instance_ids) if instance_ids else []
 
@@ -767,7 +784,6 @@ class DiscoAWS(object):
         start_time = time.time()
         max_time = start_time + timeout
 
-        instances = []
         while time.time() < max_time:
             instances = self.instances_from_amis([ami_id], launch_time=launch_time, group_name=group_name)
             if len(instances) >= min_count:

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -18,7 +18,6 @@ from .disco_log_metrics import DiscoLogMetrics
 from .disco_elb import DiscoELB, DiscoELBPortConfig
 from .disco_alarm import DiscoAlarm
 from .disco_group import DiscoGroup
-from .disco_autoscale import DiscoAutoscale
 from .disco_aws_util import (
     is_truthy,
     get_instance_launch_time,
@@ -61,7 +60,7 @@ class DiscoAWS(object):
     # Too many arguments, but we want to mock a lot of things out, so...
     # pylint: disable=too-many-arguments
     def __init__(self, config, environment_name=None, boto2_conn=None, vpc=None, remote_exec=None,
-                 storage=None, discogroup=None, autoscale=None, elb=None,
+                 storage=None, discogroup=None, elb=None,
                  log_metrics=None, alarms=None):
 
         if not environment_name and not vpc:
@@ -77,8 +76,6 @@ class DiscoAWS(object):
         self._disco_remote_exec = remote_exec or None  # lazily initialized
         self._disco_storage = storage or None  # lazily initialized
         self._discogroup = discogroup or None  # lazily initialized
-        self._autoscale = autoscale or None  # lazily initialized
-        # self._elastigroup = elastigroup or None  # lazily initialized
         self._elb = elb or None  # lazily initialized
         self._log_metrics = log_metrics or None  # lazily initialized
         self._alarms = alarms or None  # lazily initialized
@@ -103,13 +100,6 @@ class DiscoAWS(object):
         if not self._discogroup:
             self._discogroup = DiscoGroup(environment_name=self.environment_name)
         return self._discogroup
-
-    @property
-    def autoscale(self):
-        """Lazily creates disco autoscale object"""
-        if not self._autoscale:
-            self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
-        return self._autoscale
 
     @property
     def log_metrics(self):
@@ -148,16 +138,6 @@ class DiscoAWS(object):
             buckets = self.vpc.get_credential_buckets(self._project_name)
             self._disco_remote_exec = DiscoRemoteExec(buckets)
         return self._disco_remote_exec
-
-    def service(self, spotinst=False):
-        """
-        User either autoscale or elastigroup service, depending on
-        hostclass configuration in disco_aws.ini (e.g. spotinst=True)
-        """
-        if spotinst:
-            return self.elastigroup
-        else:
-            return self.autoscale
 
     def config(self, option, section=DEFAULT_CONFIG_SECTION, default=None):
         """Get a value from the config"""
@@ -239,7 +219,7 @@ class DiscoAWS(object):
 
     def get_instance_type(self, hostclass):
         """Pull in instance_type existing launch configuration"""
-        old_config = self.autoscale.get_launch_config(hostclass=hostclass)
+        old_config = self.discogroup.get_launch_config(hostclass=hostclass)
         return old_config.instance_type if old_config else DEFAULT_INSTANCE_TYPE
 
     def get_meta_network_by_name(self, meta_network_name):
@@ -274,7 +254,7 @@ class DiscoAWS(object):
         Create new BDM if parameters are specified, else create a device
         mapping from existing configuration.
         """
-        old_config = self.autoscale.get_launch_config(hostclass=hostclass)
+        old_config = self.discogroup.get_launch_config(hostclass=hostclass)
         if not old_config or any([extra_space, extra_disk, iops]):
             block_device_mappings = [self.disco_storage.configure_storage(
                 hostclass=hostclass, ami_id=ami.id,
@@ -294,7 +274,7 @@ class DiscoAWS(object):
 
     def create_scaling_schedule(self, min_size, desired_size, max_size, hostclass=None, group_name=None):
         """Create autoscaling schedule"""
-        self.autoscale.delete_all_recurring_group_actions(hostclass=hostclass, group_name=group_name)
+        self.discogroup.delete_all_recurring_group_actions(hostclass=hostclass, group_name=group_name)
         maps = [
             size_as_recurrence_map(min_size, sentinel=None),
             size_as_recurrence_map(desired_size, sentinel=None),
@@ -304,7 +284,7 @@ class DiscoAWS(object):
         combined_map = {time: [maps[0].get(time), maps[1].get(time), maps[2].get(time)]
                         for time in times if time is not None}
         for recurrence, sizes in combined_map.items():
-            self.autoscale.create_recurring_group_action(
+            self.discogroup.create_recurring_group_action(
                 str(recurrence), hostclass=hostclass, group_name=group_name,
                 min_size=sizes[0], desired_capacity=sizes[1], max_size=sizes[2])
 
@@ -360,7 +340,7 @@ class DiscoAWS(object):
             )
 
         if update_autoscaling:
-            self.autoscale.update_elb([elb['LoadBalancerName']] if elb else [], hostclass=hostclass)
+            self.discogroup.update_elb([elb['LoadBalancerName']] if elb else [], hostclass=hostclass)
 
         return elb
 
@@ -416,9 +396,7 @@ class DiscoAWS(object):
 
         elb = self.update_elb(hostclass, update_autoscaling=False, testing=testing)
 
-        service = self.service(is_truthy(str(spotinst) or self.config('spotinst', hostclass)))
-
-        group = service.update_group(
+        group = self.discogroup.update_group(
             hostclass=hostclass,
             image_id=ami.id,
             subnets=self.get_subnets(meta_network, hostclass),
@@ -442,19 +420,18 @@ class DiscoAWS(object):
             block_device_mappings=block_device_mappings,
             create_if_exists=create_if_exists,
             termination_policies=termination_policies,
-            group_name=group_name
+            group_name=group_name,
+            spotinst=is_truthy(str(spotinst) or self.config('spotinst', hostclass))
         )
 
-        # Elastigroup does not return a group object
-        if service == self.autoscale:
-            self.create_scaling_schedule(min_size, desired_size, max_size, group_name=group['name'])
+        self.create_scaling_schedule(min_size, desired_size, max_size, group_name=group['name'])
 
-            # Create alarms and custom metrics for the hostclass, if is not being used for testing
-            if not testing:
-                self.alarms.create_alarms(hostclass, group['name'])
+        # Create alarms and custom metrics for the hostclass, if is not being used for testing
+        if not testing:
+            self.alarms.create_alarms(hostclass, group['name'])
 
-            logger.info("Spun up %s instances of %s from %s into group %s",
-                        size_as_maximum_int_or_none(desired_size), hostclass, ami.id, group['name'])
+        logger.info("Spun up %s instances of %s from %s into group %s",
+                    size_as_maximum_int_or_none(desired_size), hostclass, ami.id, group['name'])
 
         return {
             "hostclass": hostclass,
@@ -485,7 +462,7 @@ class DiscoAWS(object):
                 for instance in instances:
                     self.vpc.delete_instance_routes(instance)
                     if use_autoscaling:
-                        self.autoscale.terminate(instance.id)
+                        self.discogroup.terminate(instance.id)
                 if not use_autoscaling:
                     throttled_call(self.connection.terminate_instances, instance_ids)
                 logger.info("terminated: %s", instances)
@@ -631,8 +608,7 @@ class DiscoAWS(object):
         .. warning:: This currently does a dirty shutdown, no attempt is made to preserve logs.
         """
         for hostclass in hostclasses:
-            self.autoscale.delete_groups(hostclass=hostclass, force=True)
-            self.elastigroup.delete_groups(hostclass=hostclass)
+            self.discogroup.delete_groups(hostclass=hostclass, force=True)
 
             self.elb.delete_elb(hostclass)
 

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -43,7 +43,7 @@ class DiscoDeploy(object):
         :param aws a DiscoAWS instance to use
         :param test_aws DiscoAWS instance for integration tests. may be different environment than "aws" param
         :param bake a DiscoBake instance to use
-        :param autoscale a DiscoAutoscale instance to use
+        :param discogroup a DiscoGroup instance to use
         :param elb a DiscoELB instance to use
         :param pipeline_definition a list of dicts containing hostname, deployable and other pipeline values
         :param allow_any_hostclass do not restrict to hostclasses in the pipeline definition

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -625,9 +625,9 @@ class DiscoDeploy(object):
         # If there is an already existing ASG, use its sizing. Otherwise, use the pipeline's sizing or a
         # reasonable default.
         if old_group:
-            desired_size = old_group.get('desired_capacity') or old_group['capacity']['target']
-            max_size = old_group.get('max_size') or old_group['capacity']['maximum']
-            min_size = old_group.get('min_size') or old_group['capacity']['minimum']
+            desired_size = old_group['desired_capacity']
+            max_size = old_group['max_size']
+            min_size = old_group['min_size']
         else:
             # The 'or 1' is because some people set their desired size to 0 in their pipeline.
             desired_size = int(size_as_maximum_int_or_none(

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -35,7 +35,7 @@ class DiscoDeploy(object):
     '''DiscoDeploy takes care of testing, promoting and deploying the latests AMIs'''
 
     # pylint: disable=too-many-arguments
-    def __init__(self, aws, test_aws, bake, autoscale, elb, pipeline_definition,
+    def __init__(self, aws, test_aws, bake, discogroup, elb, pipeline_definition,
                  ami=None, hostclass=None, allow_any_hostclass=False, config=None):
         '''
         Constructor for DiscoDeploy
@@ -56,7 +56,7 @@ class DiscoDeploy(object):
         self._disco_aws = aws
         self._test_aws = test_aws
         self._disco_bake = bake
-        self._disco_autoscale = autoscale
+        self._disco_group = discogroup
         self._disco_elb = elb
         self._all_stage_amis = None
         self._hostclasses = self._get_hostclasses_from_pipeline_definition(pipeline_definition)
@@ -288,7 +288,7 @@ class DiscoDeploy(object):
             # Create scheduled actions on the ASG.
             self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
         else:
-            self._disco_autoscale.delete_groups(hostclass=hostclass, force=True)
+            self._disco_group.delete_groups(hostclass=hostclass, force=True)
 
         if ami_test_failed:
             raise RuntimeError("Smoke test for non-deploy Hostclass %s AMI %s failed", hostclass, ami.id)
@@ -303,7 +303,7 @@ class DiscoDeploy(object):
         :return: List of instances
         '''
         hostclass = DiscoBake.ami_hostclass(self._disco_bake.connection.get_image(new_ami_id))
-        all_ids = [inst.instance_id for inst in self._disco_autoscale.get_instances(hostclass=hostclass)]
+        all_ids = [inst['instance_id'] for inst in self._disco_group.get_instances(hostclass=hostclass)]
         all_instances = self._disco_aws.instances(instance_ids=all_ids)
         return [inst for inst in all_instances
                 if (inst.image_id != new_ami_id) or
@@ -319,7 +319,7 @@ class DiscoDeploy(object):
         :return: List of instances
         '''
         hostclass = DiscoBake.ami_hostclass(self._disco_bake.connection.get_image(new_ami_id))
-        all_ids = [inst.instance_id for inst in self._disco_autoscale.get_instances(hostclass=hostclass)]
+        all_ids = [inst['instance_id'] for inst in self._disco_group.get_instances(hostclass=hostclass)]
         all_instances = self._disco_aws.instances(filters={"image_id": [new_ami_id]}, instance_ids=all_ids)
         return [inst for inst in all_instances
                 if not launch_time or get_instance_launch_time(inst) >= launch_time]
@@ -484,32 +484,32 @@ class DiscoDeploy(object):
             logger.exception("Spinning up a new autoscaling group failed")
 
             # Try to grab the new group. If it exists, we get a group. If not, we get a `None`.
-            new_group = self._disco_autoscale.get_existing_group(hostclass=hostclass,
-                                                                 throw_on_two_groups=False)
+            new_group = self._disco_group.get_existing_group(hostclass=hostclass,
+                                                             throw_on_two_groups=False)
 
             # It's possible that we might have ended up grabbing the old group instead of the new group we
             # just made. So check that the group we just got isn't the same as the group that already exists.
-            old_group_is_not_new_group = new_group and old_group and old_group.name != new_group.name
+            old_group_is_not_new_group = new_group and old_group and old_group['name'] != new_group['name']
 
             # If we did get a new group and its not the same as the old group (or no old group exists), let's
             # tear down the new testing group and its ELB if it exists.
             if new_group and (not old_group or old_group_is_not_new_group):
                 logger.info('Destroying the testing group')
                 # Destroy the testing ASG
-                self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                self._disco_group.delete_groups(group_name=new_group['name'], force=True)
                 if uses_elb:
                     # Destroy the testing ELB
                     self._disco_elb.delete_elb(hostclass, testing=True)
             raise RuntimeError("Spinning up a new autoscaling group failed")
 
-        new_group = self._disco_autoscale.get_existing_group(hostclass=hostclass, throw_on_two_groups=False)
+        new_group = self._disco_group.get_existing_group(hostclass=hostclass, throw_on_two_groups=False)
 
-        if old_group and old_group.name == new_group.name:
+        if old_group and old_group['name'] == new_group['name']:
             raise RuntimeError("Old group and new group should not be the same.")
 
         try:
             smoke_tests = self.wait_for_smoketests(ami.id, new_group_config["desired_size"] or 1,
-                                                   group_name=new_group.name)
+                                                   group_name=new_group['name'])
             if smoke_tests and run_tests:
                 # If smoke tests passed and we should run integration tests, run them
                 integration_tests = self.run_integration_tests(ami, wait_for_elb=uses_elb)
@@ -520,16 +520,16 @@ class DiscoDeploy(object):
                 # If testing passed, mark AMI as tested
                 self._promote_ami(ami, "tested")
                 # Get list of instances in group
-                group_instance_ids = [inst.instance_id for inst in
-                                      self._disco_autoscale.get_instances(group_name=new_group.name)]
+                group_instance_ids = [inst['instance_id'] for inst in
+                                      self._disco_group.get_instances(group_name=new_group['name'])]
                 if not group_instance_ids:
-                    raise RuntimeError("Could not find any instances in new group %s", new_group.name)
+                    raise RuntimeError("Could not find any instances in new group %s", new_group['name'])
                 group_instances = self._disco_aws.instances(instance_ids=group_instance_ids)
                 # If we are actually deploying and are able to leave testing mode
                 if deployable and self._set_testing_mode(hostclass, group_instances, False):
-                    logger.info("Successfully left testing mode for group %s", new_group.name)
+                    logger.info("Successfully left testing mode for group %s", new_group['name'])
                     # Update ASG to exit testing mode and attach to the normal ELB if applicable.
-                    self._disco_aws.spinup([new_group_config], group_name=new_group.name)
+                    self._disco_aws.spinup([new_group_config], group_name=new_group['name'])
 
                     if uses_elb:
                         try:
@@ -539,22 +539,22 @@ class DiscoDeploy(object):
                         except TimeoutError:
                             logger.exception("Waiting for health of instances attached to ELB timed out")
                             # Destroy the testing ASG
-                            self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                            self._disco_group.delete_groups(group_name=new_group['name'], force=True)
                             if uses_elb:
                                 # Destroy the testing ELB
                                 self._disco_elb.delete_elb(hostclass, testing=True)
                             raise
 
                     # Create scheduled actions on the new ASG now that we will likely keep it.
-                    self._create_scaling_schedule(pipeline_dict, group_name=new_group.name)
+                    self._create_scaling_schedule(pipeline_dict, group_name=new_group['name'])
 
                     # we can destroy the old group
                     if old_group:
                         # Empty the original ASG for connection draining purposes
-                        self._disco_autoscale.scaledown_groups(group_name=old_group.name, wait=True,
-                                                               noerror=True)
+                        self._disco_group.scaledown_groups(group_name=old_group['name'], wait=True,
+                                                           noerror=True)
                         # Destroy the original ASG
-                        self._disco_autoscale.delete_groups(group_name=old_group.name, force=True)
+                        self._disco_group.delete_groups(group_name=old_group['name'], force=True)
                     if uses_elb:
                         # Destroy the testing ELB
                         self._disco_elb.delete_elb(hostclass, testing=True)
@@ -562,14 +562,14 @@ class DiscoDeploy(object):
                 else:
                     # Otherwise, we need to keep the old group and destroy the new one
                     if deployable:
-                        reason = "Unable to exit testing mode for group {}".format(new_group.name)
+                        reason = "Unable to exit testing mode for group {}".format(new_group['name'])
                     else:
                         reason = "{} is not deployable".format(hostclass)
 
                     logger.error("%s, destroying new autoscaling group", reason)
 
                     # Destroy the testing ASG
-                    self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+                    self._disco_group.delete_groups(group_name=new_group['name'], force=True)
 
                     if uses_elb:
                         # Destroy the testing ELB
@@ -578,7 +578,7 @@ class DiscoDeploy(object):
                     # If the hostclass isn't deployable and an old group exists, we should update the old
                     # group so that new instances from that old group are spun up with the newly tested AMI.
                     if not deployable and old_group:
-                        self._disco_aws.spinup([new_group_config], group_name=old_group.name)
+                        self._disco_aws.spinup([new_group_config], group_name=old_group['name'])
 
                     # If deployable was False, return True, otherwise we're here because testing mode broke,
                     # so return False
@@ -591,7 +591,7 @@ class DiscoDeploy(object):
             logger.exception("Failed to run integration test")
 
         # Destroy the testing ASG
-        self._disco_autoscale.delete_groups(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups(group_name=new_group['name'], force=True)
         if uses_elb:
             # Destroy the testing ELB
             self._disco_elb.delete_elb(hostclass, testing=True)
@@ -625,9 +625,9 @@ class DiscoDeploy(object):
         # If there is an already existing ASG, use its sizing. Otherwise, use the pipeline's sizing or a
         # reasonable default.
         if old_group:
-            desired_size = old_group.desired_capacity
-            max_size = old_group.max_size
-            min_size = old_group.min_size
+            desired_size = old_group.get('desired_capacity') or old_group['capacity']['target']
+            max_size = old_group.get('max_size') or old_group['capacity']['maximum']
+            min_size = old_group.get('min_size') or old_group['capacity']['minimum']
         else:
             # The 'or 1' is because some people set their desired size to 0 in their pipeline.
             desired_size = int(size_as_maximum_int_or_none(
@@ -742,7 +742,7 @@ class DiscoDeploy(object):
         logger.info("testing %s %s", ami.id, ami.name)
         hostclass = DiscoBake.ami_hostclass(ami)
         pipeline_hostclass_dict = self._hostclasses.get(hostclass)
-        group = self._disco_autoscale.get_existing_group(hostclass)
+        group = self._disco_group.get_existing_group(hostclass)
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 
@@ -812,7 +812,7 @@ class DiscoDeploy(object):
         if not pipeline_dict:
             raise RuntimeError("Pipeline Dictionary is not defined.")
 
-        group = self._disco_autoscale.get_existing_group(hostclass)
+        group = self._disco_group.get_existing_group(hostclass)
         deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
 

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -9,20 +9,22 @@ from base64 import b64encode
 import requests
 import boto3
 
+from .base_group import BaseGroup
 from .exceptions import TooManyAutoscalingGroups
 
 logger = logging.getLogger(__name__)
 
-SPOTINST_API = 'https://api.spotinst.io/aws/ec2/group/'
+SPOTINST_API = 'https://api.spotinst.io/aws/ec2/group'
 
 
-class DiscoElastigroup(object):
+class DiscoElastigroup(BaseGroup):
     """Class orchestrating elastigroups"""
 
     def __init__(self, environment_name, session=None, account_id=None):
         self.environment_name = environment_name
         self._session = session
         self._account_id = account_id
+        super(DiscoElastigroup, self).__init__()
 
     @property
     def token(self):
@@ -61,6 +63,17 @@ class DiscoElastigroup(object):
             self._account_id = boto3.client('sts').get_caller_identity().get('Account')
         return self._account_id
 
+    def _spotinst_call(self, path='/', data=None, method='get'):
+        if method not in ['get', 'post', 'put', 'delete']:
+            raise Exception('Method {} is not supported'.format(method))
+        method_to_call = getattr(self.session, method)
+        response = method_to_call(SPOTINST_API + path, data=json.dumps(data) if data else None)
+        if response.status_code == 200:
+            return response
+        else:
+            # raise Exception('Error communicating with Spotinst API: {}'.format(path))
+            logger.info('Error communicating with Spotinst API: %s', path)
+
     def _get_new_groupname(self, hostclass):
         """Returns a new elastigroup name when given a hostclass"""
         return self.environment_name + '_' + hostclass + "_" + str(int(time.time()))
@@ -76,13 +89,13 @@ class DiscoElastigroup(object):
         """Returns the hostclass when given an elastigroup name"""
         return group_name.split('_')[1]
 
-    def _get_existing_groups(self, hostclass=None, group_name=None):
+    def get_existing_groups(self, hostclass=None, group_name=None):
         """
         Returns all elastigroups for a given hostclass or group name, sorted by most recent creation. If no
         elastigroup can be found, returns an empty list.
         """
         try:
-            groups = self.session.get(SPOTINST_API).json()['response']['items']
+            groups = self._spotinst_call().json()['response']['items']
             groups = [group for group in groups if group['name'].startswith(self.environment_name)]
         except KeyError:
             return []
@@ -103,7 +116,7 @@ class DiscoElastigroup(object):
         elastigroup will be returned. If there are more than two elastigroups, this method will
         always throw an exception.
         """
-        groups = self._get_existing_groups(hostclass=hostclass, group_name=group_name)
+        groups = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
         if not groups:
             return None
         elif len(groups) == 1 or (len(groups) == 2 and not throw_on_two_groups):
@@ -113,11 +126,26 @@ class DiscoElastigroup(object):
 
     def _get_group_instances(self, group_id):
         """Returns list of instance ids in a group"""
-        return self.session.get(SPOTINST_API + group_id + '/status').json()['response']['items']
+        return self._spotinst_call(path='/' + group_id + '/status').json()['response']['items']
+
+    def get_instances(self, hostclass=None, group_name=None):
+        """Returns elastigroup instances for hostclass in the current environment"""
+        all_groups = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
+        groups_id_name = {
+            group['id']: group['name'] for group in all_groups
+        }
+        instances = []
+        for group_id in groups_id_name:
+            group_instances = self._get_group_instances(group_id)
+            for instance in group_instances:
+                instance.update({'instance_id': instance['instanceId'],
+                                 'group_name': groups_id_name[group_id]})
+            instances += group_instances
+        return instances
 
     def list_groups(self):
         """Returns list of objects for display purposes for all groups"""
-        groups = self._get_existing_groups()
+        groups = self.get_existing_groups()
         return [{'name': group['name'],
                  'image_id': group['compute']['launchSpecification']['imageId'],
                  'group_cnt': len(self._get_group_instances(group['id'])),
@@ -218,6 +246,12 @@ class DiscoElastigroup(object):
             zones[subnet['AvailabilityZone']] = subnet['SubnetId']
         return zones
 
+    def wait_for_instance_id(self, group_name):
+        """Wait for instance id(s) of an elastigroup to become available"""
+        while not all([instance['instance_id'] for instance in self.get_instances(group_name=group_name)]):
+            logger.info('Waiting for instance id(s) of %s to become available', group_name)
+            time.sleep(10)
+
     def update_group(self, hostclass, desired_size=None, min_size=None, max_size=None, instance_type=None,
                      load_balancers=None, subnets=None, security_groups=None, instance_monitoring=None,
                      ebs_optimized=None, image_id=None, key_name=None, associate_public_ip_address=None,
@@ -250,53 +284,63 @@ class DiscoElastigroup(object):
             block_device_mappings=block_device_mappings,
             group_name=group_name or self._get_new_groupname(hostclass)
         )
-        group = self.get_existing_group(hostclass)
-        if group:
+        group = self.get_existing_group(hostclass, group_name)
+        if group and not create_if_exists:
             group_id = group['id']
             # Remove fields not allowed in update
             del group_config['group']['capacity']['unit']
             del group_config['group']['compute']['product']
-            self.session.put(SPOTINST_API + group_id, data=json.dumps(group_config))
+            self._spotinst_call(path='/' + group_id, data=group_config, method='put')
             return {'name': group['name']}
         else:
-            new_group = self.session.post(SPOTINST_API, data=json.dumps(group_config)).json()
-            return {'name': new_group['response']['items'][0]['name']}
+            new_group = self._spotinst_call(data=group_config, method='post').json()
+            new_group_name = new_group['response']['items'][0]['name']
+            return {'name': new_group_name}
 
     def _delete_group(self, group_id, force=False):
         """Delete an elastigroup by group id"""
         # We need argument `force` to match method in autoscale
         # pylint: disable=unused-argument
-        self.session.delete(SPOTINST_API + group_id)
+        self._spotinst_call(path='/' + group_id, method='delete')
 
     def delete_groups(self, hostclass=None, group_name=None, force=False):
         """Delete all elastigroups based on hostclass"""
         # We need argument `force` to match method in autoscale
         # pylint: disable=unused-argument
-        groups = self._get_existing_groups(hostclass=hostclass, group_name=group_name)
+        groups = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
         for group in groups:
             logger.info("Deleting group %s", group['name'])
             self._delete_group(group_id=group['id'])
 
+    def scaledown_groups(self, hostclass=None, group_name=None, wait=False, noerror=False):
+        """
+        Scales down number of instances in a hostclass's elastigroup, or the given elastigroup, to zero.
+        If wait is true, this function will block until all instances are terminated, or it will raise
+        a WaiterError if this process times out, unless noerror is True.
+
+        Returns true if the elastigroups were successfully scaled down, False otherwise.
+        """
+        groups = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
+        for group in groups:
+            group_update = {
+                "group": {
+                    "capacity": {
+                        "target": 0,
+                        "minimum": 0,
+                        "maximum": 0
+                    }
+                }
+            }
+            logger.info("Scaling down group %s", group['name'])
+            self._spotinst_call(path='/' + group['id'], data=group_update, method='put')
+
+            if wait:
+                self.wait_instance_termination(group_name=group_name, group=group, noerror=noerror)
+
     def _get_group_id_from_instance_id(self, instance_id):
-        groups = self._get_existing_groups()
+        groups = self.get_existing_groups()
         for group in groups:
             group_id = group['id']
             instance_ids = [instance['instanceId'] for instance in self._get_group_instances(group_id)]
             if instance_id in instance_ids:
                 return group_id
-
-    def terminate(self, instance_id, decrement_capacity=True):
-        """
-        Terminate instances using the spotinst API.
-
-        Detaching instances from elastigroup will delete them.
-
-        When decrement_capacity is True this allows us to avoid
-        autoscaling immediately replacing a terminated instance.
-        """
-        data = {"instancesToDetach": [instance_id],
-                "shouldTerminateInstances": True,
-                "shouldDecrementTargetCapacity": decrement_capacity,
-                "drainingTimeout": 1}
-        group_id = self._get_group_id_from_instance_id(instance_id)
-        self.session.put(SPOTINST_API + group_id + '/detachInstances', data=json.dumps(data))

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -71,7 +71,6 @@ class DiscoElastigroup(BaseGroup):
         if response.status_code == 200:
             return response
         else:
-            # return response
             raise SpotinstException('Error communicating with Spotinst API: {}'.format(path))
 
     def _get_new_groupname(self, hostclass):
@@ -97,6 +96,9 @@ class DiscoElastigroup(BaseGroup):
         try:
             groups = self._spotinst_call().json()['response']['items']
             groups = [group for group in groups if group['name'].startswith(self.environment_name)]
+        except SpotinstException as e:
+            logger.info('Unable to get existing Spotinst groups: %s', e.message)
+            return []
         except KeyError:
             return []
         if group_name:

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -71,7 +71,8 @@ class DiscoElastigroup(BaseGroup):
         if response.status_code == 200:
             return response
         else:
-            raise SpotinstException('Error communicating with Spotinst API: {}'.format(path))
+            raise SpotinstException('Spotinst API error. Path: {} - Status code: {} - Reason: {}'.
+                                    format(path, response.status_code, response.reason))
 
     def _get_new_groupname(self, hostclass):
         """Returns a new elastigroup name when given a hostclass"""
@@ -96,8 +97,8 @@ class DiscoElastigroup(BaseGroup):
         try:
             groups = self._spotinst_call().json()['response']['items']
             groups = [group for group in groups if group['name'].startswith(self.environment_name)]
-        except SpotinstException as e:
-            logger.info('Unable to get existing Spotinst groups: %s', e.message)
+        except SpotinstException as err:
+            logger.info('Unable to get existing Spotinst groups: %s', err.message)
             return []
         except KeyError:
             return []

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -97,9 +97,8 @@ class DiscoElastigroup(BaseGroup):
         try:
             groups = self._spotinst_call().json()['response']['items']
             groups = [group for group in groups if group['name'].startswith(self.environment_name)]
-        except SpotinstException as err:
-            logger.info('Unable to get existing Spotinst groups: %s', err.message)
-            return []
+        except SpotinstException:
+            raise
         except KeyError:
             return []
         if group_name:
@@ -350,8 +349,8 @@ class DiscoElastigroup(BaseGroup):
             logger.info("Scaling down group %s", group['name'])
             try:
                 self._spotinst_call(path='/' + group['id'], data=group_update, method='put')
-            except SpotinstException as err:
-                logger.info('Unable to scaledown Spotinst group(s): %s', err.message)
+            except SpotinstException:
+                raise
 
             if wait:
                 self.wait_instance_termination(group_name=group_name, group=group, noerror=noerror)

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -300,6 +300,8 @@ class DiscoElastigroup(BaseGroup):
         else:
             new_group = self._spotinst_call(data=group_config, method='post').json()
             new_group_name = new_group['response']['items'][0]['name']
+
+            self.wait_for_instance_id(new_group_name)
             return {'name': new_group_name}
 
     def _delete_group(self, group_id):

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -10,7 +10,7 @@ import requests
 import boto3
 
 from .base_group import BaseGroup
-from .exceptions import TooManyAutoscalingGroups
+from .exceptions import TooManyAutoscalingGroups, SpotinstException
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +71,8 @@ class DiscoElastigroup(BaseGroup):
         if response.status_code == 200:
             return response
         else:
-            # raise Exception('Error communicating with Spotinst API: {}'.format(path))
-            logger.info('Error communicating with Spotinst API: %s', path)
+            # return response
+            raise SpotinstException('Error communicating with Spotinst API: {}'.format(path))
 
     def _get_new_groupname(self, hostclass):
         """Returns a new elastigroup name when given a hostclass"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -97,11 +97,8 @@ class DiscoElastigroup(BaseGroup):
         Returns all elastigroups for a given hostclass or group name, sorted by most recent creation. If no
         elastigroup can be found, returns an empty list.
         """
-        try:
-            groups = self._spotinst_call().json()['response']['items']
-            groups = [group for group in groups if group['name'].startswith(self.environment_name)]
-        except KeyError:
-            return []
+        groups = self._spotinst_call().json()['response'].get('items', [])
+        groups = [group for group in groups if group['name'].startswith(self.environment_name)]
 
         if group_name:
             groups = [group for group in groups if group['name'] == group_name]

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -70,7 +70,7 @@ class DiscoElastigroup(BaseGroup):
         try:
             response = method_to_call(SPOTINST_API + path, data=json.dumps(data) if data else None)
         except Exception as err:
-            raise SpotinstException('Error while communicating with SpotInst API', err)
+            raise SpotinstException('Error while communicating with SpotInst API: {}'.format(err))
         if response.status_code == 200:
             return response
         else:

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -35,9 +35,9 @@ class DiscoGroup(BaseGroup):
             logger.info('Unable to get existing Spotinst group: %s', err.message)
             spot_group = []
         if asg_group and spot_group:
-            return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
+            return sorted([asg_group, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
         elif asg_group:
-            return asg_group.__dict__
+            return asg_group
         elif spot_group:
             return spot_group
         else:
@@ -45,7 +45,7 @@ class DiscoGroup(BaseGroup):
 
     def get_existing_groups(self, hostclass=None, group_name=None):
         asg_groups = self.autoscale.get_existing_groups()
-        asg_groups = [group.__dict__ for group in asg_groups]
+        asg_groups = [group for group in asg_groups]
         try:
             spot_groups = self.elastigroup.get_existing_groups()
         except SpotinstException as err:
@@ -67,7 +67,7 @@ class DiscoGroup(BaseGroup):
 
     def get_instances(self, hostclass=None, group_name=None):
         asg_instances = self.autoscale.get_instances(hostclass=hostclass, group_name=group_name)
-        asg_instances = [instance.__dict__ for instance in asg_instances]
+        asg_instances = [instance for instance in asg_instances]
         try:
             spot_instances = self.elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
         except SpotinstException as err:
@@ -106,6 +106,7 @@ class DiscoGroup(BaseGroup):
         When decrement_capacity is True this allows us to avoid
         autoscaling immediately replacing a terminated instance.
         """
+        # todo check if instance belongs to spotinst or ASG and decrement the correct group
         self.autoscale.terminate(instance_id, decrement_capacity)
 
     def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -1,0 +1,69 @@
+"""Contains DiscoGroup class that is above all other group classes used"""
+import logging
+
+from .base_group import BaseGroup
+from .disco_autoscale import DiscoAutoscale
+from .disco_elastigroup import DiscoElastigroup
+
+logger = logging.getLogger(__name__)
+
+
+class DiscoGroup(BaseGroup):
+    """Implementation of DiscoGroup regardless of the type of group"""
+
+    def __init__(self, environment_name):
+        """Implementation of BaseGroup in AWS"""
+        self.environment_name = environment_name
+        self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
+        self._elastigroup = DiscoElastigroup(environment_name=self.environment_name)
+        super(DiscoGroup, self).__init__()
+
+    def get_existing_group(self, hostclass=None, group_name=None, throw_on_two_groups=True):
+        asg_group = self._autoscale.get_existing_group(
+            hostclass=hostclass,
+            group_name=group_name,
+            throw_on_two_groups=throw_on_two_groups
+        )
+        spot_group = self._elastigroup.get_existing_group(
+            hostclass=hostclass,
+            group_name=group_name,
+            throw_on_two_groups=throw_on_two_groups
+        )
+        if asg_group and spot_group:
+            return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
+        elif asg_group:
+            return asg_group.__dict__
+        elif spot_group:
+            return spot_group
+        else:
+            logger.info('No group found')
+
+    def get_existing_groups(self, hostclass=None, group_name=None):
+        asg_groups = self._autoscale.get_existing_groups()
+        asg_groups = [group.__dict__ for group in asg_groups]
+        spot_groups = self._elastigroup.get_existing_groups()
+        return asg_groups + spot_groups
+
+    def get_instances(self, hostclass=None, group_name=None):
+        asg_instances = self._autoscale.get_instances(hostclass=hostclass, group_name=group_name)
+        asg_instances = [instance.__dict__ for instance in asg_instances]
+        spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
+        return asg_instances + spot_instances
+
+    def delete_groups(self, hostclass=None, group_name=None, force=False):
+        self._autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+        self._elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+
+    def scaledown_groups(self, hostclass=None, group_name=None, wait=False, noerror=False):
+        self._autoscale.scaledown_groups(
+            hostclass=hostclass,
+            group_name=group_name,
+            wait=wait,
+            noerror=noerror
+        )
+        self._elastigroup.scaledown_groups(
+            hostclass=hostclass,
+            group_name=group_name,
+            wait=wait,
+            noerror=noerror
+        )

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -45,7 +45,6 @@ class DiscoGroup(BaseGroup):
 
     def get_existing_groups(self, hostclass=None, group_name=None):
         asg_groups = self.autoscale.get_existing_groups()
-        asg_groups = [group for group in asg_groups]
         try:
             spot_groups = self.elastigroup.get_existing_groups()
         except SpotinstException as err:
@@ -67,7 +66,6 @@ class DiscoGroup(BaseGroup):
 
     def get_instances(self, hostclass=None, group_name=None):
         asg_instances = self.autoscale.get_instances(hostclass=hostclass, group_name=group_name)
-        asg_instances = [instance for instance in asg_instances]
         try:
             spot_instances = self.elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
         except SpotinstException as err:

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -4,6 +4,7 @@ import logging
 from .base_group import BaseGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
+from .exceptions import SpotinstException
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +25,15 @@ class DiscoGroup(BaseGroup):
             group_name=group_name,
             throw_on_two_groups=throw_on_two_groups
         )
-        spot_group = self._elastigroup.get_existing_group(
-            hostclass=hostclass,
-            group_name=group_name,
-            throw_on_two_groups=throw_on_two_groups
-        )
+        try:
+            spot_group = self._elastigroup.get_existing_group(
+                hostclass=hostclass,
+                group_name=group_name,
+                throw_on_two_groups=throw_on_two_groups
+            )
+        except SpotinstException as err:
+            logger.info('Unable to get existing Spotinst group: %s', err.message)
+            spot_group = []
         if asg_group and spot_group:
             return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
         elif asg_group:
@@ -41,18 +46,41 @@ class DiscoGroup(BaseGroup):
     def get_existing_groups(self, hostclass=None, group_name=None):
         asg_groups = self._autoscale.get_existing_groups()
         asg_groups = [group.__dict__ for group in asg_groups]
-        spot_groups = self._elastigroup.get_existing_groups()
+        try:
+            spot_groups = self._elastigroup.get_existing_groups()
+        except SpotinstException as err:
+            logger.info('Unable to get existing Spotinst groups: %s', err.message)
+            spot_groups = []
         return asg_groups + spot_groups
+
+    def list_groups(self):
+        """Returns list of objects for display purposes for all groups"""
+        asg_groups = self._autoscale.list_groups()
+        try:
+            spot_groups = self._elastigroup.list_groups()
+        except SpotinstException as err:
+            logger.info('Unable to list Spotinst groups: %s', err.message)
+            spot_groups = []
+        groups = asg_groups + spot_groups
+        groups.sort(key=lambda grp: grp['name'])
+        return groups
 
     def get_instances(self, hostclass=None, group_name=None):
         asg_instances = self._autoscale.get_instances(hostclass=hostclass, group_name=group_name)
         asg_instances = [instance.__dict__ for instance in asg_instances]
-        spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
+        try:
+            spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
+        except SpotinstException as err:
+            logger.info('Unable to get Spotinst group instances: %s', err.message)
+            spot_instances = []
         return asg_instances + spot_instances
 
     def delete_groups(self, hostclass=None, group_name=None, force=False):
         self._autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
-        self._elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+        try:
+            self._elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+        except SpotinstException as err:
+            logger.info('Unable to delete Spotinst groups: %s', err.message)
 
     def scaledown_groups(self, hostclass=None, group_name=None, wait=False, noerror=False):
         self._autoscale.scaledown_groups(
@@ -61,9 +89,12 @@ class DiscoGroup(BaseGroup):
             wait=wait,
             noerror=noerror
         )
-        self._elastigroup.scaledown_groups(
-            hostclass=hostclass,
-            group_name=group_name,
-            wait=wait,
-            noerror=noerror
-        )
+        try:
+            self._elastigroup.scaledown_groups(
+                hostclass=hostclass,
+                group_name=group_name,
+                wait=wait,
+                noerror=noerror
+            )
+        except SpotinstException as err:
+            logger.info('Unable to scaledown Spotinst groups: %s', err.message)

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -4,6 +4,7 @@ import logging
 from .base_group import BaseGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
+from .exceptions import SpotinstException
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +25,14 @@ class DiscoGroup(BaseGroup):
             group_name=group_name,
             throw_on_two_groups=throw_on_two_groups
         )
-        spot_group = self._elastigroup.get_existing_group(
-            hostclass=hostclass,
-            group_name=group_name,
-            throw_on_two_groups=throw_on_two_groups
-        )
+        try:
+            spot_group = self._elastigroup.get_existing_group(
+                hostclass=hostclass,
+                group_name=group_name,
+                throw_on_two_groups=throw_on_two_groups
+            )
+        except SpotinstException as e:
+            logger.info('Unable to get existing groups: %s', e.error)
         if asg_group and spot_group:
             return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
         elif asg_group:

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -25,14 +25,11 @@ class DiscoGroup(BaseGroup):
             group_name=group_name,
             throw_on_two_groups=throw_on_two_groups
         )
-        try:
-            spot_group = self._elastigroup.get_existing_group(
-                hostclass=hostclass,
-                group_name=group_name,
-                throw_on_two_groups=throw_on_two_groups
-            )
-        except SpotinstException as e:
-            logger.info('Unable to get existing groups: %s', e.error)
+        spot_group = self._elastigroup.get_existing_group(
+            hostclass=hostclass,
+            group_name=group_name,
+            throw_on_two_groups=throw_on_two_groups
+        )
         if asg_group and spot_group:
             return sorted([asg_group.__dict__, spot_group], key=lambda grp: grp['name'], reverse=True)[0]
         elif asg_group:

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -4,7 +4,6 @@ import logging
 from .base_group import BaseGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
-from .exceptions import SpotinstException
 
 logger = logging.getLogger(__name__)
 

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -15,18 +15,18 @@ class DiscoGroup(BaseGroup):
     def __init__(self, environment_name):
         """Implementation of BaseGroup in AWS"""
         self.environment_name = environment_name
-        self._autoscale = DiscoAutoscale(environment_name=self.environment_name)
-        self._elastigroup = DiscoElastigroup(environment_name=self.environment_name)
+        self.autoscale = DiscoAutoscale(environment_name=self.environment_name)
+        self.elastigroup = DiscoElastigroup(environment_name=self.environment_name)
         super(DiscoGroup, self).__init__()
 
     def get_existing_group(self, hostclass=None, group_name=None, throw_on_two_groups=True):
-        asg_group = self._autoscale.get_existing_group(
+        asg_group = self.autoscale.get_existing_group(
             hostclass=hostclass,
             group_name=group_name,
             throw_on_two_groups=throw_on_two_groups
         )
         try:
-            spot_group = self._elastigroup.get_existing_group(
+            spot_group = self.elastigroup.get_existing_group(
                 hostclass=hostclass,
                 group_name=group_name,
                 throw_on_two_groups=throw_on_two_groups
@@ -44,10 +44,10 @@ class DiscoGroup(BaseGroup):
             logger.info('No group found')
 
     def get_existing_groups(self, hostclass=None, group_name=None):
-        asg_groups = self._autoscale.get_existing_groups()
+        asg_groups = self.autoscale.get_existing_groups()
         asg_groups = [group.__dict__ for group in asg_groups]
         try:
-            spot_groups = self._elastigroup.get_existing_groups()
+            spot_groups = self.elastigroup.get_existing_groups()
         except SpotinstException as err:
             logger.info('Unable to get existing Spotinst groups: %s', err.message)
             spot_groups = []
@@ -55,9 +55,9 @@ class DiscoGroup(BaseGroup):
 
     def list_groups(self):
         """Returns list of objects for display purposes for all groups"""
-        asg_groups = self._autoscale.list_groups()
+        asg_groups = self.autoscale.list_groups()
         try:
-            spot_groups = self._elastigroup.list_groups()
+            spot_groups = self.elastigroup.list_groups()
         except SpotinstException as err:
             logger.info('Unable to list Spotinst groups: %s', err.message)
             spot_groups = []
@@ -66,31 +66,31 @@ class DiscoGroup(BaseGroup):
         return groups
 
     def get_instances(self, hostclass=None, group_name=None):
-        asg_instances = self._autoscale.get_instances(hostclass=hostclass, group_name=group_name)
+        asg_instances = self.autoscale.get_instances(hostclass=hostclass, group_name=group_name)
         asg_instances = [instance.__dict__ for instance in asg_instances]
         try:
-            spot_instances = self._elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
+            spot_instances = self.elastigroup.get_instances(hostclass=hostclass, group_name=group_name)
         except SpotinstException as err:
             logger.info('Unable to get Spotinst group instances: %s', err.message)
             spot_instances = []
         return asg_instances + spot_instances
 
     def delete_groups(self, hostclass=None, group_name=None, force=False):
-        self._autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+        self.autoscale.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
         try:
-            self._elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
+            self.elastigroup.delete_groups(hostclass=hostclass, group_name=group_name, force=force)
         except SpotinstException as err:
             logger.info('Unable to delete Spotinst groups: %s', err.message)
 
     def scaledown_groups(self, hostclass=None, group_name=None, wait=False, noerror=False):
-        self._autoscale.scaledown_groups(
+        self.autoscale.scaledown_groups(
             hostclass=hostclass,
             group_name=group_name,
             wait=wait,
             noerror=noerror
         )
         try:
-            self._elastigroup.scaledown_groups(
+            self.elastigroup.scaledown_groups(
                 hostclass=hostclass,
                 group_name=group_name,
                 wait=wait,
@@ -98,3 +98,94 @@ class DiscoGroup(BaseGroup):
             )
         except SpotinstException as err:
             logger.info('Unable to scaledown Spotinst groups: %s', err.message)
+
+    def terminate(self, instance_id, decrement_capacity=True):
+        """
+        Terminates an instance using the autoscaling API.
+
+        When decrement_capacity is True this allows us to avoid
+        autoscaling immediately replacing a terminated instance.
+        """
+        self.autoscale.terminate(instance_id, decrement_capacity)
+
+    def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):
+        """Deletes all recurring scheduled actions for a hostclass"""
+
+        self.autoscale.delete_all_recurring_group_actions(hostclass, group_name)
+
+    def create_recurring_group_action(self, recurrance, min_size=None, desired_capacity=None, max_size=None,
+                                      hostclass=None, group_name=None):
+        """Creates a recurring scheduled action for a hostclass"""
+        self.autoscale.create_recurring_group_action(recurrance, min_size, desired_capacity, max_size,
+                                                     hostclass,
+                                                     group_name)
+
+    def update_elb(self, elb_names, hostclass=None, group_name=None):
+        """Updates an existing autoscaling group to use a different set of load balancers"""
+
+        self.autoscale.update_elb(elb_names, hostclass, group_name)
+
+    def get_launch_config(self, hostclass=None, group_name=None):
+        """Create new launchconfig group name"""
+
+        return self.autoscale.get_launch_config(hostclass, group_name)
+
+    # pylint: disable=R0913, R0914
+    def update_group(self, hostclass, desired_size=None, min_size=None, max_size=None, instance_type=None,
+                     load_balancers=None, subnets=None, security_groups=None, instance_monitoring=None,
+                     ebs_optimized=None, image_id=None, key_name=None, associate_public_ip_address=None,
+                     user_data=None, tags=None, instance_profile_name=None, block_device_mappings=None,
+                     group_name=None, create_if_exists=False, termination_policies=None, spotinst=False):
+        """
+        Create a new autoscaling group or update an existing one
+        """
+        service = self._service(spotinst)
+
+        return service.update_group(hostclass, desired_size, min_size, max_size, instance_type,
+                                    load_balancers, subnets, security_groups, instance_monitoring,
+                                    ebs_optimized, image_id, key_name,
+                                    associate_public_ip_address, user_data, tags, instance_profile_name,
+                                    block_device_mappings, group_name, create_if_exists, termination_policies,
+                                    spotinst)
+
+    def clean_configs(self):
+        """Delete unused Launch Configurations in current environment"""
+        self.autoscale.clean_configs()
+
+    def get_configs(self, names=None):
+        """Returns Launch Configurations in current environment"""
+        return self.autoscale.get_configs(names)
+
+    def delete_config(self, config_name):
+        """Delete a specific Launch Configuration"""
+        self.autoscale.delete_config(config_name)
+
+    def list_policies(self, group_name=None, policy_types=None, policy_names=None):
+        """Returns all autoscaling policies"""
+        return self.autoscale.list_policies(group_name, policy_types, policy_names)
+
+    def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,
+                      min_adjustment_magnitude=None, scaling_adjustment=None, cooldown=600,
+                      metric_aggregation_type=None, step_adjustments=None, estimated_instance_warmup=None):
+        """
+        Creates a new autoscaling policy, or updates an existing one if the autoscaling group name and
+        policy name already exist. Handles the logic of constructing the correct autoscaling policy request,
+        because not all parameters are required.
+        """
+        self.autoscale.create_policy(group_name, policy_name, policy_type, adjustment_type,
+                                     min_adjustment_magnitude, scaling_adjustment, cooldown,
+                                     metric_aggregation_type, step_adjustments, estimated_instance_warmup)
+
+    def delete_policy(self, policy_name, group_name):
+        """Deletes an autoscaling policy"""
+        self.autoscale.delete_policy(policy_name, group_name)
+
+    def _service(self, spotinst):
+        """
+        User either autoscale or elastigroup service, depending on
+        hostclass configuration in disco_aws.ini (e.g. spotinst=True)
+        """
+        if spotinst:
+            return self.elastigroup
+        else:
+            return self.autoscale

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -24,7 +24,7 @@ from .disco_config import normalize_path
 from .disco_alarm import DiscoAlarm
 from .disco_alarm_config import DiscoAlarmsConfig
 from .disco_autoscale import DiscoAutoscale
-from .disco_elastigroup import DiscoElastigroup
+from .disco_group import DiscoGroup
 from .disco_config import read_config
 from .disco_constants import CREDENTIAL_BUCKET_TEMPLATE, NETWORKS, VPC_CONFIG_FILE
 from .disco_elasticache import DiscoElastiCache
@@ -578,9 +578,9 @@ class DiscoVPC(object):
     def _destroy_instances(self):
         """ Find all instances in vpc and terminate them """
         autoscale = DiscoAutoscale(environment_name=self.environment_name)
-        autoscale.delete_groups(force=True)
-        elastigroup = DiscoElastigroup(environment_name=self.environment_name)
-        elastigroup.delete_groups()
+        # autoscale.delete_groups(force=True)
+        discogroup = DiscoGroup(environment_name=self.environment_name)
+        discogroup.delete_groups()
         reservations = throttled_call(self.boto3_ec2.describe_instances,
                                       Filters=self.vpc_filters())['Reservations']
         instances = [i['InstanceId']

--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -23,7 +23,6 @@ from .disco_config import normalize_path
 
 from .disco_alarm import DiscoAlarm
 from .disco_alarm_config import DiscoAlarmsConfig
-from .disco_autoscale import DiscoAutoscale
 from .disco_group import DiscoGroup
 from .disco_config import read_config
 from .disco_constants import CREDENTIAL_BUCKET_TEMPLATE, NETWORKS, VPC_CONFIG_FILE
@@ -577,8 +576,6 @@ class DiscoVPC(object):
 
     def _destroy_instances(self):
         """ Find all instances in vpc and terminate them """
-        autoscale = DiscoAutoscale(environment_name=self.environment_name)
-        # autoscale.delete_groups(force=True)
         discogroup = DiscoGroup(environment_name=self.environment_name)
         discogroup.delete_groups()
         reservations = throttled_call(self.boto3_ec2.describe_instances,
@@ -597,7 +594,7 @@ class DiscoVPC(object):
         waiter = self.boto3_ec2.get_waiter('instance_terminated')
         waiter.wait(InstanceIds=instances,
                     Filters=create_filters({'instance-state-name': ['terminated']}))
-        autoscale.clean_configs()
+        discogroup.clean_configs()
 
         logger.debug("waiting for instance shutdown scripts")
         time.sleep(60)  # see http://copperegg.com/hooking-into-the-aws-shutdown-flow/

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -180,3 +180,8 @@ class RouteCreationError(RuntimeError):
 class TooManyAutoscalingGroups(RuntimeError):
     """Error trying to create more than the expected number of autoscaling groups"""
     pass
+
+
+class SpotinstException(Exception):
+    """Generic Spotinst exception"""
+    pass

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.8"
+__version__ = "1.3.10"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.9"
+__version__ = "1.3.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -10,3 +10,4 @@ coverage<4
 # Additional libraries
 moto>=0.4.30
 six>=1.7.3
+requests-mock>=1.3.0,<2

--- a/test/unit/test_autoscale.py
+++ b/test/unit/test_autoscale.py
@@ -20,6 +20,14 @@ class DiscoAutoscaleTests(TestCase):
         self.environment_name = "us-moon-1"
         self._autoscale = DiscoAutoscale("us-moon-1", self._mock_connection, self._mock_boto3_connection)
 
+    def mock_response(self, results):
+        '''Creates a mock paginated boto response wrapping the given results'''
+        result = MagicMock()
+        result.__iter__.return_value = results
+        result.next_token = None
+
+        return result
+
     def mock_group(self, hostclass, name=None, launch_config_name=None):
         '''Creates a mock autoscaling group for hostclass'''
         group_mock = MagicMock()
@@ -50,35 +58,38 @@ class DiscoAutoscaleTests(TestCase):
 
     def test_get_group_scale_down(self):
         """Test scaling down to 0 hosts"""
-        self._autoscale._get_group_generator = MagicMock(return_value=[self.mock_group("mhcdummy")])
+        self._mock_connection.get_all_groups.return_value = self.mock_response([self.mock_group("mhcdummy")])
+
         group = self._autoscale.get_group(
             hostclass="mhcdummy",
             launch_config="launch_config-X", vpc_zone_id="zone-X",
             min_size=0, max_size=1, desired_size=0)
-        self.assertEqual(group.min_size, 0)
-        self.assertEqual(group.desired_capacity, 0)
+        self.assertEqual(group['min_size'], 0)
+        self.assertEqual(group['desired_capacity'], 0)
 
     def test_get_group_no_scale(self):
         """Test getting a group and not scaling it"""
-        self._autoscale._get_group_generator = MagicMock(return_value=[self.mock_group("mhcdummy")])
+        self._mock_connection.get_all_groups.return_value = self.mock_response([self.mock_group("mhcdummy")])
+
         group = self._autoscale.get_group(
             hostclass="mhcdummy",
             launch_config="launch_config-X", vpc_zone_id="zone-X",
             min_size=None, max_size=None, desired_size=None)
-        self.assertEqual(group.min_size, 1)
-        self.assertEqual(group.max_size, 1)
-        self.assertEqual(group.desired_capacity, 1)
+        self.assertEqual(group['min_size'], 1)
+        self.assertEqual(group['max_size'], 1)
+        self.assertEqual(group['desired_capacity'], 1)
 
     def test_get_group_scale_up(self):
         """Test getting a group and scaling it up"""
-        self._autoscale._get_group_generator = MagicMock(return_value=[self.mock_group("mhcdummy")])
+        self._mock_connection.get_all_groups.return_value = self.mock_response([self.mock_group("mhcdummy")])
+
         group = self._autoscale.get_group(
             hostclass="mhcdummy",
             launch_config="launch_config-X", vpc_zone_id="zone-X",
             min_size=None, max_size=5, desired_size=4)
-        self.assertEqual(group.min_size, 1)
-        self.assertEqual(group.max_size, 5)
-        self.assertEqual(group.desired_capacity, 4)
+        self.assertEqual(group['min_size'], 1)
+        self.assertEqual(group['max_size'], 5)
+        self.assertEqual(group['desired_capacity'], 4)
 
     def test_get_group_add_policies(self):
         """Test getting a group automatically adds scaling policies"""
@@ -92,7 +103,7 @@ class DiscoAutoscaleTests(TestCase):
 
         self._mock_boto3_connection.put_scaling_policy.assert_has_calls([
             call(
-                AutoScalingGroupName=group.name,
+                AutoScalingGroupName=group['name'],
                 PolicyName='up',
                 PolicyType='SimpleScaling',
                 AdjustmentType='PercentChangeInCapacity',
@@ -101,7 +112,7 @@ class DiscoAutoscaleTests(TestCase):
                 MinAdjustmentMagnitude=1
             ),
             call(
-                AutoScalingGroupName=group.name,
+                AutoScalingGroupName=group['name'],
                 PolicyName='down',
                 PolicyType='SimpleScaling',
                 AdjustmentType='PercentChangeInCapacity',
@@ -113,7 +124,7 @@ class DiscoAutoscaleTests(TestCase):
 
     def test_get_group_attach_elb(self):
         """Test getting a group and attaching an elb"""
-        self._autoscale._get_group_generator = MagicMock(return_value=[self.mock_group("mhcdummy")])
+        self._mock_connection.get_all_groups.return_value = self.mock_response([self.mock_group("mhcdummy")])
 
         group = self._autoscale.get_group(
             hostclass="mhcdummy",
@@ -121,7 +132,7 @@ class DiscoAutoscaleTests(TestCase):
             load_balancers=['fake_elb'])
 
         self._mock_boto3_connection.attach_load_balancers.assert_called_with(
-            AutoScalingGroupName=group.name,
+            AutoScalingGroupName=group['name'],
             LoadBalancerNames=['fake_elb'])
 
     @patch("boto.ec2.autoscale.group.AutoScalingGroup")
@@ -362,7 +373,8 @@ class DiscoAutoscaleTests(TestCase):
         '''update_elb will add new lb and remove old when there is no overlap in sets'''
         grp = self.mock_group("mhcfoo")
         grp.load_balancers = ["old_lb1", "old_lb2"]
-        self._autoscale.get_existing_group = MagicMock(return_value=grp)
+        self._mock_connection.get_all_groups.return_value = self.mock_response([grp])
+
         ret = self._autoscale.update_elb(["new_lb"], hostclass="mhcfoo")
         self.assertEqual(ret, (set(["new_lb"]), set(["old_lb1", "old_lb2"])))
 
@@ -370,7 +382,8 @@ class DiscoAutoscaleTests(TestCase):
         '''update_elb will not churn an lb that is in both the existing config and new config'''
         grp = self.mock_group("mhcfoo")
         grp.load_balancers = ["old_lb", "both_lb"]
-        self._autoscale.get_existing_group = MagicMock(return_value=grp)
+        self._mock_connection.get_all_groups.return_value = self.mock_response([grp])
+
         ret = self._autoscale.update_elb(["new_lb", "both_lb"], hostclass="mhcfoo")
         self.assertEqual(ret, (set(["new_lb"]), set(["old_lb"])))
 
@@ -378,7 +391,8 @@ class DiscoAutoscaleTests(TestCase):
         '''update_elb will remove all load balancers when none are configured'''
         grp = self.mock_group("mhcfoo")
         grp.load_balancers = ["old_lb1", "old_lb2"]
-        self._autoscale.get_existing_group = MagicMock(return_value=grp)
+        self._mock_connection.get_all_groups.return_value = self.mock_response([grp])
+
         ret = self._autoscale.update_elb([], hostclass="mhcfoo")
         self.assertEqual(ret, (set([]), set(["old_lb1", "old_lb2"])))
 
@@ -386,66 +400,72 @@ class DiscoAutoscaleTests(TestCase):
         '''group_generator correctly filters based on the environment'''
         good_groups = [self.mock_group("mhcfoo"), self.mock_group("mhcbar"), self.mock_group("mhcfoobar")]
         bad_groups = [self.mock_group("mhcnoncomformist", name="foo-mhcnoncomformist-123141231123")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_groups + bad_groups
-        self._mock_connection.get_all_groups.return_value = groups
+        self._mock_connection.get_all_groups.return_value = self.mock_response(good_groups + bad_groups)
 
-        self.assertEqual(set(self._autoscale.get_existing_groups()), set(good_groups))
+        good_group_ids = [group.name for group in good_groups]
+        actual_group_ids = [group['name'] for group in self._autoscale.get_existing_groups()]
+
+        self.assertEqual(sorted(good_group_ids), sorted(actual_group_ids))
 
     def test_gg_filters_hostclass_correctly(self):
         '''get_existing_groups correctly filters based on the hostclass'''
         good_groups = [self.mock_group("mhcneedle")]
         bad_groups = [self.mock_group("mhcfoo"), self.mock_group("mhcbar"), self.mock_group("mhcfoobar")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_groups + bad_groups
-        self._mock_connection.get_all_groups.return_value = groups
+        self._mock_connection.get_all_groups.return_value = self.mock_response(good_groups + bad_groups)
 
-        self.assertEqual(set(self._autoscale.get_existing_groups(hostclass="mhcneedle")), set(good_groups))
+        good_group_ids = [group.name for group in good_groups]
+
+        actual_groups = self._autoscale.get_existing_groups(hostclass="mhcneedle")
+        actual_group_ids = [group['name'] for group in actual_groups]
+
+        self.assertEqual(sorted(good_group_ids), sorted(actual_group_ids))
 
     def test_ig_filters_env_correctly(self):
         '''inst_generator correctly filters based on the environment'''
         good_insts = [self.mock_inst("mhcfoo"), self.mock_inst("mhcbar"), self.mock_inst("mhcfoobar")]
         bad_insts = [self.mock_inst("mhcnoncomformist", group_name="foo_mhcnoncomformist_123141231123")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_insts + bad_insts
-        self._mock_connection.get_all_autoscaling_instances.return_value = groups
+        mock_response = self.mock_response(good_insts + bad_insts)
+        self._mock_connection.get_all_autoscaling_instances.return_value = mock_response
 
-        self.assertEqual(self._autoscale.get_instances(), good_insts)
+        good_inst_ids = [inst.instance_id for inst in good_insts]
+        actual_inst_ids = [inst['instance_id'] for inst in self._autoscale.get_instances()]
+
+        self.assertEqual(sorted(actual_inst_ids), sorted(good_inst_ids))
 
     def test_ig_filters_hostclass_correctly(self):
         '''inst_generator correctly filters based on the hostclass'''
         good_insts = [self.mock_inst("mhcneedle")]
         bad_insts = [self.mock_inst("mhcfoo"), self.mock_inst("mhcbar"), self.mock_inst("mhcfoobar")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_insts + bad_insts
-        self._mock_connection.get_all_autoscaling_instances.return_value = groups
+        mock_response = self.mock_response(good_insts + bad_insts)
+        self._mock_connection.get_all_autoscaling_instances.return_value = mock_response
 
-        self.assertEqual(self._autoscale.get_instances(hostclass="mhcneedle"), good_insts)
+        good_inst_ids = [inst.instance_id for inst in good_insts]
+
+        actual_instances = self._autoscale.get_instances(hostclass="mhcneedle")
+        actual_inst_ids = [inst['instance_id'] for inst in actual_instances]
+
+        self.assertEqual(sorted(actual_inst_ids), sorted(good_inst_ids))
 
     def test_ig_filters_groupname_correctly(self):
         '''inst_generator correctly filters based on the group name'''
         good_insts = [self.mock_inst("mhcneedle")]
         bad_insts = [self.mock_inst("mhcfoo"), self.mock_inst("mhcbar"), self.mock_inst("mhcfoobar")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_insts + bad_insts
-        self._mock_connection.get_all_autoscaling_instances.return_value = groups
+        mock_response = self.mock_response(good_insts + bad_insts)
+        self._mock_connection.get_all_autoscaling_instances.return_value = mock_response
 
-        self.assertEqual(self._autoscale.get_instances(group_name=good_insts[0].group_name),
-                         good_insts)
+        good_inst_ids = [inst.instance_id for inst in good_insts]
+
+        actual_instances = self._autoscale.get_instances(group_name=good_insts[0].group_name)
+        actual_inst_ids = [inst['instance_id'] for inst in actual_instances]
+
+        self.assertEqual(sorted(actual_inst_ids), sorted(good_inst_ids))
 
     def test_cg_filters_env_correctly(self):
         '''config_generator correctly filters based on the environment'''
         good_lgs = [self.mock_lg("mhcfoo"), self.mock_lg("mhcbar"), self.mock_lg("mhcfoobar")]
         bad_lgs = [self.mock_lg("mhcnoncomformist", name="foo_mhcnoncomformist_123141231123")]
-        groups = MagicMock()
-        groups.next_token = None
-        groups.__iter__.return_value = good_lgs + bad_lgs
-        self._mock_connection.get_all_launch_configurations.return_value = groups
+        mock_response = self.mock_response(good_lgs + bad_lgs)
+        self._mock_connection.get_all_launch_configurations.return_value = mock_response
 
         self.assertEqual(self._autoscale.get_configs(), good_lgs)
 
@@ -457,7 +477,7 @@ class DiscoAutoscaleTests(TestCase):
             self.mock_group("mhcfoo", launch_config_name="")
         ]
 
-        self._autoscale.get_existing_groups = MagicMock(return_value=mock_groups)
+        self._mock_connection.get_all_groups.return_value = self.mock_response(mock_groups)
         self._autoscale.get_configs = MagicMock()
 
         self._autoscale.get_launch_configs()

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -49,9 +49,9 @@ class DiscoAWSTests(TestCase):
     @patch_disco_aws
     def test_create_scaling_schedule_only_desired(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
-        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
+        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, discogroup=MagicMock())
         aws.create_scaling_schedule("1", "2@1 0 * * *:3@6 0 * * *", "5", hostclass="mhcboo")
-        aws.autoscale.assert_has_calls([
+        aws.discogroup.assert_has_calls([
             call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
             call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=None, desired_capacity=2, max_size=None),
@@ -62,23 +62,23 @@ class DiscoAWSTests(TestCase):
     @patch_disco_aws
     def test_create_scaling_schedule_no_sched(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
-        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
+        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, discogroup=MagicMock())
         aws.create_scaling_schedule("1", "2", "5", hostclass="mhcboo")
-        aws.autoscale.assert_has_calls([
+        aws.discogroup.assert_has_calls([
             call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None)
         ])
 
     @patch_disco_aws
     def test_create_scaling_schedule_overlapping(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
-        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
+        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, discogroup=MagicMock())
         aws.create_scaling_schedule(
             "1@1 0 * * *:2@6 0 * * *",
             "2@1 0 * * *:3@6 0 * * *",
             "6@1 0 * * *:9@6 0 * * *",
             hostclass="mhcboo"
         )
-        aws.autoscale.assert_has_calls([
+        aws.discogroup.assert_has_calls([
             call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
             call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=1, desired_capacity=2, max_size=6),
@@ -89,14 +89,14 @@ class DiscoAWSTests(TestCase):
     @patch_disco_aws
     def test_create_scaling_schedule_mixed(self, mock_config, **kwargs):
         """test create_scaling_schedule with only desired schedule"""
-        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, autoscale=MagicMock())
+        aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, discogroup=MagicMock())
         aws.create_scaling_schedule(
             "1@1 0 * * *:2@7 0 * * *",
             "2@1 0 * * *:3@6 0 * * *",
             "6@2 0 * * *:9@6 0 * * *",
             hostclass="mhcboo"
         )
-        aws.autoscale.assert_has_calls([
+        aws.discogroup.assert_has_calls([
             call.delete_all_recurring_group_actions(hostclass='mhcboo', group_name=None),
             call.create_recurring_group_action('1 0 * * *', hostclass='mhcboo', group_name=None,
                                                min_size=1, desired_capacity=2, max_size=None),
@@ -136,15 +136,15 @@ class DiscoAWSTests(TestCase):
         self.assertEqual(metadata["hostclass"], "mhcunittest")
         self.assertFalse(metadata["no_destroy"])
         self.assertTrue(metadata["chaos"])
-        _lc = aws.autoscale.get_configs()[0]
+        _lc = aws.discogroup.get_configs()[0]
         self.assertRegexpMatches(_lc.name, r".*_mhcunittest_[0-9]*")
         self.assertEqual(_lc.image_id, mock_ami.id)
-        self.assertTrue(aws.autoscale.get_existing_group(hostclass="mhcunittest"))
-        _ag = aws.autoscale.get_existing_groups()[0]
-        self.assertRegexpMatches(_ag.name, r"unittestenv_mhcunittest_[0-9]*")
-        self.assertEqual(_ag.min_size, 1)
-        self.assertEqual(_ag.max_size, 1)
-        self.assertEqual(_ag.desired_capacity, 1)
+        self.assertTrue(aws.discogroup.get_existing_group(hostclass="mhcunittest"))
+        _ag = aws.discogroup.get_existing_groups()[0]
+        self.assertRegexpMatches(_ag['name'], r"unittestenv_mhcunittest_[0-9]*")
+        self.assertEqual(_ag['min_size'], 1)
+        self.assertEqual(_ag['max_size'], 1)
+        self.assertEqual(_ag['desired_capacity'], 1)
 
     @patch_disco_aws
     def test_provision_hc_simple_with_no_chaos(self, mock_config, **kwargs):
@@ -168,15 +168,15 @@ class DiscoAWSTests(TestCase):
         self.assertEqual(metadata["hostclass"], "mhcunittest")
         self.assertFalse(metadata["no_destroy"])
         self.assertFalse(metadata["chaos"])
-        _lc = aws.autoscale.get_configs()[0]
+        _lc = aws.discogroup.get_configs()[0]
         self.assertRegexpMatches(_lc.name, r".*_mhcunittest_[0-9]*")
         self.assertEqual(_lc.image_id, mock_ami.id)
-        self.assertTrue(aws.autoscale.get_existing_group(hostclass="mhcunittest"))
-        _ag = aws.autoscale.get_existing_groups()[0]
-        self.assertRegexpMatches(_ag.name, r"unittestenv_mhcunittest_[0-9]*")
-        self.assertEqual(_ag.min_size, 1)
-        self.assertEqual(_ag.max_size, 1)
-        self.assertEqual(_ag.desired_capacity, 1)
+        self.assertTrue(aws.discogroup.get_existing_group(hostclass="mhcunittest"))
+        _ag = aws.discogroup.get_existing_groups()[0]
+        self.assertRegexpMatches(_ag['name'], r"unittestenv_mhcunittest_[0-9]*")
+        self.assertEqual(_ag['min_size'], 1)
+        self.assertEqual(_ag['max_size'], 1)
+        self.assertEqual(_ag['desired_capacity'], 1)
 
     @patch_disco_aws
     def test_provision_hc_with_chaos_using_config(self, mock_config, **kwargs):
@@ -202,15 +202,15 @@ class DiscoAWSTests(TestCase):
         self.assertEqual(metadata["hostclass"], "mhcunittest")
         self.assertFalse(metadata["no_destroy"])
         self.assertTrue(metadata["chaos"])
-        _lc = aws.autoscale.get_configs()[0]
+        _lc = aws.discogroup.get_configs()[0]
         self.assertRegexpMatches(_lc.name, r".*_mhcunittest_[0-9]*")
         self.assertEqual(_lc.image_id, mock_ami.id)
-        self.assertTrue(aws.autoscale.get_existing_group(hostclass="mhcunittest"))
-        _ag = aws.autoscale.get_existing_groups()[0]
-        self.assertRegexpMatches(_ag.name, r"unittestenv_mhcunittest_[0-9]*")
-        self.assertEqual(_ag.min_size, 1)
-        self.assertEqual(_ag.max_size, 1)
-        self.assertEqual(_ag.desired_capacity, 1)
+        self.assertTrue(aws.discogroup.get_existing_group(hostclass="mhcunittest"))
+        _ag = aws.discogroup.get_existing_groups()[0]
+        self.assertRegexpMatches(_ag['name'], r"unittestenv_mhcunittest_[0-9]*")
+        self.assertEqual(_ag['min_size'], 1)
+        self.assertEqual(_ag['max_size'], 1)
+        self.assertEqual(_ag['desired_capacity'], 1)
 
     @patch_disco_aws
     def test_provision_hostclass_schedules(self, mock_config, **kwargs):
@@ -231,10 +231,10 @@ class DiscoAWSTests(TestCase):
                                       desired_size="2@1 0 * * *:3@6 0 * * *",
                                       max_size="6@1 0 * * *:9@6 0 * * *")
 
-        _ag = aws.autoscale.get_existing_groups()[0]
-        self.assertEqual(_ag.min_size, 1)  # minimum of listed sizes
-        self.assertEqual(_ag.desired_capacity, 3)  # maximum of listed sizes
-        self.assertEqual(_ag.max_size, 9)  # maximum of listed sizes
+        _ag = aws.discogroup.get_existing_groups()[0]
+        self.assertEqual(_ag['min_size'], 1)  # minimum of listed sizes
+        self.assertEqual(_ag['desired_capacity'], 3)  # maximum of listed sizes
+        self.assertEqual(_ag['max_size'], 9)  # maximum of listed sizes
 
     @patch_disco_aws
     def test_provision_hostclass_sched_some_none(self, mock_config, **kwargs):
@@ -254,11 +254,11 @@ class DiscoAWSTests(TestCase):
                                       min_size="",
                                       desired_size="2@1 0 * * *:3@6 0 * * *", max_size="")
 
-        _ag = aws.autoscale.get_existing_groups()[0]
-        print("({0}, {1}, {2})".format(_ag.min_size, _ag.desired_capacity, _ag.max_size))
-        self.assertEqual(_ag.min_size, 0)  # minimum of listed sizes
-        self.assertEqual(_ag.desired_capacity, 3)  # maximum of listed sizes
-        self.assertEqual(_ag.max_size, 3)  # maximum of listed sizes
+        _ag = aws.discogroup.get_existing_groups()[0]
+        print("({0}, {1}, {2})".format(_ag['min_size'], _ag['desired_capacity'], _ag['max_size']))
+        self.assertEqual(_ag['min_size'], 0)  # minimum of listed sizes
+        self.assertEqual(_ag['desired_capacity'], 3)  # maximum of listed sizes
+        self.assertEqual(_ag['max_size'], 3)  # maximum of listed sizes
 
     @patch_disco_aws
     def test_provision_hostclass_sched_all_none(self, mock_config, **kwargs):
@@ -277,11 +277,11 @@ class DiscoAWSTests(TestCase):
                                       hostclass="mhcunittest", owner="unittestuser",
                                       min_size="", desired_size="", max_size="")
 
-        _ag0 = aws.autoscale.get_existing_groups()[0]
+        _ag0 = aws.discogroup.get_existing_groups()[0]
 
-        self.assertEqual(_ag0.min_size, 0)  # minimum of listed sizes
-        self.assertEqual(_ag0.desired_capacity, 0)  # maximum of listed sizes
-        self.assertEqual(_ag0.max_size, 0)  # maximum of listed sizes
+        self.assertEqual(_ag0['min_size'], 0)  # minimum of listed sizes
+        self.assertEqual(_ag0['desired_capacity'], 0)  # maximum of listed sizes
+        self.assertEqual(_ag0['max_size'], 0)  # maximum of listed sizes
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -292,11 +292,11 @@ class DiscoAWSTests(TestCase):
                                       hostclass="mhcunittest", owner="unittestuser",
                                       min_size="3", desired_size="6", max_size="9")
 
-        _ag1 = aws.autoscale.get_existing_groups()[0]
+        _ag1 = aws.discogroup.get_existing_groups()[0]
 
-        self.assertEqual(_ag1.min_size, 3)  # minimum of listed sizes
-        self.assertEqual(_ag1.desired_capacity, 6)  # maximum of listed sizes
-        self.assertEqual(_ag1.max_size, 9)  # maximum of listed sizes
+        self.assertEqual(_ag1['min_size'], 3)  # minimum of listed sizes
+        self.assertEqual(_ag1['desired_capacity'], 6)  # maximum of listed sizes
+        self.assertEqual(_ag1['max_size'], 9)  # maximum of listed sizes
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -307,11 +307,11 @@ class DiscoAWSTests(TestCase):
                                       hostclass="mhcunittest", owner="unittestuser",
                                       min_size="", desired_size="", max_size="")
 
-        _ag2 = aws.autoscale.get_existing_groups()[0]
+        _ag2 = aws.discogroup.get_existing_groups()[0]
 
-        self.assertEqual(_ag2.min_size, 3)  # minimum of listed sizes
-        self.assertEqual(_ag2.desired_capacity, 6)  # maximum of listed sizes
-        self.assertEqual(_ag2.max_size, 9)  # maximum of listed sizes
+        self.assertEqual(_ag2['min_size'], 3)  # minimum of listed sizes
+        self.assertEqual(_ag2['desired_capacity'], 6)  # maximum of listed sizes
+        self.assertEqual(_ag2['max_size'], 9)  # maximum of listed sizes
 
     @patch_disco_aws
     def test_update_elb_delete(self, mock_config, **kwargs):

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 import boto.ec2.instance
 from mock import MagicMock, create_autospec, call, ANY
 
-from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoAutoscale, DiscoBake, DiscoELB
+from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoGroup, DiscoBake, DiscoELB
 from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN, DEPLOYMENT_STRATEGY_CLASSIC
 from disco_aws_automation.exceptions import (
     TimeoutError,
@@ -154,18 +154,18 @@ class DiscoDeployTests(TestCase):
 
     def setUp(self):
         self._environment_name = "foo"
-        self._disco_autoscale = create_autospec(DiscoAutoscale, instance=True)
+        self._disco_group = create_autospec(DiscoGroup, instance=True)
         self._disco_elb = create_autospec(DiscoELB, instance=True)
         self._disco_aws = create_autospec(DiscoAWS, instance=True)
         self._test_aws = self._disco_aws
         self._existing_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.return_value = self._existing_group
+        self._disco_group.get_existing_group.return_value = self._existing_group.__dict__
         self._disco_bake = MagicMock()
         self._disco_bake.promote_ami = MagicMock()
         self._disco_bake.ami_stages = MagicMock(return_value=['untested', 'failed', 'tested'])
         self._disco_bake.get_ami_creation_time = DiscoBake.extract_ami_creation_time_from_ami_name
         self._ci_deploy = DiscoDeploy(
-            self._disco_aws, self._test_aws, self._disco_bake, self._disco_autoscale, self._disco_elb,
+            self._disco_aws, self._test_aws, self._disco_bake, self._disco_group, self._disco_elb,
             pipeline_definition=MOCK_PIPELINE_DEFINITION,
             ami=None, hostclass=None, allow_any_hostclass=False,
             config=get_mock_config(MOCK_CONFIG_DEFINITON))
@@ -480,9 +480,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -495,7 +495,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 2, 'max_size': 2,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_nodeploy_works(self):
@@ -506,9 +506,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcbluegreennondeployable")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -517,7 +517,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1, 'max_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreennondeployable'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_not_called()
 
     def test_bg_deploy_works_with_original_group(self):
@@ -529,9 +529,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False))
@@ -544,7 +544,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=old_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=old_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_bad_new_group_name(self):
@@ -553,7 +553,7 @@ class DiscoDeployTests(TestCase):
         ami.name = "mhcbluegreen 2"
         ami.id = "ami-12345678"
         group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.return_value = group
+        self._disco_group.get_existing_group.return_value = group.__dict__
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
 
     def test_bg_deploy_with_failing_tests(self):
@@ -565,14 +565,14 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=False)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_called_once_with(ami, 'failed')
         self._disco_aws.spinup.assert_called_once_with([{
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_when_unable_to_test(self):
@@ -584,14 +584,14 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(side_effect=IntegrationTestError)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_aws.spinup.assert_called_once_with([{
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
         self._disco_bake.promote_ami.assert_not_called()
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_failing_elbs(self):
@@ -604,10 +604,10 @@ class DiscoDeployTests(TestCase):
         self._disco_elb.wait_for_instance_health_state.side_effect = TimeoutError
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
         instance_ids = [inst.instance_id for inst in instances]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertRaises(TimeoutError, self._ci_deploy.test_ami, ami, dry_run=False)
@@ -622,7 +622,7 @@ class DiscoDeployTests(TestCase):
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
                     'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_deploy_with_bad_testing_mode(self):
@@ -634,9 +634,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcbluegreen", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
@@ -646,7 +646,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
     def test_bg_with_hc_not_in_pl_and_no_group(self):
@@ -657,9 +657,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -671,7 +671,7 @@ class DiscoDeployTests(TestCase):
             [{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 1,
               'integration_test': None, 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
               'hostclass': 'mhcfoo'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_hc_not_in_pl_and_group(self):
         '''Blue/green is non-deployable if hostclass is not in pipeline, dies, and updates existing group'''
@@ -682,9 +682,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhcfoo", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhcfoo")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (1, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -699,7 +699,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no', 'min_size': 2,
                     'integration_test': None, 'desired_size': 3, 'max_size': 4, 'smoke_test': 'no',
                     'hostclass': 'mhcfoo'}], group_name=old_group.name)])
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with old group'''
@@ -711,7 +711,7 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.spinup.side_effect = Exception
         old_group = self.mock_group("mhcbluegreen")
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -719,7 +719,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_og(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no old group'''
@@ -730,7 +730,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
         new_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -738,7 +738,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
+        self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
 
     def test_bg_with_spinup_error_and_no_groups(self):
         '''Blue/green can handle an an exception when spinning up the new ASG with no groups'''
@@ -748,7 +748,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
-        self._disco_autoscale.get_existing_group.side_effect = [None, None]
+        self._disco_group.get_existing_group.side_effect = [None, None]
         self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -756,7 +756,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 2,
             'integration_test': "blue_green_service", 'desired_size': 2, 'max_size': 2, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_with_error_and_og_and_no_ng(self):
         '''Blue/green can handle an an exception when spinning up the new ASG w/ old group and no new group'''
@@ -767,7 +767,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = Exception
         old_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, None]
         self.assertRaises(Exception, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -775,7 +775,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_with_too_many_autoscaling_groups(self):
         '''Blue/green can handle too many autoscaling groups error when spinning up a new ASG'''
@@ -786,7 +786,7 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         self._disco_aws.spinup.side_effect = TooManyAutoscalingGroups
         old_group = self.mock_group("mhcbluegreen")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, None]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, None]
         self.assertRaises(TooManyAutoscalingGroups, self._ci_deploy.test_ami, ami, dry_run=False)
         self._disco_bake.promote_ami.assert_not_called()
         self._disco_elb.wait_for_instance_health_state.assert_not_called()
@@ -794,7 +794,7 @@ class DiscoDeployTests(TestCase):
             'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
             'integration_test': "blue_green_service", 'desired_size': 1, 'max_size': 1, 'smoke_test': 'no',
             'hostclass': 'mhcbluegreen'}], testing=True, create_if_exists=True)
-        self._disco_autoscale.delete_groups.assert_not_called()
+        self._disco_group.delete_groups.assert_not_called()
 
     def test_bg_timed_autoscaling(self):
         '''Blue/green can handle creating timed autoscaling actions'''
@@ -804,9 +804,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhctimedautoscale")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -837,9 +837,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         old_group = self.mock_group("mhctimedautoscale", min_size=2, max_size=4, desired_size=3)
         new_group = self.mock_group("mhctimedautoscale")
-        self._disco_autoscale.get_existing_group.side_effect = [old_group, new_group]
+        self._disco_group.get_existing_group.side_effect = [old_group.__dict__, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -869,9 +869,9 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
         self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
         new_group = self.mock_group("mhctimedautoscalenodeploy")
-        self._disco_autoscale.get_existing_group.side_effect = [None, new_group]
+        self._disco_group.get_existing_group.side_effect = [None, new_group.__dict__]
         instances = [self.mock_instance(), self.mock_instance(), self.mock_instance()]
-        self._disco_autoscale.get_instances.return_value = instances
+        self._disco_group.get_instances.return_value = [_i.__dict__ for _i in instances]
         self._disco_aws.instances.return_value = instances
         self._disco_aws.remotecmd.return_value = (0, "")
         self.assertIsNone(self._ci_deploy.test_ami(ami,
@@ -949,7 +949,7 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.spinup.assert_called_once_with(
             [{'ami': 'ami-12345678', 'sequence': 1, 'min_size': 0, 'desired_size': 1,
               'smoke_test': 'no', 'max_size': 1, 'hostclass': 'mhcnewscarey'}], testing=True)
-        self._disco_autoscale.delete_groups.assert_called_once_with(hostclass='mhcnewscarey', force=True)
+        self._disco_group.delete_groups.assert_called_once_with(hostclass='mhcnewscarey', force=True)
 
     def test_nodeploy_ami_failure(self):
         '''No deploy instances are failed and not promoted when smoketest fails'''
@@ -1324,7 +1324,7 @@ class DiscoDeployTests(TestCase):
                 ami,
                 pipeline_dict=None,
                 dry_run=False,
-                old_group=self._existing_group
+                old_group=self._existing_group.__dict__
             )
         ])
 
@@ -1338,11 +1338,11 @@ class DiscoDeployTests(TestCase):
     def test_update_ami_not_in_autoscale_deploy(self):
         '''Test update_ami handling new deployable hostclass'''
         ami = self.mock_ami("mhcsmokey 1")
-        self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
+        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_tested_ami = MagicMock(return_value=True)
         self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
                                                      deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcsmokey")
+        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcsmokey")
         self._ci_deploy.handle_tested_ami.assert_called_with(
             ami,
             pipeline_dict={
@@ -1360,12 +1360,12 @@ class DiscoDeployTests(TestCase):
         '''Test update_ami handling new non-deployable hostclass'''
         ami = self.mock_ami("mhcscarey 1")
         self._ci_deploy.is_deployable = MagicMock(return_value=False)
-        self._ci_deploy._disco_autoscale.get_existing_group = MagicMock(return_value=None)
+        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
         self._ci_deploy.handle_nodeploy_ami = MagicMock(return_value=True)
         self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
                                                      deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
         self.assertEqual(self._ci_deploy.is_deployable.call_count, 1)
-        self._ci_deploy._disco_autoscale.get_existing_group.assert_called_with("mhcscarey")
+        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcscarey")
         self._ci_deploy.handle_nodeploy_ami.assert_called_with(
             ami,
             pipeline_dict={

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -2,7 +2,6 @@
 Tests of disco_elastigroup
 """
 import random
-import json
 
 from unittest import TestCase
 
@@ -58,6 +57,7 @@ class DiscoElastigroupTests(TestCase):
     def test_delete_groups_bad_hostclass(self):
         """Verifies elastigroup not deleted for bad hostclass"""
         self.elastigroup._delete_group = MagicMock()
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.delete_groups(hostclass="mhcfoo")
 
@@ -66,6 +66,7 @@ class DiscoElastigroupTests(TestCase):
     def test_delete_groups_bad_groupname(self):
         """Verifies elastigroup not deleted for bad group name"""
         self.elastigroup._delete_group = MagicMock()
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.delete_groups(group_name='moon_mhcfoo_12345678')
 
@@ -76,7 +77,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group = self.mock_elastigroup(hostclass='mhcfoo')
 
         self.elastigroup._delete_group = MagicMock()
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group])
 
         self.elastigroup.delete_groups(hostclass='mhcfoo')
 
@@ -87,7 +88,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group = self.mock_elastigroup(hostclass='mhcfoo')
 
         self.elastigroup._delete_group = MagicMock()
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group])
 
         self.elastigroup.delete_groups(group_name=mock_group['name'])
 
@@ -98,7 +99,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group1 = self.mock_elastigroup(hostclass="mhcfoo")
         mock_group2 = self.mock_elastigroup(hostclass="mhcbar")
 
-        self.elastigroup._get_existing_groups = MagicMock(return_value=[mock_group1, mock_group2])
+        self.elastigroup.get_existing_groups = MagicMock(return_value=[mock_group1, mock_group2])
         self.elastigroup._get_group_instances = MagicMock(return_value=['instance1', 'instance2'])
 
         actual_listings = self.elastigroup.list_groups()
@@ -129,10 +130,12 @@ class DiscoElastigroupTests(TestCase):
         """Verifies new elastigroup is created"""
         self.elastigroup._create_az_subnets_dict = MagicMock()
         self.elastigroup._create_elastigroup_config = MagicMock(return_value=dict())
+        self.elastigroup.get_existing_group = MagicMock(return_value=None)
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.update_group(hostclass="mhcfoo")
 
-        self.elastigroup.session.post.assert_called_once_with(SPOTINST_API, data=json.dumps({}))
+        self.elastigroup._spotinst_call.assert_called_once_with(data={}, method='post')
 
     def test_update_existing_group(self):
         """Verifies existing elastigroup is updated"""
@@ -150,8 +153,9 @@ class DiscoElastigroupTests(TestCase):
         self.elastigroup._create_az_subnets_dict = MagicMock()
         self.elastigroup._create_elastigroup_config = MagicMock(return_value=mock_group_config)
         self.elastigroup.get_existing_group = MagicMock(return_value=mock_group)
+        self.elastigroup._spotinst_call = MagicMock()
 
         self.elastigroup.update_group(hostclass="mhcfoo")
 
-        self.elastigroup.session.put.assert_called_once_with(SPOTINST_API + mock_group['id'],
-                                                             data=json.dumps(mock_group_config))
+        self.elastigroup._spotinst_call.assert_called_once_with(path='/' + mock_group['id'],
+                                                                data=mock_group_config, method='put')

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -133,7 +133,7 @@ class DiscoElastigroupTests(TestCase):
         self.elastigroup.get_existing_group = MagicMock(return_value=None)
         self.elastigroup._spotinst_call = MagicMock()
 
-        self.elastigroup.update_group(hostclass="mhcfoo")
+        self.elastigroup.update_group(hostclass="mhcfoo", spotinst=True)
 
         self.elastigroup._spotinst_call.assert_called_once_with(data={}, method='post')
 
@@ -155,7 +155,7 @@ class DiscoElastigroupTests(TestCase):
         self.elastigroup.get_existing_group = MagicMock(return_value=mock_group)
         self.elastigroup._spotinst_call = MagicMock()
 
-        self.elastigroup.update_group(hostclass="mhcfoo")
+        self.elastigroup.update_group(hostclass="mhcfoo", spotinst=True)
 
         self.elastigroup._spotinst_call.assert_called_once_with(path='/' + mock_group['id'],
                                                                 data=mock_group_config, method='put')


### PR DESCRIPTION
* Replace all calls to `DiscoAutoScale` and `DiscoElastiGroup` with calls to DiscoGroup which now acts as a middle man to any calls to the first 2 classes. DiscoGroup's responsibility is to decide which (or both) classes pass the given call to
* Improve unit tests for SpotInst. Introduce `requests_mock` library for mocking out REST API calls
* Normalize the interfaces of `DiscoAutoScale` and `DiscoElastiGroup` so that they have the same interface and methods/return values


Notes:
Some methods of `DiscoElastiGroup` are not implemented yet. These are for functionality that `DiscoAutoScale` supports but isn't supported in `DiscoElastiGroup`. We will have future PRs to implement the remaining functionality