### PR TITLE
AL-1220 Fix Integration Tests

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.13"
+__version__ = "2.0.14"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/helpers/integration_helpers.py
+++ b/test/helpers/integration_helpers.py
@@ -12,7 +12,7 @@ from StringIO import StringIO
 import boto
 
 
-TEST_HOSTCLASS = "mhcntp"
+TEST_HOSTCLASS = "mhcbanana"
 
 CREATE_AMI_EXPR = re.compile(r"Created.*?AMI (?P<ami_id>ami-\w+)")
 
@@ -71,6 +71,7 @@ class IntegrationTest(TestCase):
                                    env=os.environ.copy())  # relay ASIAQ_CONFIG and any other env vars
 
         output = process.communicate()[0]
+
         captured_stdout.write(output)
 
         if not quiet and process.returncode:

--- a/test/integration/test_disco_aws.py
+++ b/test/integration/test_disco_aws.py
@@ -8,7 +8,7 @@ from re import search, MULTILINE
 from time import time, sleep
 
 from test.helpers.disco_env_helpers import DiscoEnv, DISCO_AWS_COMMAND
-from test.helpers.integration_helpers import IntegrationTest
+from test.helpers.integration_helpers import IntegrationTest, TEST_HOSTCLASS
 
 
 class TestDiscoAWS(IntegrationTest, DiscoEnv, TestCase):
@@ -32,7 +32,7 @@ class TestDiscoAWS(IntegrationTest, DiscoEnv, TestCase):
             "--env", self.env_name,
             "isready",
             "--hostclass", hostclass
-        ])
+        ], quiet=True)
         isready_regex = r"i-[0-9a-f]+ is ready$"
         return search(isready_regex, output, MULTILINE)
 
@@ -40,9 +40,9 @@ class TestDiscoAWS(IntegrationTest, DiscoEnv, TestCase):
         """
         Instance isready test
         """
-        max_wait = 300
+        max_wait = 600
         max_time = time() + max_wait
-        hostclass = "mhcbanana"
+        hostclass = "mhcadminproxy"
 
         last_status = self.isready(hostclass)
         while time() < max_time and not last_status:
@@ -102,7 +102,7 @@ class TestDiscoAWS(IntegrationTest, DiscoEnv, TestCase):
         """
         Start instance with provision and then terminate it
         """
-        hostclass = "mhcntp"
+        hostclass = TEST_HOSTCLASS
         self.provision(hostclass)
         self.assertRegexpMatches(self.instances(), hostclass)
         self.terminate(hostclass)

--- a/test/integration/test_disco_bake.py
+++ b/test/integration/test_disco_bake.py
@@ -54,7 +54,7 @@ class DiscoBakeTests(IntegrationTest):
 
     @cleanup_amis
     def test_promote(self, captured_stdout):
-        '''Verify we can bake a pahse 2 AMI and promote it'''
+        '''Verify we can bake a phase 2 AMI and promote it'''
         output = self._bake(captured_stdout, "bake", "--use-local-ip", "--hostclass", TEST_HOSTCLASS)
 
         ami_id = self.get_ami_id(output)

--- a/test/integration/test_disco_iam.py
+++ b/test/integration/test_disco_iam.py
@@ -1,7 +1,6 @@
 """
 Integration tests for disco_iam.py
 """
-from unittest import skip
 from test.helpers.integration_helpers import IntegrationTest
 
 LISTUSERS_CMD = "disco_iam.py listusers"

--- a/test/integration/test_disco_iam.py
+++ b/test/integration/test_disco_iam.py
@@ -39,7 +39,6 @@ class DiscoIamTests(IntegrationTest):
         """
         self.assertTrue(self.run_cmd(LISTROLES_CMD).count("\n") >= 2)
 
-    @skip("enable this if you require identity providers")
     def test_list_providers(self):
         """
         List providers


### PR DESCRIPTION
There were a few things breaking the integration tests:

* A bunch of tests were using mhcntp, which no longer exists. Changed
that to mhcbanana.
* The tests were expecting mhcadminproxy to come up, but the pipeline
they were using didnt have mhcadminproxy. Added mhcadminproxy to the
pipeline.
* The integration tests were calling `disco_aws.py isready`, but not
handling when that command would return an error code. Changed how we
were calling that method to not error out if the command failed.

Additionally, enabled the identity provider integration test, now that
we use them, and fixed a typo.