### PR TITLE
Added Tags Support When Listing AMIs

### DIFF
--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -1,1 +1,41 @@
 """Binaries"""
+from __future__ import print_function
+from collections import defaultdict
+
+import sys
+
+
+def print_table(rows, headers=None, space_between_columns=4):
+    """
+    Convenience method for printing a list of dictionary objects into a table. Automatically sizes the
+    columns to be the maximum size of any entry in the dictionary, and adds additional buffer whitespace.
+
+    Params:
+        rows -                  A list of dictionaries representing a table of information, where keys are the
+                                headers of the table. Ex. { 'Name': 'John', 'Age': 23 }
+
+        headers -               A list of the headers to print for the table. Must be a subset of the keys of
+                                the dictionaries that compose the row. If a header isn't present or it's value
+                                has a falsey value, the value printed is '-'.
+
+        space_between_columns - The amount of space between the columns of text. Defaults to 4.
+    """
+    columns_to_sizing = defaultdict(int)
+    format_string = ''
+
+    headers = headers or rows[0].keys()
+
+    for row in rows:
+        for header in headers:
+            value = row.get(header, '-')
+            columns_to_sizing[header] = max(len(str(value)), columns_to_sizing[header])
+
+    for header in headers:
+        column_size = max(columns_to_sizing[header], len(header)) + space_between_columns
+        format_string += '{' + header + ':<' + str(column_size) + '}'
+
+    print(format_string.format(**{key: key for key in headers}), file=sys.stderr)
+
+    for row in rows:
+        defaulted_row = {header: row.get(header) or '-' for header in headers}
+        print(format_string.format(**defaulted_row))

