### PR TITLE
Implement remaining Elastigroup behavior

### DIFF
--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -139,8 +139,12 @@ class BaseGroup(object):
         waiter = throttled_call(self.boto3_ec.get_waiter, 'instance_terminated')
         instance_ids = [inst['instance_id'] for inst in self.get_instances(group_name=group_name)]
 
+        # don't wait if there are no instances to wait for
+        if not instance_ids:
+            return True
+
         try:
-            logger.info("Waiting for scaledown of group %s", group['name'])
+            logger.info("Waiting for scaledown of group %s, instances %s", group['name'], instance_ids)
             waiter.wait(InstanceIds=instance_ids)
         except WaiterError:
             if noerror:

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -420,7 +420,7 @@ class DiscoAutoscale(BaseGroup):
                         'min_size': group['min_size'],
                         'desired_capacity': group['desired_capacity'],
                         'max_size': group['max_size'],
-                        'type': group['asg']}
+                        'type': group['type']}
             grp_list.append(grp_dict)
         return grp_list
 

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -86,7 +86,8 @@ class DiscoAutoscale(BaseGroup):
                     'launch_config_name': group.launch_config_name,
                     'termination_policies': group.termination_policies,
                     'vpc_zone_identifier': group.vpc_zone_identifier,
-                    'load_balancers': group.load_balancers
+                    'load_balancers': group.load_balancers,
+                    'type': 'asg'
                 }
             next_token = groups.next_token
             if not next_token:
@@ -419,7 +420,7 @@ class DiscoAutoscale(BaseGroup):
                         'min_size': group['min_size'],
                         'desired_capacity': group['desired_capacity'],
                         'max_size': group['max_size'],
-                        'type': 'asg'}
+                        'type': group['asg']}
             grp_list.append(grp_dict)
         return grp_list
 
@@ -544,7 +545,11 @@ class DiscoAutoscale(BaseGroup):
 
     def delete_policy(self, policy_name, group_name):
         """Deletes an autoscaling policy"""
-        return throttled_call(self.boto3_autoscale.delete_policy, policy_name, group_name)
+        return throttled_call(
+            self.boto3_autoscale.delete_policy,
+            PolicyName=policy_name,
+            AutoScalingGroupName=group_name
+        )
 
     def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):
         """Deletes all recurring scheduled actions for a hostclass"""

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -702,10 +702,7 @@ class DiscoAWS(object):
     @staticmethod
     def _instance_count_lt_min_size(group, all_instances):
         group_instances = [_i for _i in all_instances if _i['group_name'] == group['name']]
-        if group.get('id'):
-            return len(group_instances) < group['capacity']['minimum']
-        else:
-            return len(group_instances) < group['min_size']
+        return len(group_instances) < group['min_size']
 
     def wait_for_autoscaling_instances(self, metadata_list, timeout=AUTOSCALE_TIMEOUT):
         """

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -434,32 +434,33 @@ class DiscoElastigroup(BaseGroup):
     def create_recurring_group_action(self, recurrance, min_size=None, desired_capacity=None, max_size=None,
                                       hostclass=None, group_name=None):
         """Creates a recurring scheduled action for a hostclass"""
-        existing_group = self.get_existing_group(hostclass=hostclass, group_name=group_name)
-
-        task = {
-            'cronExpression': recurrance,
-            'taskType': 'scale'
-        }
-
-        if min_size:
-            task['scaleMinCapcity'] = min_size
-
-        if max_size:
-            task['scaleMaxCapcity'] = max_size
-
-        if desired_capacity:
-            task['scaleTargetCapacity'] = desired_capacity
-
-        existing_schedule = existing_group['scheduling']
-        existing_schedule['tasks'].append(task)
-
-        group_config = {
-            'group': {
-                'scheduling': existing_schedule
+        existing_groups = self.get_existing_groups(hostclass=hostclass, group_name=group_name)
+        for existing_group in existing_groups:
+            logger.info("Creating scheduled action for hostclass %s, group_name %s", hostclass, group_name)
+            task = {
+                'cronExpression': recurrance,
+                'taskType': 'scale'
             }
-        }
 
-        self._spotinst_call(path='/' + existing_group['id'], data=group_config, method='put')
+            if min_size:
+                task['scaleMinCapcity'] = min_size
+
+            if max_size:
+                task['scaleMaxCapcity'] = max_size
+
+            if desired_capacity:
+                task['scaleTargetCapacity'] = desired_capacity
+
+            existing_schedule = existing_group['scheduling']
+            existing_schedule['tasks'].append(task)
+
+            group_config = {
+                'group': {
+                    'scheduling': existing_schedule
+                }
+            }
+
+            self._spotinst_call(path='/' + existing_group['id'], data=group_config, method='put')
 
     def update_elb(self, elb_names, hostclass=None, group_name=None):
         """Updates an existing autoscaling group to use a different set of load balancers"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -522,7 +522,8 @@ class DiscoElastigroup(BaseGroup):
         block_device_mappings = existing_group['blockDeviceMappings']
 
         # find which device uses snapshots. throw errors if none found or more than 1 found
