### PR TITLE
Fix updating ELB config for spotinst groups

### DIFF
--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -377,6 +377,13 @@ class DiscoDeploy(object):
 
                     if uses_elb:
                         try:
+                            # get the list of instance Ids again because they might have changed after
+                            # updating the group (this happens for Spotinst but not for regular ASGs)
+                            group_instance_ids = [
+                                inst['instance_id']
+                                for inst in self._disco_group.get_instances(group_name=new_group['name'])
+                            ]
+
                             # Wait until the new ASG is registered and marked as healthy by ELB.
                             self._disco_elb.wait_for_instance_health_state(hostclass=hostclass,
                                                                            instance_ids=group_instance_ids)

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -362,6 +362,11 @@ class DiscoElastigroup(BaseGroup):
                 group_config['group']['capacity']['target'] = group['desired_capacity']
 
             self._spotinst_call(path='/' + group_id, data=group_config, method='put')
+
+            # if the ELB config changed then we need to roll the group to pick up the new config
+            if set(group['load_balancers']) != set(load_balancers or []):
+                self._roll_group(group_id, wait=True)
+
             return {'name': group['name']}
         else:
             new_group = self._spotinst_call(data=group_config, method='post').json()
@@ -506,42 +511,9 @@ class DiscoElastigroup(BaseGroup):
 
         self._spotinst_call(path='/' + existing_group['id'], data=group_config, method='put')
 
-        instance_ids = {instance['instanceId']
-                        for instance in self._get_group_instances(existing_group['id'])
-                        if instance['instanceId']}
-
         # Spotinst requires us to roll (recreate) the instances for them to pick up the new ELBs
         # this is done in a blue/green way so doesn't cause downtime
-        self._roll_group(existing_group['id'], 100, GROUP_ROLL_TIMEOUT)
-
-        # there isn't a roll status API so we will check progress of the operation by monitoring
-        # the instance Ids that belong to the group. Once none of the old instances are attached
-        # to the group then we know we are done
-        # give the group 10 minutes for the new instances to become healthy and the old instances to die
-        current_time = time.time()
-        stop_time = current_time + GROUP_ROLL_TIMEOUT
-        while current_time < stop_time:
-            new_instance_ids = {instance['instanceId']
-                                for instance in self._get_group_instances(existing_group['id'])
-                                if instance['instanceId']}
-
-            remaining_instances = instance_ids.intersection(new_instance_ids)
-
-            if not remaining_instances:
-                break
-
-            logger.info(
-                "Waiting for %s to roll in order to update ELB settings",
-                remaining_instances
-            )
-            time.sleep(20)
-            current_time = time.time()
-
-        if current_time >= stop_time:
-            raise TimeoutError(
-                "Timed out after waiting %s seconds for rolling deploy of %s" %
-                (GROUP_ROLL_TIMEOUT, hostclass or group_name)
-            )
+        self._roll_group(existing_group['id'], wait=True)
 
         return new_lbs, extras
 
@@ -636,7 +608,21 @@ class DiscoElastigroup(BaseGroup):
 
         self._spotinst_call(path='/' + existing_group['id'], data=group_config, method='put')
 
-    def _roll_group(self, group_id, batch_percentage, grace_period):
+    def _roll_group(self, group_id, batch_percentage=100, grace_period=GROUP_ROLL_TIMEOUT, wait=False):
+        """
+        Recreate the instances in a Elastigroup
+        :param group_id (str): Elastigroup ID to roll
+        :param batch_percentage (int): Percentage of instances to roll at a time (0-100)
+        :param grace_period (int): Time in seconds to wait for new instances to become healthy
+        :param wait (boolean): True to wait for roll operation to finish
+        :raises TimeoutError if grace_period has expired
+        """
+        if wait:
+            # if we will be waiting then get the instance Ids now so we can monitor them
+            instance_ids = {instance['instanceId']
+                            for instance in self._get_group_instances(group_id)
+                            if instance['instanceId']}
+
         request = {
             "batchSizePercentage": batch_percentage,
             "gracePeriod": grace_period,
@@ -646,3 +632,33 @@ class DiscoElastigroup(BaseGroup):
         }
 
         self._spotinst_call(path='/%s/roll' % group_id, data=request, method='put')
+
+        if wait:
+            # there isn't a roll status API so we will check progress of the operation by monitoring
+            # the instance Ids that belong to the group. Once none of the old instances are attached
+            # to the group then we know we are done
+            # give the group 10 minutes for the new instances to become healthy and the old instances to die
+            current_time = time.time()
+            stop_time = current_time + grace_period
+            while current_time < stop_time:
+                new_instance_ids = {instance['instanceId']
+                                    for instance in self._get_group_instances(group_id)
+                                    if instance['instanceId']}
+
+                remaining_instances = instance_ids.intersection(new_instance_ids)
+
+                if not remaining_instances:
+                    break
+
+                logger.info(
+                    "Waiting for %s to roll in order to update ELB settings",
+                    remaining_instances
+                )
+                time.sleep(20)
+                current_time = time.time()
+
+            if current_time >= stop_time:
+                raise TimeoutError(
+                    "Timed out after waiting %s seconds for rolling deploy of %s" %
+                    (grace_period, group_id)
+                )

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -259,8 +259,13 @@ class DiscoElastigroupTests(TestCase):
                 "items": [mock_group]
             }
         })
-
         requests.put(SPOTINST_API + mock_group['id'], json={})
+        requests.get(SPOTINST_API + mock_group['id'] + '/status', json={
+            'response': {
+                'items': []
+            }
+        })
+        requests.put(SPOTINST_API + mock_group['id'] + '/roll', json={})
 
         self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
 

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -199,8 +199,13 @@ class DiscoElastigroupTests(TestCase):
                 "items": [mock_group]
             }
         })
-
         requests.put(SPOTINST_API + mock_group['id'])
+        requests.get(SPOTINST_API + mock_group['id'] + '/status', json={
+            'response': {
+                'items': []
+            }
+        })
+        requests.put(SPOTINST_API + mock_group['id'] + '/roll', json={})
 
         self.elastigroup.update_group(
             hostclass="mhcfoo",


### PR DESCRIPTION
Spotinst requires us to "roll" a group after changing ELB config.
This means recreating all the instances in a blue/green way. Change
update_elb to roll the group and wait for the new instances to spinup