--- a/bin/disco_autoscale.py
+++ b/bin/disco_autoscale.py
@@ -4,11 +4,11 @@ Command line tool for working with autoscaling groups and launch configurations.
 """
 
 from __future__ import print_function
+
 import argparse
 import sys
 
-from collections import defaultdict
-
+from bin import print_table
 from disco_aws_automation import DiscoGroup
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_config import read_config
@@ -238,42 +238,6 @@ def run():
         discogroup.delete_policy(args.policy_name, args.group_name)
 
     sys.exit(0)
-
-
-def print_table(rows, headers=None, space_between_columns=4):
-    """
-    Convenience method for printing a list of dictionary objects into a table. Automatically sizes the
-    columns to be the maximum size of any entry in the dictionary, and adds additional buffer whitespace.
-
-    Params:
-        rows -                  A list of dictionaries representing a table of information, where keys are the
-                                headers of the table. Ex. { 'Name': 'John', 'Age': 23 }
-
-        headers -               A list of the headers to print for the table. Must be a subset of the keys of
-                                the dictionaries that compose the row. If a header isn't present or it's value
-                                has a falsey value, the value printed is '-'.
-
-        space_between_columns - The amount of space between the columns of text. Defaults to 4.
-    """
-    columns_to_sizing = defaultdict(int)
-    format_string = ''
-
-    headers = headers or rows[0].keys()
-
-    for row in rows:
-        for header in headers:
-            value = row.get(header, '-')
-            columns_to_sizing[header] = max(len(str(value)), columns_to_sizing[header])
-
-    for header in headers:
-        column_size = max(columns_to_sizing[header], len(header)) + space_between_columns
-        format_string += '{' + header + ':<' + str(column_size) + '}'
-
-    print(format_string.format(**{key: key for key in headers}), file=sys.stderr)
-
-    for row in rows:
-        defaulted_row = {header: row.get(header) or '-' for header in headers}
-        print(format_string.format(**defaulted_row))
 
 
 if __name__ == "__main__":

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -58,6 +58,8 @@ def get_parser():
                                  help='Only show amis for this hostclass.', type=str, default=None)
     parser_listamis.add_argument('--in-prod', dest='in_prod', action='store_const', const=True,
                                  help='Show whether AMI is executable in prod.', default=False)
+    parser_listamis.add_argument('--show-tags', dest='show_tags', action='store_const', const=True,
+                                 help='Show any additional tags on the AMI', default=False)
 
     parser_liststragglers = subparsers.add_parser(
         'liststragglers', help='List hostclasses for which AMIs have not been recently promoted')
@@ -167,7 +169,7 @@ def run():
                                        args.hostclass), key=bakery.ami_timestamp)
         now = datetime.utcnow()
         for ami in amis:
-            bakery.pretty_print_ami(ami, now, in_prod=args.in_prod)
+            bakery.pretty_print_ami(ami, now, in_prod=args.in_prod, show_tags=args.show_tags)
         if not amis:
             sys.exit(1)
     elif args.mode == "liststragglers":

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -76,6 +76,10 @@ def get_parser():
                                       help='Display the latest ami for this stage or later', type=str)
     parser_listlatestami.add_argument('--hostclass', dest='hostclass', required=True,
                                       help='Display the latest ami for this hostclass.', type=str)
+    parser_listlatestami.add_argument('--in-prod', dest='in_prod', action='store_const', const=True,
+                                      help='Show whether AMI is executable in prod.', default=False)
+    parser_listlatestami.add_argument('--show-tags', dest='show_tags', action='store_const', const=True,
+                                      help='Show any additional tags on the AMI', default=False)
 
     parser_deleteami = subparsers.add_parser('deleteami', help='Delete AMI')
     parser_deleteami.set_defaults(mode="deleteami")
@@ -171,7 +175,6 @@ def run():
         now = datetime.utcnow()
         headers, output = bakery.tabilize_amis(
             amis=amis,
-            age_since_when=now,
             in_prod=args.in_prod,
             show_tags=args.show_tags
         )
@@ -186,7 +189,12 @@ def run():
         bakery = DiscoBake()
         ami = bakery.find_ami(args.stage, args.hostclass)
         if ami:
-            bakery.pretty_print_ami(ami)
+            headers, output = bakery.tabilize_amis(
+                amis=[ami],
+                in_prod=args.in_prod,
+                show_tags=args.show_tags
+            )
+            print_table(headers=headers, rows=output)
         else:
             sys.exit(1)
     elif args.mode == "deleteami":

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -9,6 +9,7 @@ import argparse
 from collections import OrderedDict
 from datetime import datetime
 
+from bin import print_table
 from disco_aws_automation import DiscoBake, HostclassTemplating
 from disco_aws_automation.disco_aws_util import run_gracefully
 from disco_aws_automation.disco_logging import configure_logging
@@ -168,8 +169,13 @@ def run():
                                        args.state,
                                        args.hostclass), key=bakery.ami_timestamp)
         now = datetime.utcnow()
-        for ami in amis:
-            bakery.pretty_print_ami(ami, now, in_prod=args.in_prod, show_tags=args.show_tags)
+        headers, output = bakery.tabilize_amis(
+            amis=amis,
+            age_since_when=now,
+            in_prod=args.in_prod,
+            show_tags=args.show_tags
+        )
+        print_table(output, headers)
         if not amis:
             sys.exit(1)
     elif args.mode == "liststragglers":

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import sys
 import argparse
 from collections import OrderedDict
-from datetime import datetime
 
 from bin import print_table
 from disco_aws_automation import DiscoBake, HostclassTemplating

--- a/bin/disco_bake.py
+++ b/bin/disco_bake.py
@@ -166,19 +166,23 @@ def run():
         ami_ids = [args.ami] if args.ami else None
         instance_ids = [args.instance] if args.instance else None
         bakery = DiscoBake()
-        amis = sorted(bakery.list_amis(ami_ids,
-                                       instance_ids,
-                                       args.stage,
-                                       args.product_line,
-                                       args.state,
-                                       args.hostclass), key=bakery.ami_timestamp)
-        now = datetime.utcnow()
+        amis = sorted(
+            bakery.list_amis(
+                ami_ids,
+                instance_ids,
+                args.stage,
+                args.product_line,
+                args.state,
+                args.hostclass
+            ),
+            key=bakery.ami_timestamp
+        )
         headers, output = bakery.tabilize_amis(
             amis=amis,
             in_prod=args.in_prod,
             show_tags=args.show_tags
         )
-        print_table(output, headers)
+        print_table(headers=headers, rows=output)
         if not amis:
             sys.exit(1)
     elif args.mode == "liststragglers":

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -113,7 +113,7 @@ class DiscoBake(object):
 
         print(output)
 
-    def tabilize_amis(self, amis, age_since_when, in_prod=False, show_tags=False):
+    def tabilize_amis(self, amis, age_since_when=None, in_prod=False, show_tags=False):
         age_since_when = age_since_when or datetime.datetime.utcnow()
 
         headers = ["ID", "Created", "Name", "State", "Stage", "Product Line", "Age"]

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -113,6 +113,49 @@ class DiscoBake(object):
 
         print(output)
 
+    def tabilize_amis(self, amis, age_since_when, in_prod=False, show_tags=False):
+        age_since_when = age_since_when or datetime.datetime.utcnow()
+
+        headers = ["ID", "Created", "Name", "State", "Stage", "Product Line", "Age"]
+
+        if in_prod:
+            headers.append("Production")
+
+        if show_tags:
+            headers.append("Tags")
+
+        output = []
+
+        for ami in amis:
+            name = ami.name
+            creation_time = self.get_ami_creation_time(ami)
+
+            if ami.name and AMI_NAME_PATTERN.match(ami.name):
+                name = self.ami_hostclass(ami)
+            info = {
+                "ID": ami.id,
+                "Created": str(creation_time),
+                "Name": name,
+                "State": ami.state,
+                "Stage": ami.tags.get("stage"),
+                "Product Line": ami.tags.get("productline"),
+                "Age": DiscoBake.time_diff_in_hours(age_since_when, creation_time)
+            }
+
+            if show_tags:
+                ami_tags = [':'.join([key, value])
+                            for key, value in ami.tags.iteritems()
+                            if key not in ["stage", "productline"]]
+                info["Tags"] = ', '.join(ami_tags)
+
+            if in_prod:
+                info["Production"] = "prod" if self.is_prod_ami(ami) else "non-prod"
+
+            output.append(info)
+
+        return headers, output
+
+
     def option(self, key):
         '''Returns an option from the [bake] section of the disco_aws.ini config file'''
         return self._config.get("bake", key)

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -114,6 +114,15 @@ class DiscoBake(object):
         print(output)
 
     def tabilize_amis(self, amis, age_since_when=None, in_prod=False, show_tags=False):
+        """
+        Convenience function for tabulating a list of AMIs such that they can be printed more easily by
+        the print_table function.
+        :param amis: List of AMIs to tabulate.
+        :param age_since_when: Time to compare the AMIs against. Defaults to now.
+        :param in_prod: If True, shows whether the AMIs are available in prod. Defaults to False.
+        :param show_tags: If True, shows the tags applied to the AMI. Defaults to False.
+        :return: A tuple of (headers, rows) for use with the print_table function.
+        """
         age_since_when = age_since_when or datetime.datetime.utcnow()
 
         headers = ["ID", "Created", "Name", "State", "Stage", "Product Line", "Age"]
@@ -154,7 +163,6 @@ class DiscoBake(object):
             output.append(info)
 
         return headers, output
-
 
     def option(self, key):
         '''Returns an option from the [bake] section of the disco_aws.ini config file'''

--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -83,7 +83,7 @@ class DiscoBake(object):
         time_diff = now - old_time
         return int(time_diff.total_seconds() / 60 / 60)
 
-    def pretty_print_ami(self, ami, age_since_when=None, in_prod=False):
+    def pretty_print_ami(self, ami, age_since_when=None, in_prod=False, show_tags=False):
         '''Prints an a pretty AMI description to the standard output'''
         name = ami.name
         age_since_when = age_since_when or datetime.datetime.utcnow()
@@ -101,6 +101,12 @@ class DiscoBake(object):
             ami.tags.get("productline", "-"),
             DiscoBake.time_diff_in_hours(age_since_when, creation_time),
         )
+
+        if show_tags:
+            ami_tags = [':'.join([key, value])
+                        for key, value in ami.tags.iteritems()
+                        if key not in ["stage", "productline"]]
+            output += ', '.join(ami_tags)
 
         if in_prod:
             output += "     prod" if self.is_prod_ami(ami) else " non-prod"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Added a new `--show-tags` option to `disco_bake.py listamis` that prints
all of the tags added to the AMI, except for the stage and productline
tags, as those are already displayed in their own columns. Currently,
the tags are displayed in the format of `key:value, key:value,...`.

Also added headers support using the `print_table` function previously
only used for the listpolicies subcommand of disco_autoscale.py.