### PR TITLE
Persist spotinst ebs volumes

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -243,6 +243,9 @@ class DiscoElastigroup(BaseGroup):
 
         if len(bdms) == 0:
             bdms = None
+        else:
+            # automatically take snapshots of EBS volumes so data isn't lost if the instance goes down
+            strategy['shouldPersistBlockDevices'] = True
 
         network_interfaces = [
             {"deleteOnTermination": True,

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -245,7 +245,9 @@ class DiscoElastigroup(BaseGroup):
             bdms = None
         else:
             # automatically take snapshots of EBS volumes so data isn't lost if the instance goes down
-            strategy['shouldPersistBlockDevices'] = True
+            strategy['persistence'] = {
+                'shouldPersistBlockDevices': True
+            }
 
         network_interfaces = [
             {"deleteOnTermination": True,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -410,4 +410,4 @@ class DiscoElastigroupTests(TestCase):
             group_name=""
         )
 
-        self.assertTrue(config['group']['strategy'].get('shouldPersistBlockDevices'))
+        self.assertTrue(config['group']['strategy'].get('persistence', {}).get('shouldPersistBlockDevices'))


### PR DESCRIPTION
Rebased on top of #240 to get unit test fixes. Will wait for that to be merged first


Enable `shouldPersistBlockDevices` feature for any hostclass with EBS volumes. This will cause spotinst to take snapshots every 5 minutes. This makes it mostly safe to use spotinst with EBS hostclasses. Spotinst will keep the latest 2 snapshots so we don't need to worry about cleaning them up