### PR TITLE
Reduce spotinst warnings when spotinst token is missing

### DIFF
--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -48,8 +48,8 @@ class DiscoGroup(BaseGroup):
 
         try:
             return fun(*args, **kwargs)
-        except SpotinstException as err:
-            logger.info('Unable to call DiscoElastigroup.%s: %s', fun.__name__, err.message)
+        except SpotinstException:
+            logger.exception('Unable to call DiscoElastigroup.%s', fun.__name__)
             return default
 
     def get_existing_groups(self, hostclass=None, group_name=None):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Added generic function for calling DiscoElastiGroup with error handling and added logic to show fewer warnings if the SpotInst token is missing.