-        snapshot_devices = [device for device in block_device_mappings if device.get('snapshotId')]
+        snapshot_devices = [device['ebs'] for device in block_device_mappings
+                            if device.get('ebs', {}).get('snapshotId')]
 
         if not snapshot_devices:
             raise Exception("Hostclass %s does not mount a snapshot" % hostclass)

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -126,7 +126,8 @@ class DiscoElastigroup(BaseGroup):
                     in group['compute']['launchSpecification']['loadBalancersConfig']['loadBalancers']
                 ],
                 'image_id': group['compute']['launchSpecification']['imageId'],
-                'id': group['id']
+                'id': group['id'],
+                'type': 'spot'
             }
             for group in groups if group['name'].startswith(self.environment_name)
         ]
@@ -184,7 +185,7 @@ class DiscoElastigroup(BaseGroup):
                  'min_size': group['min_size'],
                  'desired_capacity': group['desired_capacity'],
                  'max_size': group['max_size'],
-                 'type': 'spot'} for group in groups]
+                 'type': group['type']} for group in groups]
 
     def _create_elastigroup_config(self, hostclass, availability_vs_cost, desired_size, min_size, max_size,
                                    instance_type, zones, load_balancers, security_groups, instance_monitoring,
@@ -413,7 +414,7 @@ class DiscoElastigroup(BaseGroup):
 
     def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""
-        pass
+        return []
 
     # pylint: disable=too-many-arguments
     def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -490,7 +490,7 @@ class DiscoElastigroup(BaseGroup):
 
     def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""
-        return []
+        raise Exception('Scaling for Elastigroups is not implemented')
 
     # pylint: disable=too-many-arguments
     def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,
@@ -501,11 +501,11 @@ class DiscoElastigroup(BaseGroup):
         policy name already exist. Handles the logic of constructing the correct autoscaling policy request,
         because not all parameters are required.
         """
-        pass
+        raise Exception('Scaling for Elastigroups is not implemented')
 
     def delete_policy(self, policy_name, group_name):
         """Deletes an autoscaling policy"""
-        pass
+        raise Exception('Scaling for Elastigroups is not implemented')
 
     def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
         """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -561,11 +561,3 @@ class DiscoElastigroup(BaseGroup):
         )
 
         self._spotinst_call(path='/' + existing_group['id'], data=group_config, method='put')
-
-    def _get_group_id_from_instance_id(self, instance_id):
-        groups = self.get_existing_groups()
-        for group in groups:
-            group_id = group['id']
-            instance_ids = [instance['instanceId'] for instance in self._get_group_instances(group_id)]
-            if instance_id in instance_ids:
-                return group_id

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -399,19 +399,19 @@ class DiscoElastigroup(BaseGroup):
 
     def get_launch_config(self, hostclass=None, group_name=None):
         """Create new launchconfig group name"""
-        pass
+        raise Exception('Elastigroups don\'t have launch configs')
 
     def clean_configs(self):
         """Delete unused Launch Configurations in current environment"""
-        pass
+        raise Exception('Elastigroups don\'t have launch configs')
 
     def get_configs(self, names=None):
         """Returns Launch Configurations in current environment"""
-        pass
+        raise Exception('Elastigroups don\'t have launch configs')
 
     def delete_config(self, config_name):
         """Delete a specific Launch Configuration"""
-        pass
+        raise Exception('Elastigroups don\'t have launch configs')
 
     def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -392,7 +392,9 @@ class DiscoElastigroup(BaseGroup):
 
             group_config = {
                 'group': {
-                    'scheduling': []
+                    'scheduling': {
+                        'tasks': []
+                    }
                 }
             }
 

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -43,6 +43,12 @@ class DiscoGroup(BaseGroup):
             logger.info('No group found')
 
     def _elastigroup_call(self, fun, default=None, *args, **kwargs):
