### PR TITLE
AL-1031 Remove Classic Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ reports
 .idea/*
 .ropeproject/
 *.iml
+tasks/lint/pylintrc_merged

--- a/README.md
+++ b/README.md
@@ -2316,7 +2316,7 @@ There are a few configuration options for integration tests in ```disco_aws.ini`
 test_hostclass=mhcfootest
 test_user=integration_tester
 test_command=/opt/asiaq/bin/run_tests.sh
-deployment_strategy=classic # One of [classic, blue_green]
+deployment_strategy=blue_green # One of [blue_green]
 ```
 
 * test_hostclass
@@ -2326,7 +2326,7 @@ deployment_strategy=classic # One of [classic, blue_green]
 * test_command
   * The command to execute the tests on ```test_hostclass``` as the ```test_user```. Typically a shell script with some logic for handling the test argument that is passed to it. The exit code of this command determines whether or not the integration tests were successful.
 * deployment_strategy
-  * The deployment strategy to use when deploying a new AMI. Either ```classic``` or ```blue_green```. The default is currently ```classic```.
+  * The deployment strategy to use when deploying a new AMI. The default is currently ```blue_green```.
 
 These options can be specified in two places in ```disco_aws.ini```, in the ```[test]``` section or in a given hostclass' section. Below is an example of specifying defaults in the ```[test]``` section and overriding them for the mhcfoo hostclass.
 
@@ -2365,10 +2365,6 @@ sequence,hostclass,min_size,desired_size,max_size,instance_type,extra_disk,iops,
 In the above pipeline, mhcbar will be integration tested by passing ```mhcbar_integration``` as the argument to the ```test_command``` on the generic ```test_hostclass``` defined in our example ```disco_aws.ini``` above. In contrast, mhcfoo will be integration tested by passing ```mhcfoo_integration``` as the argument to the ```test_command``` on it's specially defined ```test_hostclass```. And because mhcnointegrationtests left the ```integration_test``` column empty, no integration tests will be run for it.
 
 #### Deployment Strategies
-
-##### Classic
-
-Classic deployment strategy is used by default. Instances with a new AMI are spun up in the existing ASG and automatically added to the existing nerve and ELB groups. There are a number of problems with this strategy, so it is slated for deprecation and removal soon. Let us speak no more of it.
 
 ##### Blue/Green
 

--- a/disco_aws_automation/disco_constants.py
+++ b/disco_aws_automation/disco_constants.py
@@ -9,7 +9,6 @@ SMOKETEST_TIMEOUT = 600
 AUTOSCALE_POLL_INTERVAL = 15  # seconds
 AUTOSCALE_TIMEOUT = 300
 DEPLOYMENT_STRATEGY_BLUE_GREEN = "blue_green"
-DEPLOYMENT_STRATEGY_CLASSIC = "classic"
 
 YES_LIST = ['true', 'yes', 't', 'y', 'aye', '1']
 NO_LIST = ['false', 'no', 'f', 'n', 'nay', '0']

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -4,7 +4,6 @@ import copy
 import logging
 import random
 import sys
-from datetime import datetime
 
 from ConfigParser import NoOptionError, NoSectionError
 from boto.exception import EC2ResponseError
@@ -14,14 +13,16 @@ from .disco_config import read_config
 from .disco_aws_util import get_instance_launch_time
 from .exceptions import (
     TimeoutError,
-    MaintenanceModeError,
     IntegrationTestError,
     SmokeTestError,
-    TooManyAutoscalingGroups
+    TooManyAutoscalingGroups,
+    UnknownDeploymentStrategyException
 )
 from .disco_aws_util import is_truthy, size_as_minimum_int_or_none, size_as_maximum_int_or_none
-from .disco_constants import (DEFAULT_CONFIG_SECTION, DEPLOYMENT_STRATEGY_BLUE_GREEN,
-                              DEPLOYMENT_STRATEGY_CLASSIC)
+from .disco_constants import (
+    DEFAULT_CONFIG_SECTION,
+    DEPLOYMENT_STRATEGY_BLUE_GREEN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -231,68 +232,6 @@ class DiscoDeploy(object):
         except:
             logger.exception("promotion failed")
 
-    def handle_nodeploy_ami(self, ami, pipeline_dict=None, dry_run=False, old_group=None):
-        '''Promotes a non-deployable host and updates the autoscaling group to use it next time
-
-        A host is launched in testing mode and if it passes smoketests it is promoted and
-        the autoscaling group for that hostclass is updated.
-
-        The currently active instances of this hostclass are not put in maintenance mode and
-        are not replaced by the new AMI.
-
-        '''
-        ami_test_failed = False
-        hostclass = DiscoBake.ami_hostclass(ami)
-
-        if not pipeline_dict:
-            pipeline_dict = {"hostclass": hostclass}
-
-        logger.info(
-            "Smoke testing non-deploy Hostclass %s AMI %s with %s deployment strategy",
-            hostclass, ami.id, DEPLOYMENT_STRATEGY_CLASSIC
-        )
-
-        if dry_run:
-            return
-
-        # Generate the two pipelines we'll need, one with double instance sizing for deployment, and another
-        # that has correct instance sizing for the final form of the ASG.
-        new_hostclass_dict = self._generate_deploy_pipeline(
-            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC,
-            pipeline_dict=pipeline_dict,
-            old_group=old_group,
-            ami=ami
-        )
-
-        rollback_hostclass_dict = self._generate_post_deploy_pipeline(
-            pipeline_dict=pipeline_dict,
-            old_group=old_group,
-            ami=ami
-        )
-
-        now = datetime.utcnow()
-
-        self._disco_aws.spinup([new_hostclass_dict], testing=True)
-
-        if self.wait_for_smoketests(ami.id, rollback_hostclass_dict["desired_size"], launch_time=now):
-            self._promote_ami(ami, "tested")
-        else:
-            self._promote_ami(ami, "failed")
-            rollback_hostclass_dict.pop("ami", None)
-            logger.error("AMI smoke test failed.")
-            ami_test_failed = True
-
-        if old_group:
-            self._disco_aws.terminate(self._get_new_instances(ami.id, launch_time=now), use_autoscaling=True)
-            self._disco_aws.spinup([rollback_hostclass_dict])
-            # Create scheduled actions on the ASG.
-            self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
-        else:
-            self._disco_group.delete_groups(hostclass=hostclass, force=True)
-
-        if ami_test_failed:
-            raise RuntimeError("Smoke test for non-deploy Hostclass %s AMI %s failed", hostclass, ami.id)
-
     def _get_old_instances(self, new_ami_id, launch_time=None):
         '''
         Returns instances for the hostclass of new_ami_id that are not running new_ami_id
@@ -343,102 +282,6 @@ class DiscoDeploy(object):
                     raise
         return max(images, key=self._disco_bake.get_ami_creation_time).id if len(images) else None
 
-    def run_tests_with_maintenance_mode(self, ami):
-        '''
-        Runs integration tests for a hostclass beloning to a particular AMI.
-
-        This method puts all AMIs not matching the passed in AMI into maintenance mode.
-        If tests pass the old instances are left in maintenance mode, otherwise they are returned to normal.
-        '''
-        hostclass = DiscoBake.ami_hostclass(ami)
-        self._set_maintenance_mode(hostclass, self._get_old_instances(ami.id), True)
-        ret = self.run_integration_tests(ami)
-        if not ret:
-            self._set_maintenance_mode(hostclass, self._get_old_instances(ami.id), False)
-        return ret
-
-    def handle_tested_ami(self, ami, pipeline_dict=None, run_tests=False, dry_run=False, old_group=None):
-        '''
-        Tests hostclasses which we can deploy normally.
-
-        Deploys AMIs inside the same autoscaling group, and destroys old instances on successful passing,
-        otherwise destroys the new instances and rolls back the ASG's configuration.
-        '''
-        ami_test_failed = False
-        hostclass = DiscoBake.ami_hostclass(ami)
-
-        logger.info(
-            "testing deployable hostclass %s AMI %s with %s deployment strategy",
-            hostclass,
-            ami.id,
-            DEPLOYMENT_STRATEGY_CLASSIC
-        )
-
-        if dry_run:
-            return
-
-        if not pipeline_dict:
-            pipeline_dict = {}
-
-        if old_group and run_tests and not self.run_integration_tests(ami):
-            raise RuntimeError("Failed pre-test -- not testing AMI {}".format(ami.id))
-
-        # Generate the two pipelines we'll need, one with double instance sizing for deployment, and another
-        # that has correct instance sizing for the final form of the ASG.
-        new_hostclass_dict = self._generate_deploy_pipeline(
-            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC,
-            pipeline_dict=pipeline_dict,
-            old_group=old_group,
-            ami=ami
-        )
-
-        post_hostclass_dict = self._generate_post_deploy_pipeline(
-            pipeline_dict=pipeline_dict,
-            old_group=old_group,
-            ami=ami
-        )
-
-        now = datetime.utcnow()
-
-        self._disco_aws.spinup([new_hostclass_dict])
-
-        try:
-            if (self.wait_for_smoketests(ami.id, post_hostclass_dict["desired_size"], launch_time=now) and
-                    (not run_tests or self.run_tests_with_maintenance_mode(ami))):
-                # Roll forward with new configuration
-                self._disco_aws.terminate(self._get_old_instances(ami.id, launch_time=now),
-                                          use_autoscaling=True)
-                self._disco_aws.spinup([post_hostclass_dict])
-                # Create scheduled actions on the ASG.
-                self._create_scaling_schedule(pipeline_dict, hostclass=hostclass)
-                self._promote_ami(ami, "tested")
-                return
-            else:
-                self._promote_ami(ami, "failed")
-                logger.error("AMI smoke test failed.")
-                ami_test_failed = True
-        except (MaintenanceModeError, IntegrationTestError):
-            logger.exception("Failed to run integration test")
-
-        # Revert to old configuration
-        post_hostclass_dict["smoke_test"] = "no"
-        post_hostclass_dict.pop("ami", None)
-
-        # Revert to the latest tested AMI if possible
-        old_ami_id = self._get_latest_other_image_id(ami.id)
-        if old_ami_id:
-            post_hostclass_dict["ami"] = old_ami_id
-        else:
-            logger.error("Unable to rollback to old AMI. Autoscaling group will use new AMI on next event!")
-
-        self._disco_aws.terminate(self._get_new_instances(ami.id, launch_time=now), use_autoscaling=True)
-        self._disco_aws.spinup([post_hostclass_dict])
-
-        if ami_test_failed:
-            raise RuntimeError("Testing of deployable hostclass %s AMI %s failed", hostclass, ami.id)
-
-        raise RuntimeError("Failed to run integration test")
-
     # This method handles blue/green from end to end, so it has a lot of logic in it. We should at some point
     # look at breaking it up a bit and/or the feasibility of that.
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-return-statements
@@ -467,7 +310,7 @@ class DiscoDeploy(object):
 
         uses_elb = is_truthy(self.hostclass_option_default(hostclass, "elb", "no"))
 
-        new_group_config = self._generate_post_deploy_pipeline(
+        new_group_config = self._generate_deploy_pipeline(
             pipeline_dict=pipeline_dict,
             old_group=old_group,
             ami=ami
@@ -587,7 +430,7 @@ class DiscoDeploy(object):
                     return
             else:
                 self._promote_ami(ami, "failed")
-        except (MaintenanceModeError, IntegrationTestError):
+        except IntegrationTestError:
             logger.exception("Failed to run integration test")
 
         # Destroy the testing ASG
@@ -615,8 +458,8 @@ class DiscoDeploy(object):
             hostclass=hostclass
         )
 
-    def _generate_post_deploy_pipeline(self, pipeline_dict, old_group, ami):
-        """Generate pipeline with sizing for post deployment"""
+    def _generate_deploy_pipeline(self, pipeline_dict, old_group, ami):
+        """Generate pipeline with sizing for deployment"""
         new_config = copy.deepcopy(pipeline_dict)
         new_config["sequence"] = 1
         new_config["smoke_test"] = "no"
@@ -647,42 +490,6 @@ class DiscoDeploy(object):
         new_config["max_size"] = max_size
 
         return new_config
-
-    def _generate_deploy_pipeline(self, deployment_strategy, pipeline_dict, old_group, ami):
-        """Generate pipeline with sizing for deployment"""
-        new_config = self._generate_post_deploy_pipeline(pipeline_dict, old_group, ami)
-
-        # If we are using classic deployment and an older group exists, we need to double the sizing so that
-        # new instances are actually deployed. These numbers will be later shrunk.
-        if old_group and deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
-            new_config["desired_size"] *= 2
-            new_config["min_size"] = new_config["desired_size"] / 2
-            new_config["max_size"] = new_config["desired_size"]
-
-        return new_config
-
-    def _set_maintenance_mode(self, hostclass, instances, mode_on):
-        '''
-        Takes instances into or out of maintenance mode.
-
-
-        If we fail to put an instance into the desired mode we terminate that instance
-        and raise a MaintenanceModeError exception.
-        '''
-        exit_code = 0
-        bad_instances = []
-        for inst in instances:
-            _code, _stdout = self._disco_aws.remotecmd(
-                inst, ["sudo", "/opt/wgen/bin/maintenance-mode.sh", "on" if mode_on else "off"],
-                user=self.hostclass_option(hostclass, "test_user"), nothrow=True)
-            sys.stdout.write(_stdout)
-            if _code:
-                exit_code = _code
-                bad_instances.append(inst)
-        if exit_code:
-            self._disco_aws.terminate(bad_instances)
-            raise MaintenanceModeError(
-                "Failed to {} maintenance mode".format("enter" if mode_on else "exit"))
 
     def _set_testing_mode(self, hostclass, instances, mode_on):
         '''
@@ -743,8 +550,14 @@ class DiscoDeploy(object):
         hostclass = DiscoBake.ami_hostclass(ami)
         pipeline_hostclass_dict = self._hostclasses.get(hostclass)
         group = self._disco_group.get_existing_group(hostclass)
-        deployable = self.is_deployable(hostclass)
         testable = bool(self.get_integration_test(hostclass))
+
+        # We are only deployable in testing if we are in the pipeline. Otherwise assume that we aren't
+        # deployable. This must be done because we don't want to deploy things that shouldn't end up in
+        # the testing environment and but do need to be tested. An example would be hostclasses that are
+        # only expected to exist in the bakery_environment. This doesn't hold true for update, which
+        # should just always deploy things unless explicitly told no.
+        deployable = pipeline_hostclass_dict and self.is_deployable(hostclass)
 
         if deployment_strategy is not None:
             desired_deployment_strategy = deployment_strategy
@@ -752,21 +565,7 @@ class DiscoDeploy(object):
             desired_deployment_strategy = self.hostclass_option_default(hostclass, 'deployment_strategy',
                                                                         DEPLOYMENT_STRATEGY_BLUE_GREEN)
 
-        if desired_deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
-            logger.warning(
-                "Classic deployment will be removed in a future version of Asiaq."
-                "Please switch to Blue/Green deployment by setting `deployment_strategy=%s` under your "
-                "hostclass' section in disco_aws.ini",
-                DEPLOYMENT_STRATEGY_BLUE_GREEN
-            )
-
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:
-            # We are only deployable in testing if we are in the pipeline. Otherwise assume that we aren't
-            # deployable. This must be done because we don't want to deploy things that shouldn't end up in
-            # the testing environment and but do need to be tested. An example would be hostclasses that are
-            # only expected to exist in the bakery_environment. This doesn't hold true for update, which
-            # should just always deploy things unless explicitly told no.
-            deployable = pipeline_hostclass_dict and deployable
             return self.handle_blue_green_ami(
                 ami,
                 pipeline_dict=pipeline_hostclass_dict,
@@ -775,34 +574,10 @@ class DiscoDeploy(object):
                 run_tests=testable,
                 dry_run=dry_run
             )
-        elif not deployable:
-            self.handle_nodeploy_ami(
-                ami,
-                pipeline_dict=pipeline_hostclass_dict,
-                dry_run=dry_run,
-                old_group=group
-            )
-        elif testable:
-            self.handle_tested_ami(
-                ami,
-                pipeline_dict=pipeline_hostclass_dict,
-                run_tests=True,
-                dry_run=dry_run,
-                old_group=group
-            )
-        elif pipeline_hostclass_dict:
-            self.handle_tested_ami(
-                ami,
-                pipeline_dict=pipeline_hostclass_dict,
-                dry_run=dry_run,
-                old_group=group
-            )
         else:
-            self.handle_nodeploy_ami(
-                ami,
-                pipeline_dict=None,
-                dry_run=dry_run,
-                old_group=group)
+            raise UnknownDeploymentStrategyException(
+                "Unsupported deployment strategy: {0}".format(desired_deployment_strategy)
+            )
 
     def update_ami(self, ami, dry_run, deployment_strategy=None):
         '''Handles updating a hostclass to the latest tested AMI'''
@@ -822,14 +597,6 @@ class DiscoDeploy(object):
             desired_deployment_strategy = self.hostclass_option_default(hostclass, 'deployment_strategy',
                                                                         DEPLOYMENT_STRATEGY_BLUE_GREEN)
 
-        if desired_deployment_strategy == DEPLOYMENT_STRATEGY_CLASSIC:
-            logger.warning(
-                "Classic deployment will be removed in a future version of Asiaq."
-                "Please switch to Blue/Green deployment by setting `deployment_strategy=%s` under your "
-                "hostclass' section in disco_aws.ini",
-                DEPLOYMENT_STRATEGY_BLUE_GREEN
-            )
-
         if desired_deployment_strategy == DEPLOYMENT_STRATEGY_BLUE_GREEN:
             self.handle_blue_green_ami(
                 ami,
@@ -839,19 +606,9 @@ class DiscoDeploy(object):
                 run_tests=testable,
                 dry_run=dry_run
             )
-        elif not deployable:
-            self.handle_nodeploy_ami(
-                ami,
-                pipeline_dict=pipeline_dict,
-                dry_run=dry_run,
-                old_group=group
-            )
         else:
-            self.handle_tested_ami(
-                ami,
-                pipeline_dict=pipeline_dict,
-                dry_run=dry_run,
-                old_group=group
+            raise UnknownDeploymentStrategyException(
+                "Unsupported deployment strategy: {0}".format(desired_deployment_strategy)
             )
 
     def test(self, dry_run=False, deployment_strategy=None):

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -554,7 +554,7 @@ class DiscoDeploy(object):
 
         # We are only deployable in testing if we are in the pipeline. Otherwise assume that we aren't
         # deployable. This must be done because we don't want to deploy things that shouldn't end up in
-        # the testing environment and but do need to be tested. An example would be hostclasses that are
+        # the testing environment but do need to be tested. An example would be hostclasses that are
         # only expected to exist in the bakery_environment. This doesn't hold true for update, which
         # should just always deploy things unless explicitly told no.
         deployable = pipeline_hostclass_dict and self.is_deployable(hostclass)

--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -57,11 +57,6 @@ class CommandError(RuntimeError):
     pass
 
 
-class MaintenanceModeError(RuntimeError):
-    """ Error entering or leaving maintenance mode """
-    pass
-
-
 class IntegrationTestError(RuntimeError):
     """ Error running integration tests """
     pass
@@ -184,4 +179,9 @@ class TooManyAutoscalingGroups(RuntimeError):
 
 class SpotinstException(Exception):
     """Generic Spotinst exception"""
+    pass
+
+
+class UnknownDeploymentStrategyException(Exception):
+    """Error trying to use an unknown deployment strategy"""
     pass

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.17"
+__version__ = "2.0.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -9,15 +9,15 @@ from datetime import datetime
 from datetime import timedelta
 
 import boto.ec2.instance
-from mock import MagicMock, create_autospec, call, ANY
+from mock import MagicMock, create_autospec, call
 
 from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoGroup, DiscoBake, DiscoELB
-from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN, DEPLOYMENT_STRATEGY_CLASSIC
+from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN
 from disco_aws_automation.exceptions import (
     TimeoutError,
-    MaintenanceModeError,
     IntegrationTestError,
-    TooManyAutoscalingGroups
+    TooManyAutoscalingGroups,
+    UnknownDeploymentStrategyException
 )
 from test.helpers.patch_disco_aws import get_mock_config
 
@@ -456,16 +456,6 @@ class DiscoDeployTests(TestCase):
         self._ci_deploy._disco_bake.promote_ami = MagicMock(side_effect=Exception())
         ami = MagicMock()
         self._ci_deploy._promote_ami(ami, "super")
-
-    def test_nodeploy_ami_dry_run(self):
-        """We don't call spinup in a no deploy AMI dry_run"""
-        self._ci_deploy.handle_nodeploy_ami(MagicMock(), dry_run=True)
-        self.assertEqual(self._disco_aws.spinup.call_count, 0)
-
-    def test_tested_ami_dry_run(self):
-        """We don't call spinup in a deployed AMI dry_run"""
-        self._ci_deploy.handle_tested_ami(MagicMock(), dry_run=True)
-        self.assertEqual(self._disco_aws.spinup.call_count, 0)
 
     def test_blue_green_dry_run(self):
         """We don't call spinup in a blue/green dry_run"""
@@ -917,182 +907,6 @@ class DiscoDeployTests(TestCase):
         self._disco_elb.wait_for_instance_health_state.assert_called_with(hostclass="mhcbluegreen",
                                                                           testing=True)
 
-    def test_nodeploy_ami_success(self):
-        '''No deploy instances are promoted and autoscaling updated, when smoketest passes'''
-        ami = MagicMock()
-        ami.name = "mhcscarey 1 2"
-        ami.id = "ami-12345678"
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
-                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, 1, launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
-                    'min_size': 1, 'integration_test': None, 'desired_size': 2,
-                    'smoke_test': 'no', 'max_size': 2, 'hostclass': 'mhcscarey'}],
-                  testing=True),
-             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
-                    'min_size': 1, 'desired_size': 1, 'max_size': 1,
-                    'integration_test': None, 'smoke_test': 'no',
-                    'hostclass': 'mhcscarey'}])])
-
-    def test_nodeploy_no_dict(self):
-        '''Instance not in pipeline is still tested and promoted'''
-        ami = MagicMock()
-        ami.name = "mhcnewscarey 1 2"
-        ami.id = "ami-12345678"
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy.handle_nodeploy_ami(ami, pipeline_dict=None, dry_run=False)
-        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, 1, launch_time=ANY)
-        self._disco_aws.spinup.assert_called_once_with(
-            [{'ami': 'ami-12345678', 'sequence': 1, 'min_size': 0, 'desired_size': 1,
-              'smoke_test': 'no', 'max_size': 1, 'hostclass': 'mhcnewscarey'}], testing=True)
-        self._disco_group.delete_groups.assert_called_once_with(hostclass='mhcnewscarey', force=True)
-
-    def test_nodeploy_ami_failure(self):
-        '''No deploy instances are failed and not promoted when smoketest fails'''
-        ami = MagicMock()
-        ami.name = "mhcscarey 1 2"
-        ami.id = "ami-12345678"
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._disco_bake.promote_ami.assert_called_with(ami, 'failed')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id, 1, launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
-                    'min_size': 1, 'integration_test': None, 'desired_size': 2,
-                    'smoke_test': 'no', 'max_size': 2, 'hostclass': 'mhcscarey'}],
-                  testing=True),
-             call([{'sequence': 1, 'deployable': 'no', 'min_size': 1,
-                    'integration_test': None, 'desired_size': 1, 'smoke_test': 'no',
-                    'max_size': 1, 'hostclass': 'mhcscarey'}])])
-
-    def test_smoketest_ami_success(self):
-        '''Smoketest instances are promoted and autoscaling updated on success'''
-        ami = MagicMock()
-        ami.name = "mhcsmokey 1 2"
-        ami.id = "ami-12345678"
-        self._existing_group.desired_capacity = 2
-        self._existing_group.max_size = 2
-        self._existing_group.min_size = 2
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
-                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id,
-                                                               self._existing_group.desired_capacity,
-                                                               launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'min_size': 2, 'integration_test': None, 'desired_size': 4,
-                    'smoke_test': 'no', 'max_size': 4, 'hostclass': 'mhcsmokey'}]),
-             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'min_size': 2, 'integration_test': None, 'desired_size': 2,
-                    'smoke_test': 'no', 'max_size': 2, 'hostclass': 'mhcsmokey'}])])
-
-    def test_smoketest_ami_failure(self):
-        '''Smoketest instances are failed and autoscaling updated on failure'''
-        ami = MagicMock()
-        ami.name = "mhcsmokey 1 2"
-        ami.id = "ami-12345678"
-        self._existing_group.desired_capacity = 2
-        self._existing_group.max_size = 2
-        self._existing_group.min_size = 2
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._disco_bake.promote_ami.assert_called_with(ami, 'failed')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id,
-                                                               self._existing_group.desired_capacity,
-                                                               launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'min_size': 2, 'integration_test': None, 'desired_size': 4,
-                    'smoke_test': 'no', 'max_size': 4, 'hostclass': 'mhcsmokey'}]),
-             call([{'deployable': 'yes', 'sequence': 1, 'min_size': 2, 'integration_test': None,
-                    'desired_size': 2, 'max_size': 2, 'hostclass': 'mhcsmokey',
-                    'smoke_test': 'no'}])])
-
-    def test_timed_autoscaling_ami_success(self):
-        '''Timed autoscaling instances are promoted and correct autoscaling sizes updated on success'''
-        ami = MagicMock()
-        ami.name = "mhctimedautoscale 1 2"
-        ami.id = "ami-12345678"
-        self._existing_group.desired_capacity = 2
-        self._existing_group.max_size = 2
-        self._existing_group.min_size = 2
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
-                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id,
-                                                               self._existing_group.desired_capacity,
-                                                               launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
-                    'min_size': 2, 'desired_size': 4, 'max_size': 4}]),
-             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
-                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
-                    'min_size': 2, 'desired_size': 2, 'max_size': 2}])])
-        self._disco_aws.create_scaling_schedule.assert_called_once_with(
-            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
-            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
-            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
-            group_name=None,
-            hostclass='mhctimedautoscale'
-        )
-
-    def test_timed_autoscaling_ami_success_nd(self):
-        '''Timed autoscaling is not set for non-deployable hostclasses'''
-        ami = MagicMock()
-        ami.name = "mhctimedautoscalenodeploy 1 2"
-        ami.id = "ami-12345678"
-        self._existing_group.desired_capacity = 2
-        self._existing_group.max_size = 2
-        self._existing_group.min_size = 2
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
-                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._disco_bake.promote_ami.assert_called_with(ami, 'tested')
-        self._ci_deploy.wait_for_smoketests.assert_called_with(ami.id,
-                                                               self._existing_group.desired_capacity,
-                                                               launch_time=ANY)
-        self._disco_aws.spinup.assert_has_calls(
-            [call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
-                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscalenodeploy',
-                    'min_size': 2, 'desired_size': 4, 'max_size': 4}], testing=True),
-             call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'no',
-                    'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscalenodeploy',
-                    'min_size': 2, 'desired_size': 2, 'max_size': 2}])])
-        self._disco_aws.create_scaling_schedule.assert_called_once_with(
-            min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
-            desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
-            max_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
-            group_name=None,
-            hostclass='mhctimedautoscalenodeploy'
-        )
-
-    def test_set_maintenance_mode_on(self):
-        '''_set_maintenance_mode makes expected remotecmd call'''
-        self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(0, ""))
-        self._ci_deploy._set_maintenance_mode(hostclass="mhcfoo", instances=["i-1"], mode_on=True)
-        self._ci_deploy._disco_aws.remotecmd.assert_called_with(
-            "i-1", ["sudo", "/opt/wgen/bin/maintenance-mode.sh", "on"],
-            user="test_user", nothrow=True)
-
-    def test_set_maintenance_mode_error(self):
-        '''_set_maintenance_mode handles errors'''
-        self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(1, ""))
-        self.assertRaises(MaintenanceModeError, self._ci_deploy._set_maintenance_mode,
-                          hostclass="foo", instances=["i-1"], mode_on=False)
-        self._ci_deploy._disco_aws.remotecmd.assert_called_with(
-            "i-1", ["sudo", "/opt/wgen/bin/maintenance-mode.sh", "off"],
-            user="test_user", nothrow=True)
-
     def test_get_latest_other_image_id_1(self):
         '''_get_latest_other_image_id uses amis of old deployed instances'''
         ami = self.mock_ami("mhcabc 1")
@@ -1174,26 +988,6 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.instances = MagicMock(return_value=instances)
         self.assertEquals(self._ci_deploy._get_old_instances(ami_id1), [inst2])
 
-    def test_maintenance_mode_failure(self):
-        '''Test that we handle maintenance mode failure appropriately'''
-        ami = MagicMock()
-        ami.name = "mhcintegrated 1 2"
-        ami.id = "ami-12345678"
-        inst1 = self.mock_instance()
-        inst2 = self.mock_instance()
-        self._existing_group.desired_capacity = 2
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
-        self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self._ci_deploy.get_host = MagicMock()
-        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
-        self._ci_deploy._disco_aws.remotecmd = MagicMock(return_value=(1, ''))
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._ci_deploy._get_old_instances.assert_called_with(ami.id)
-        self._ci_deploy._disco_aws.terminate.assert_has_calls(
-            [call([inst1]), call([inst2], use_autoscaling=True)])
-
     def test_pre_test_failure(self):
         '''Test that an exception is raised if the pre-test fails'''
         ami = self.mock_ami("mhcintegrated 1 2")
@@ -1230,154 +1024,12 @@ class DiscoDeployTests(TestCase):
         self._disco_aws.instances_from_hostclasses = MagicMock(return_value=[])
         self.assertRaises(IntegrationTestError, self._ci_deploy.run_integration_tests, ami)
 
-    def test_run_integration_tests_success(self):
-        '''Test that handle run_tests success appropriately'''
-        ami = self.mock_ami("mhcintegrated 1 2")
-        inst1 = self.mock_instance()
-        inst2 = self.mock_instance()
-        self._existing_group.desired_capacity = 2
-        self._ci_deploy._set_maintenance_mode = MagicMock(return_value=True)
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
-        self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
-        self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertIsNone(self._ci_deploy.test_ami(ami, dry_run=False,
-                                                   deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._ci_deploy._get_old_instances.assert_called_with(ami.id, launch_time=ANY)
-        self._ci_deploy._disco_aws.terminate.assert_has_calls(
-            [call([inst1], use_autoscaling=True)])
-
-    def test_wait_for_smoketests_fail(self):
-        '''Test that handle smoketest failure appropriately'''
-        ami = self.mock_ami("mhcintegrated 1 2")
-        inst1 = self.mock_instance()
-        inst2 = self.mock_instance()
-        self._existing_group.desired_capacity = 2
-        self._ci_deploy._set_maintenance_mode = MagicMock(return_value=True)
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=False)
-        self._ci_deploy.run_integration_tests = MagicMock(return_value=True)
-        self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
-        self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._ci_deploy._get_new_instances.assert_called_with(ami.id, launch_time=ANY)
-        self._ci_deploy._disco_aws.terminate.assert_has_calls(
-            [call([inst2], use_autoscaling=True)])
-
-    def test_run_integration_tests_fail(self):
-        '''Test that run_integration_tests handles failure appropriately'''
-        ami = self.mock_ami("mhcintegrated 1 2")
-        inst1 = self.mock_instance()
-        inst2 = self.mock_instance()
-        self._existing_group.desired_capacity = 2
-        self._ci_deploy._set_maintenance_mode = MagicMock(return_value=True)
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy.run_integration_tests = MagicMock(side_effect=[True, False])
-        self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
-        self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._ci_deploy._get_new_instances.assert_called_with(ami.id, launch_time=ANY)
-        self._ci_deploy._disco_aws.terminate.assert_has_calls(
-            [call([inst2], use_autoscaling=True)])
-        self.assertEqual(self._ci_deploy._set_maintenance_mode.call_count, 2)
-
-    def test_run_integration_tests_fail_fallback(self):
-        '''Test that run_integration_tests handles failure with fallback amis'''
-        ami1 = self.mock_ami("mhcintegrated 1")
-        inst1 = self.mock_instance()
-        inst1.image_id = ami1.id
-        ami2 = self.mock_ami("mhcintegrated 2")
-        inst2 = self.mock_instance()
-        inst2.image_id = ami2.id
-        self._existing_group.desired_capacity = 2
-        self._existing_group.max_size = 2
-        self._ci_deploy._set_maintenance_mode = MagicMock(return_value=True)
-        self._ci_deploy.wait_for_smoketests = MagicMock(return_value=True)
-        self._ci_deploy.run_integration_tests = MagicMock(side_effect=[True, False])
-        self._ci_deploy._get_old_instances = MagicMock(return_value=[inst1])
-        self._ci_deploy._get_new_instances = MagicMock(return_value=[inst2])
-        self._ci_deploy._get_latest_other_image_id = MagicMock(return_value=ami1.id)
-        self.assertRaises(RuntimeError, self._ci_deploy.test_ami, ami2, dry_run=False,
-                          deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC)
-        self._disco_aws.spinup.assert_has_calls(
-            [
-                call([{'ami': ami2.id, 'sequence': 1, 'deployable': 'yes',
-                       'min_size': 2, 'integration_test': 'foo_service', 'desired_size': 4,
-                       'smoke_test': 'no', 'max_size': 4, 'hostclass': 'mhcintegrated'}]),
-                call([{'ami': ami1.id, 'sequence': 1, 'deployable': 'yes', 'min_size': 1,
-                       'integration_test': 'foo_service', 'desired_size': 2, 'smoke_test': 'no',
-                       'max_size': 2, 'hostclass': 'mhcintegrated'}])])
-
-    def test_ami_of_non_pipeline_hostclass(self):
-        '''Test test_ami handling of non-pipeline hostclass'''
-        ami = self.mock_ami("mhcbar 1")
-        self._existing_group.desired_capacity = 2
-        self._ci_deploy.handle_nodeploy_ami = MagicMock()
-        self.assertIsNone(self._ci_deploy.test_ami(
-            ami,
-            dry_run=False,
-            deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC
-        ))
-        self._ci_deploy.handle_nodeploy_ami.assert_has_calls([
-            call(
-                ami,
-                pipeline_dict=None,
-                dry_run=False,
-                old_group=self._existing_group.__dict__
-            )
-        ])
-
     def test_update_ami_not_in_pipeline(self):
         '''Test update_ami handling of non-pipeline hostclass'''
         ami = self.mock_ami("mhcbar 1")
         self._ci_deploy.is_deployable = MagicMock()
         self.assertRaises(RuntimeError, self._ci_deploy.update_ami, ami, dry_run=False)
         self.assertEqual(self._ci_deploy.is_deployable.call_count, 0)
-
-    def test_update_ami_not_in_autoscale_deploy(self):
-        '''Test update_ami handling new deployable hostclass'''
-        ami = self.mock_ami("mhcsmokey 1")
-        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
-        self._ci_deploy.handle_tested_ami = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
-                                                     deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcsmokey")
-        self._ci_deploy.handle_tested_ami.assert_called_with(
-            ami,
-            pipeline_dict={
-                'min_size': '2',
-                'integration_test': None,
-                'deployable': 'yes',
-                'desired_size': '2',
-                'hostclass': 'mhcsmokey'
-            },
-            dry_run=False,
-            old_group=None
-        )
-
-    def test_update_ami_not_in_autoscale_nodeploy(self):
-        '''Test update_ami handling new non-deployable hostclass'''
-        ami = self.mock_ami("mhcscarey 1")
-        self._ci_deploy.is_deployable = MagicMock(return_value=False)
-        self._ci_deploy._disco_group.get_existing_group = MagicMock(return_value=None)
-        self._ci_deploy.handle_nodeploy_ami = MagicMock(return_value=True)
-        self.assertIsNone(self._ci_deploy.update_ami(ami, dry_run=False,
-                                                     deployment_strategy=DEPLOYMENT_STRATEGY_CLASSIC))
-        self.assertEqual(self._ci_deploy.is_deployable.call_count, 1)
-        self._ci_deploy._disco_group.get_existing_group.assert_called_with("mhcscarey")
-        self._ci_deploy.handle_nodeploy_ami.assert_called_with(
-            ami,
-            pipeline_dict={
-                'min_size': '1',
-                'integration_test': None,
-                'deployable': 'no',
-                'desired_size': '1',
-                'hostclass': 'mhcscarey'
-            },
-            dry_run=False,
-            old_group=None
-        )
 
     def test_test_with_amis(self):
         '''Test test with amis'''
@@ -1484,7 +1136,7 @@ class DiscoDeployTests(TestCase):
 
     def test_correct_zero_pipeline_sizing(self):
         '''Tests that get deploy sizing corrects zero pipeline sizing'''
-        post_deploy_pipeline = self._ci_deploy._generate_post_deploy_pipeline(
+        post_deploy_pipeline = self._ci_deploy._generate_deploy_pipeline(
             pipeline_dict={
                 'desired_size': "0",
                 'min_size': "0",
@@ -1497,3 +1149,23 @@ class DiscoDeployTests(TestCase):
         self.assertEqual(post_deploy_pipeline['desired_size'], 1)
         self.assertEqual(post_deploy_pipeline['min_size'], 0)
         self.assertEqual(post_deploy_pipeline['max_size'], 1)
+
+    def test_unsupported_strategy_test(self):
+        """Tests exception for bad strategy with test_ami"""
+        self.assertRaises(
+            UnknownDeploymentStrategyException,
+            self._ci_deploy.test_ami,
+            ami=self._amis_by_name['mhcbar 2'],
+            deployment_strategy="foobar",
+            dry_run=False
+        )
+
+    def test_unsupported_strategy_update(self):
+        """Tests exception for bad strategy with update_ami"""
+        self.assertRaises(
+            UnknownDeploymentStrategyException,
+            self._ci_deploy.update_ami,
+            ami=self._amis_by_name['mhcfoo 4'],
+            deployment_strategy="foobar",
+            dry_run=False
+        )


### PR DESCRIPTION
Removed all classic deployment code. Added exception that is thrown if
an unknown deployment strategy is used (which is any that isn't
blue_green). Also removed tests for the classic deployment code and
added two tests to verify that the exception is thrown. Also updated the
README to no longer discuss classic deployment.