### PR TITLE
Change remaining instances of DiscoAWS.autoscale to DiscoAWS.discogroup

### DIFF
--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -126,7 +126,7 @@ def run():
             aws.disco_storage.delete_snapshot(snapshot_id)
     elif args.mode == "update":
         snapshot = aws.disco_storage.get_latest_snapshot(args.hostclass)
-        aws.autoscale.update_snapshot(snapshot.id, snapshot.volume_size, hostclass=args.hostclass)
+        aws.discogroup.update_snapshot(snapshot.id, snapshot.volume_size, hostclass=args.hostclass)
 
 if __name__ == "__main__":
     run_gracefully(run)

--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -150,3 +150,8 @@ class BaseGroup(object):
                 raise
 
         return True
+
+    @abstractmethod
+    def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
+        """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
+        pass

--- a/disco_aws_automation/disco_chaos.py
+++ b/disco_aws_automation/disco_chaos.py
@@ -33,7 +33,7 @@ class DiscoChaos(object):
     def _get_autoscaling_groups(self):
         '''Returns list of autoscaling groups (with caching)'''
         if self._groups is None:
-            self._groups = self.disco_aws.autoscale.get_existing_groups()  # pragma: no cover
+            self._groups = self.disco_aws.discogroup.get_existing_groups()  # pragma: no cover
         return self._groups
 
     @staticmethod

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -430,6 +430,10 @@ class DiscoElastigroup(BaseGroup):
         """Deletes an autoscaling policy"""
         pass
 
+    def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
+        """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
+        pass
+
     def _get_group_id_from_instance_id(self, instance_id):
         groups = self.get_existing_groups()
         for group in groups:

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -200,6 +200,10 @@ class DiscoGroup(BaseGroup):
         """Deletes an autoscaling policy"""
         self.autoscale.delete_policy(policy_name, group_name)
 
+    def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
+        """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
+        self.autoscale.update_snapshot(snapshot_id, snapshot_size, hostclass, group_name)
+
     def _service_call(self, use_spotinst, fun_name, default=None, *args, **kwargs):
         """Make a call to either DiscoAutoscale or DiscoElastigroup"""
         if use_spotinst:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_chaos.py
+++ b/test/unit/test_disco_chaos.py
@@ -2,9 +2,10 @@
 Tests of disco_aws
 """
 from unittest import TestCase
+
 from mock import MagicMock, create_autospec
 
-from disco_aws_automation import DiscoChaos, DiscoAWS, DiscoAutoscale
+from disco_aws_automation import DiscoChaos, DiscoAWS, DiscoGroup
 from test.helpers.patch_disco_aws import (get_default_config_dict,
                                           get_mock_config,
                                           TEST_ENV_NAME)
@@ -33,9 +34,9 @@ class DiscoChaosTests(TestCase):
 
     def test_get_autoscaling_group_right_params(self):
         '''Test that get_autoscaling_groups makes only valid calls'''
-        self.chaos._disco_aws.autoscale = create_autospec(DiscoAutoscale)
+        self.chaos._disco_aws.discogroup = create_autospec(DiscoGroup)
         self.chaos._get_autoscaling_groups()
-        self.assertEqual(self.chaos._disco_aws.autoscale.get_existing_groups.call_count, 1)
+        self.assertEqual(self.chaos._disco_aws.discogroup.get_existing_groups.call_count, 1)
 
     def test_terminate_right_params(self):
         '''Test that terminate makes only valid calls'''


### PR DESCRIPTION
There were a few more places that depended on the `autoscale` instance in `DiscoAWS`
Other classes shouldn't be depending on a internal field of `DiscoAWS` but for
now change it to a `discogroup` instance since thats now the interface for all
ASG and spotinst activities

This fixes an issue with snapshotting