+        """
+        Call a function in DiscoElastiGroup and handle cases when SpotInst usage is disabled
+        Args:
+            fun (function): The function to call
+            default:  Default value to return in case SpotInst usage is disabled
+        """
         if not self.elastigroup.is_spotinst_enabled():
             return default
 
@@ -70,7 +76,8 @@ class DiscoGroup(BaseGroup):
     def get_instances(self, hostclass=None, group_name=None):
         asg_instances = self.autoscale.get_instances(hostclass=hostclass, group_name=group_name)
         spot_instances = self._elastigroup_call(
-            self.elastigroup.get_instances, default=[],
+            self.elastigroup.get_instances,
+            default=[],
             hostclass=hostclass,
             group_name=group_name
         )
@@ -114,24 +121,37 @@ class DiscoGroup(BaseGroup):
 
     def delete_all_recurring_group_actions(self, hostclass=None, group_name=None):
         """Deletes all recurring scheduled actions for a hostclass"""
-
         self.autoscale.delete_all_recurring_group_actions(hostclass, group_name)
+        self._elastigroup_call(self.elastigroup.delete_all_recurring_group_actions, hostclass, group_name)
 
     def create_recurring_group_action(self, recurrance, min_size=None, desired_capacity=None, max_size=None,
                                       hostclass=None, group_name=None):
         """Creates a recurring scheduled action for a hostclass"""
-        self.autoscale.create_recurring_group_action(recurrance, min_size, desired_capacity, max_size,
-                                                     hostclass,
-                                                     group_name)
+        self._service_call_for_group(
+            'create_recurring_group_action',
+            _hostclass=hostclass,
+            _group_name=group_name,
+            recurrance=recurrance,
+            min_size=min_size,
+            desired_capacity=desired_capacity,
+            max_size=max_size,
+            hostclass=hostclass,
+            group_name=group_name
+        )
 
     def update_elb(self, elb_names, hostclass=None, group_name=None):
         """Updates an existing autoscaling group to use a different set of load balancers"""
-
-        self.autoscale.update_elb(elb_names, hostclass, group_name)
+        self._service_call_for_group(
+            'update_elb',
+            _hostclass=hostclass,
+            _group_name=group_name,
+            elb_names=elb_names,
+            hostclass=hostclass,
+            group_name=group_name
+        )
 
     def get_launch_config(self, hostclass=None, group_name=None):
         """Create new launchconfig group name"""
-
         return self.autoscale.get_launch_config(hostclass, group_name)
 
     # pylint: disable=R0913, R0914
@@ -143,6 +163,19 @@ class DiscoGroup(BaseGroup):
         """
         Create a new autoscaling group or update an existing one
         """
