### PR TITLE
Added support for --tag to disco_bake.py

### DIFF
--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -113,7 +113,7 @@ def get_parser():
                              help="Use instances' local ip address for operations. "
                              "Set this flag when baking from same subnet as where the baking is occuring.")
     parser_bake.add_argument('--tag', dest='tags', required=False, action='append', type=str, default=[],
-                             help='The key:value pair used to tag the snapshot '
+                             help='The key:value pair used to tag the AMI '
                                   '(Example: --tag application:dnext)')
 
     parser_create = subparsers.add_parser(

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -111,6 +111,9 @@ def get_parser():
                              const=True, default=False,
                              help="Use instances' local ip address for operations. "
                              "Set this flag when baking from same subnet as where the baking is occuring.")
+    parser_bake.add_argument('--tag', dest='tags', required=False, action='append', type=str, default=[],
+                             help='The key:value pair used to tag the snapshot '
+                                  '(Example: --tag application:dnext)')
 
     parser_create = subparsers.add_parser(
         'create', help="Create a hostclass",
@@ -132,8 +135,9 @@ def run():
     configure_logging(args.debug)
 
     if args.mode == "bake":
+        extra_tags = dict(tag.split(':', 1) for tag in args.tags)
         bakery = DiscoBake(use_local_ip=args.use_local_ip)
-        bakery.bake_ami(args.hostclass, args.no_destroy, args.source_ami, args.stage)
+        bakery.bake_ami(args.hostclass, args.no_destroy, args.source_ami, args.stage, extra_tags=extra_tags)
     elif args.mode == "create":
         HostclassTemplating.create_hostclass(args.hostclass)
     elif args.mode == "promote":

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -6,6 +6,7 @@ Command line tool for baking AMI's and otherwise working with them.
 from __future__ import print_function
 import sys
 import argparse
+from collections import OrderedDict
 from datetime import datetime
 
 from disco_aws_automation import DiscoBake, HostclassTemplating
@@ -135,7 +136,7 @@ def run():
     configure_logging(args.debug)
 
     if args.mode == "bake":
-        extra_tags = dict(tag.split(':', 1) for tag in args.tags)
+        extra_tags = OrderedDict(tag.split(':', 1) for tag in args.tags)
         bakery = DiscoBake(use_local_ip=args.use_local_ip)
         bakery.bake_ami(args.hostclass, args.no_destroy, args.source_ami, args.stage, extra_tags=extra_tags)
     elif args.mode == "create":

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -61,7 +61,7 @@ def get_parser():
     parser_take_group.add_argument('--ami', dest='amis', default=[], action='append', type=str)
     parser_take_group.add_argument('--volume-id', dest='volume_id', type=str)
     parser_take.add_argument('--tag', dest='tags', required=False, action='append', type=str,
-                             help='The key-value pair used to tag the snapshot '
+                             help='The key:value pair used to tag the snapshot '
                                   '(Example: --tag disk_usage:300MB)')
 
     parser_update = subparsers.add_parser(

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -327,7 +327,7 @@ class DiscoBake(object):
                     user
                 )
 
-    def bake_ami(self, hostclass, no_destroy, source_ami_id=None, stage=None):
+    def bake_ami(self, hostclass, no_destroy, source_ami_id=None, stage=None, extra_tags=None):
         # Pylint thinks this function has too many local variables and too many statements and branches
         # pylint: disable=R0914, R0915, R0912
         """
@@ -426,7 +426,7 @@ class DiscoBake(object):
 
             productline = self.hc_option_default(hostclass, "product_line", None)
 
-            DiscoBake._tag_ami_with_metadata(image, stage, source_ami_id, productline)
+            DiscoBake._tag_ami_with_metadata(image, stage, source_ami_id, productline, extra_tags=extra_tags)
 
             wait_for_state(image, u'available',
                            int(self.hc_option_default(hostclass, "ami_available_wait_time", "600")))
@@ -445,12 +445,12 @@ class DiscoBake(object):
         return image
 
     @staticmethod
-    def _tag_ami_with_metadata(ami, stage, source_ami_id, productline=None):
+    def _tag_ami_with_metadata(ami, stage, source_ami_id, productline=None, extra_tags=None):
         """
         Tags an AMI with the stage, source_ami, the branch/git-hash of disco_aws_automation,
         and the productline if provided
         """
-        tag_dict = OrderedDict()
+        tag_dict = extra_tags or OrderedDict()
         tag_dict['stage'] = stage
         tag_dict['source_ami'] = source_ami_id
         tag_dict['baker'] = getpass.getuser()

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -448,9 +448,14 @@ class DiscoBake(object):
     def _tag_ami_with_metadata(ami, stage, source_ami_id, productline=None, extra_tags=None):
         """
         Tags an AMI with the stage, source_ami, the branch/git-hash of disco_aws_automation,
-        and the productline if provided
+        and the productline if provided.
+
+        Also accepts an extra_tags parameter, which is an additional dictionary of tags that will be
+        appended to the AMI after the tags required by Asiaq.
         """
-        tag_dict = extra_tags or OrderedDict()
+        # An ordered dictionary is used because AWS has limits on the number of tags that can be applied,
+        # so we order the tags by their importance to Asiaq's ability to function. Ergo, stage is first.
+        tag_dict = OrderedDict()
         tag_dict['stage'] = stage
         tag_dict['source_ami'] = source_ami_id
         tag_dict['baker'] = getpass.getuser()
@@ -458,6 +463,11 @@ class DiscoBake(object):
 
         if productline:
             tag_dict['productline'] = productline
+
+        # Append extra tags to the existing tag dict without overriding any tags Asiaq provides.
+        for key, value in extra_tags.iteritems():
+            if key not in tag_dict:
+                tag_dict[key] = value
 
         DiscoBake._tag_ami(ami, tag_dict)
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
disco_bake.py now accepts a --tag while baking AMIs, allowing the user to set additional tags to the resulting AMI. These tags cannot override the existing tags that Asiaq already sets. Also added a few unit tests to check this functionality.