### PR TITLE
Capture Stdout From Tests

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.9"
+__version__ = "2.0.10"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -61,7 +61,7 @@ module Nose
     #
     command_args = [
       test_dir == Nose::UNIT_TEST_DIR ? unit_test_vars : "",
-      "nosetests -s",
+      "nosetests",
       test_dir == Nose::UNIT_TEST_DIR ? unit_test_params : "",
       "--where=#{Dir.pwd}",
       "--where=#{ProjectPaths::PACKAGE_DIR}",


### PR DESCRIPTION
The stdout from our unit tests is growing quite a bit. We should hide
it.