+        existing_group = self.get_existing_group(hostclass, group_name)
+
+        # if there is an existing group and create_if_exists is false then we will be updating that group
+        # in that case, use the group type of the existing group instead of the passed in type
+        if existing_group and not create_if_exists:
+            existing_spot = existing_group['type'] == 'spot'
+            if existing_spot != spotinst:
+                logger.info(
+                    'Running update_group using %s group type because existing group type is %s',
+                    existing_group['type'], existing_group['type']
+                )
+                spotinst = existing_spot
+
         return self._service_call(
             spotinst, 'update_group',
             hostclass=hostclass,
@@ -182,7 +215,16 @@ class DiscoGroup(BaseGroup):
 
     def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""
-        return self.autoscale.list_policies(group_name, policy_types, policy_names)
+        asg_policies = self.autoscale.list_policies(group_name, policy_types, policy_names)
+        spot_policies = self._elastigroup_call(
+            self.elastigroup.list_policies,
+            default=[],
+            group_name=group_name,
+            policy_types=policy_types,
+            policy_names=policy_names
+        )
+
+        return asg_policies + spot_policies
 
     def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,
                       min_adjustment_magnitude=None, scaling_adjustment=None, cooldown=600,
@@ -192,23 +234,68 @@ class DiscoGroup(BaseGroup):
         policy name already exist. Handles the logic of constructing the correct autoscaling policy request,
         because not all parameters are required.
         """
-        self.autoscale.create_policy(group_name, policy_name, policy_type, adjustment_type,
-                                     min_adjustment_magnitude, scaling_adjustment, cooldown,
-                                     metric_aggregation_type, step_adjustments, estimated_instance_warmup)
+        self._service_call_for_group(
+            'create_policy',
+            _group_name=group_name,
+            group_name=group_name,
+            policy_name=policy_name,
+            policy_type=policy_type,
+            adjustment_type=adjustment_type,
+            min_adjustment_magnitude=min_adjustment_magnitude,
+            scaling_adjustment=scaling_adjustment,
+            cooldown=cooldown,
+            metric_aggregation_type=metric_aggregation_type,
+            step_adjustments=step_adjustments,
+            estimated_instance_warmup=estimated_instance_warmup
+        )
 
     def delete_policy(self, policy_name, group_name):
         """Deletes an autoscaling policy"""
-        self.autoscale.delete_policy(policy_name, group_name)
+        self._service_call_for_group(
+            'delete_policy',
+            _group_name=group_name,
+            policy_name=policy_name,
+            group_name=group_name
+        )
 
     def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
         """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
-        self.autoscale.update_snapshot(snapshot_id, snapshot_size, hostclass, group_name)
+        self._service_call_for_group(
+            'update_snapshot',
+            _hostclass=hostclass,
+            _group_name=group_name,
+            hostclass=hostclass,
+            group_name=group_name,
+            snapshot_id=snapshot_id,
+            snapshot_size=snapshot_size
+        )
 
     def _service_call(self, use_spotinst, fun_name, default=None, *args, **kwargs):
-        """Make a call to either DiscoAutoscale or DiscoElastigroup"""
+        """
+        Make a call to either DiscoAutoscale or DiscoElastigroup
+        Args:
+            use_spotinst (bool): Use DiscoElastiGroup if True
+            fun_name (str): Function name to call for the selected service
+            default: Default value to use when calling DiscoElastigroup in case SpotInst is disabled
+        """
         if use_spotinst:
             fun = getattr(self.elastigroup, fun_name)
             return self._elastigroup_call(fun, default, *args, **kwargs)
         else:
             fun = getattr(self.autoscale, fun_name)
             return fun(*args, **kwargs)
+
+    def _service_call_for_group(self, fun_name, _hostclass=None, _group_name=None, *args,
+                                **kwargs):
+        """
+        Make a call to either DiscoAutoscale or DiscoElastigroup based on the type of group affected
+        Defaults to using DiscoAutoscale if the group is not found
+        Args:
+            fun_name (str): Function to call on the selected service
+            _hostclass (str): Hostclass name to find group by
+            _group_name (str): ASG or Elastigroup name to find group by
+        """
+        existing_group = self.get_existing_group(_hostclass, _group_name)
+        use_spotinst = existing_group and existing_group['type'] == 'spot'
+
+        return self._service_call(use_spotinst, fun_name, *args, **kwargs)

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -4,7 +4,6 @@ import logging
 from .base_group import BaseGroup
 from .disco_autoscale import DiscoAutoscale
 from .disco_elastigroup import DiscoElastigroup
-from .exceptions import SpotinstException
 
 logger = logging.getLogger(__name__)
 
@@ -52,11 +51,7 @@ class DiscoGroup(BaseGroup):
         if not self.elastigroup.is_spotinst_enabled():
             return default
 
-        try:
-            return fun(*args, **kwargs)
-        except SpotinstException:
-            logger.exception('Unable to call DiscoElastigroup.%s', fun.__name__)
-            return default
+        return fun(*args, **kwargs)
 
     def get_existing_groups(self, hostclass=None, group_name=None):
         asg_groups = self.autoscale.get_existing_groups()

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -215,16 +215,7 @@ class DiscoGroup(BaseGroup):
 
     def list_policies(self, group_name=None, policy_types=None, policy_names=None):
         """Returns all autoscaling policies"""
-        asg_policies = self.autoscale.list_policies(group_name, policy_types, policy_names)
-        spot_policies = self._elastigroup_call(
-            self.elastigroup.list_policies,
-            default=[],
-            group_name=group_name,
-            policy_types=policy_types,
-            policy_names=policy_names
-        )
-
-        return asg_policies + spot_policies
+        return self.autoscale.list_policies(group_name, policy_types, policy_names)
 
     def create_policy(self, group_name, policy_name, policy_type="SimpleScaling", adjustment_type=None,
                       min_adjustment_magnitude=None, scaling_adjustment=None, cooldown=600,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_aws.py
+++ b/test/unit/test_disco_aws.py
@@ -123,6 +123,7 @@ class DiscoAWSTests(TestCase):
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -154,6 +155,7 @@ class DiscoAWSTests(TestCase):
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -189,6 +191,7 @@ class DiscoAWSTests(TestCase):
                        log_metrics=MagicMock())
         mock_ami = self._get_image_mock(aws)
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -219,6 +222,7 @@ class DiscoAWSTests(TestCase):
         """
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -243,6 +247,7 @@ class DiscoAWSTests(TestCase):
         """
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):
@@ -267,6 +272,7 @@ class DiscoAWSTests(TestCase):
         """
         aws = DiscoAWS(config=mock_config, environment_name=TEST_ENV_NAME, log_metrics=MagicMock())
         aws.update_elb = MagicMock(return_value=None)
+        aws.discogroup.elastigroup._spotinst_call = MagicMock()
 
         with patch("disco_aws_automation.DiscoAWS.get_meta_network", return_value=_get_meta_network_mock()):
             with patch("boto.ec2.connection.EC2Connection.get_all_snapshots", return_value=[]):

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -45,7 +45,15 @@ class DiscoElastigroupTests(TestCase):
                             "type": "CLASSIC"
                         }]
                     },
-                    "blockDeviceMappings": []
+                    "blockDeviceMappings": [{
+                        "deviceName": "/dev/xvda",
+                        "ebs": {
+                            "deleteOnTermination": "true",
+                            "volumeSize": "80",
+                            "volumeType": "gp2",
+                            "snapshotId": "snapshot-abcd1234"
+                        }
+                    }]
                 },
                 "availabilityZones": [{
                     "name": 'us-moon-1a',
@@ -53,20 +61,25 @@ class DiscoElastigroupTests(TestCase):
                 }]
             },
             "scheduling": {
-                "tasks": []
+                "tasks": [{
+                    'taskType': 'scale',
+                    'cronExpression': '12 0 * * *',
+                    'scaleMinCapcity': 5
+                }]
             }
         }
 
         return mock_elastigroup
 
-    def assert_request_made(self, requests, url, method):
+    def assert_request_made(self, requests, url, method, json=None):
         """Assert that a request was made to the given url and method"""
         filtered_items = [item for item in requests.request_history
-                          if item.url == url and item.method == method]
+                          if (item.url == url and item.method == method) and
+                          (not json or item.json() == json)]
 
         history_contains = len(filtered_items) > 0
 
-        self.assertEqual(history_contains, True, "%s request was not made to %s" % (url, method))
+        self.assertTrue(history_contains, "%s request was not made to %s with data %s" % (url, method, json))
 
     def setUp(self):
         """Pre-test setup"""
@@ -181,6 +194,7 @@ class DiscoElastigroupTests(TestCase):
         mock_group = self.mock_elastigroup(hostclass='mhcfoo')
         mock_group_config = {
             "group": {
+                "name": "moon_mhcfoo_1234",
                 "capacity": {
                     "unit": "instance"
                 },
@@ -198,3 +212,155 @@ class DiscoElastigroupTests(TestCase):
 
         self.elastigroup._spotinst_call.assert_called_once_with(path='/' + mock_group['id'],
                                                                 data=mock_group_config, method='put')
+
+    @requests_mock.Mocker()
+    def test_update_snapshot(self, requests):
+        """Verifies that snapshots for a Elastigroup are updated"""
+        mock_group = self.mock_elastigroup(hostclass='mhcfoo')
+
+        requests.get(SPOTINST_API, json={
+            "response": {
+                "items": [mock_group]
+            }
+        })
+
+        requests.put(SPOTINST_API + mock_group['id'], json={})
+
+        self.elastigroup.update_snapshot('snapshot-newsnapshotid', 100, hostclass='mhcfoo')
+
+        expected_request = {
+            'group': {
+                'compute': {
+                    'launchSpecification': {
+                        'blockDeviceMappings': [{
+                            "deviceName": "/dev/xvda",
+                            "ebs": {
+                                "deleteOnTermination": "true",
+                                "volumeSize": 100,
+                                "volumeType": "gp2",
+                                "snapshotId": "snapshot-newsnapshotid"
+                            }
+                        }]
+                    }
+                }
+            }
+        }
+
+        self.assert_request_made(requests, SPOTINST_API + mock_group['id'], 'PUT', json=expected_request)
+
+    @requests_mock.Mocker()
+    def test_update_elb(self, requests):
+        """Verifies ELBs for a Elastigroup are updated"""
+        mock_group = self.mock_elastigroup(hostclass='mhcfoo')
+
+        requests.get(SPOTINST_API, json={
+            "response": {
+                "items": [mock_group]
+            }
+        })
+
+        requests.put(SPOTINST_API + mock_group['id'], json={})
+
+        self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
+
+        expected_request = {
+            'group': {
+                'compute': {
+                    'launchSpecification': {
+                        'loadBalancersConfig': {
+                            'loadBalancers': [{
+                                'name': 'elb-newelb',
+                                'type': 'CLASSIC'
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+
+        self.assert_request_made(requests, SPOTINST_API + mock_group['id'], 'PUT', json=expected_request)
+
+    @requests_mock.Mocker()
+    def test_create_recurring_group_action(self, requests):
+        """Verifies recurring actions are created for Elastigroups"""
+        mock_group = self.mock_elastigroup(hostclass='mhcfoo')
+
+        requests.get(SPOTINST_API, json={
+            "response": {
+                "items": [mock_group]
+            }
+        })
+
+        requests.put(SPOTINST_API + mock_group['id'], json={})
+
+        self.elastigroup.create_recurring_group_action('0 0 * * *', min_size=1, hostclass='mhcfoo')
+
+        expected_request = {
+            'group': {
+                'scheduling': {
+                    'tasks': [{
+                        'taskType': 'scale',
+                        'cronExpression': '12 0 * * *',
+                        'scaleMinCapcity': 5
+                    }, {
+                        'taskType': 'scale',
+                        'cronExpression': '0 0 * * *',
+                        'scaleMinCapcity': 1
+                    }]
+                }
+            }
+        }
+
+        self.assert_request_made(requests, SPOTINST_API + mock_group['id'], 'PUT', json=expected_request)
+
+    @requests_mock.Mocker()
+    def test_delete_all_recurring_group_actions(self, requests):
+        """Verifies recurring actions are deleted for Elastigroups"""
+        mock_group = self.mock_elastigroup(hostclass='mhcfoo')
+
+        requests.get(SPOTINST_API, json={
+            "response": {
+                "items": [mock_group]
+            }
+        })
+
+        requests.put(SPOTINST_API + mock_group['id'], json={})
+
+        self.elastigroup.delete_all_recurring_group_actions(hostclass='mhcfoo')
+
+        expected_request = {
+            'group': {
+                'scheduling': {
+                    'tasks': []
+                }
+            }
+        }
+
+        self.assert_request_made(requests, SPOTINST_API + mock_group['id'], 'PUT', json=expected_request)
+
+    @requests_mock.Mocker()
+    def test_scaledown(self, requests):
+        """Verifies Elastigroups are scaled down"""
+        mock_group = self.mock_elastigroup(hostclass='mhcfoo')
+
+        requests.get(SPOTINST_API, json={
+            "response": {
+                "items": [mock_group]
+            }
+        })
+
+        requests.put(SPOTINST_API + mock_group['id'], json={})
+
+        self.elastigroup.scaledown_groups(hostclass='mhcfoo')
+
+        expected_request = {
+            "group": {
+                "capacity": {
+                    "target": 0,
+                    "minimum": 0,
+                    "maximum": 0
+                }
+            }
+        }
+
+        self.assert_request_made(requests, SPOTINST_API + mock_group['id'], 'PUT', json=expected_request)

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -51,6 +51,9 @@ class DiscoElastigroupTests(TestCase):
                     "name": 'us-moon-1a',
                     "subnetId": "subnet-abcd1234"
                 }]
+            },
+            "scheduling": {
+                "tasks": []
             }
         }
 

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -44,7 +44,8 @@ class DiscoElastigroupTests(TestCase):
                             "name": "elb-1234",
                             "type": "CLASSIC"
                         }]
-                    }
+                    },
+                    "blockDeviceMappings": []
                 },
                 "availabilityZones": [{
                     "name": 'us-moon-1a',


### PR DESCRIPTION
* DiscoGroup now checks the type of an existing group before modifying it and selects the correct group service based on its type

* Implement `update_snapshot`
* Implement `update_elb`
* Add support for scheduled actions
* Scaling policy and launch config related methods now throw not implemented exceptions

@kelibezhani 