### PR TITLE
Use a better way to get the account id in DiscoSNS

### DIFF
--- a/disco_aws_automation/disco_sns.py
+++ b/disco_aws_automation/disco_sns.py
@@ -5,6 +5,8 @@ import itertools
 import boto
 from boto.exception import BotoServerError
 
+import boto3
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,7 +23,7 @@ class DiscoSNS(object):
         if not account_id:
             try:
                 # Attempt to look up ARN from user information.
-                arn = boto.connect_iam().get_user().arn
+                account_id = boto3.client('sts').get_caller_identity().get('Account')
             except BotoServerError:
                 # Instance Roles have no user ID, so we fetch the instance profile arn
                 logger.debug(
@@ -29,7 +31,7 @@ class DiscoSNS(object):
                     "Attempting to lookup ARN from InstanceProfile instead."
                 )
                 arn = boto.utils.get_instance_metadata(data='meta-data/iam/')['info']['InstanceProfileArn']
-            account_id = arn.split(':')[4]
+                account_id = arn.split(':')[4]
         self.account_id = account_id
 
     def topic_arn_from_name(self, name):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "1.3.19"
+__version__ = "1.3.20"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
DiscoSNS was breaking for SSO users because the boto get_user() call does not work for federated users

It was failing with this error
```
2017-03-29 01:00:27,269 boto ERROR 400 Bad Request
2017-03-29 01:00:27,269 boto ERROR <ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>Must specify userName when calling with non-User credentials</Message>
  </Error>
  <RequestId>a04921f5-143c-11e7-8bd2-439a4e6634a2</RequestId>
</ErrorResponse>
```