### PR TITLE
Handled multiple instance types for ephemeral disk count

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -259,7 +259,8 @@ class DiscoAWS(object):
             block_device_mappings = [self.disco_storage.configure_storage(
                 hostclass=hostclass, ami_id=ami.id,
                 extra_space=extra_space, extra_disk=extra_disk, iops=iops,
-                ephemeral_disk_count=self.disco_storage.get_ephemeral_disk_count(instance_type))]
+                ephemeral_disk_count=min([self.disco_storage.get_ephemeral_disk_count(i_type)
+                                          for i_type in instance_type.split(':')]))]
         else:
             block_device_mappings = [old_config.block_device_mappings]
         return block_device_mappings

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Spotinst implementation allows defining multiple instance types. Handling this in ephemeral disk count by assigning the minimum number of ephemeral disks supported by the given instance types.