### PR TITLE
Fixed VPC peering update

### DIFF
--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -67,7 +67,7 @@ class DiscoVPCPeerings(object):
                                "not implemented yet."
                                .format(existing_peerings - desired_peerings))
 
-        if not dry_run:
+        if not dry_run and missing_peerings:
             self._create_peering_connections(missing_peerings)
             self._create_peering_routes(missing_peerings)
 

--- a/disco_aws_automation/disco_vpc_peerings.py
+++ b/disco_aws_automation/disco_vpc_peerings.py
@@ -48,7 +48,9 @@ class DiscoVPCPeerings(object):
                                             peering_config.target_endpoint.vpc['VpcId']}
                 peering_endpoints = {peering.source_endpoint.vpc['VpcId'],
                                      peering.target_endpoint.vpc['VpcId']}
-                return peering_config_endpoints == peering_endpoints
+                if peering_config_endpoints == peering_endpoints:
+                    return True
+            return False
 
         missing_peerings = set.copy(desired_peerings)
         for peering in desired_peerings:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.18"
+__version__ = "2.0.19"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.22"
+__version__ = "2.0.23"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.23"
+__version__ = "2.0.24"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.21"
+__version__ = "2.0.22"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.20"
+__version__ = "2.0.21"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_vpc_peerings.py
+++ b/test/unit/test_disco_vpc_peerings.py
@@ -125,8 +125,8 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
 
         self.disco_vpc_peerings.update_peering_connections(MagicMock())
 
-        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with(set())
-        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with(set())
+        self.disco_vpc_peerings._create_peering_connections.assert_not_called()
+        self.disco_vpc_peerings._create_peering_routes.assert_not_called()
 
     def test_not_update_existing_peerings_2(self):
         """Test existing peering is not udpated (configured peering source & target opposite of existing)"""
@@ -141,5 +141,5 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
 
         self.disco_vpc_peerings.update_peering_connections(MagicMock())
 
-        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with(set())
-        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with(set())
+        self.disco_vpc_peerings._create_peering_connections.assert_not_called()
+        self.disco_vpc_peerings._create_peering_routes.assert_not_called()

--- a/test/unit/test_disco_vpc_peerings.py
+++ b/test/unit/test_disco_vpc_peerings.py
@@ -98,28 +98,36 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
 
         self.assertItemsEqual(actual, expected)
 
+
+class DiscoVPCPeeringsTests2(unittest.TestCase):
+    """Test DiscoVPCPeerings"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.disco_vpc_peerings = DiscoVPCPeerings()
+        cls.vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
+        cls.vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
+        cls.peering_connection_1 = PeeringConnection(cls.vpc_endpoint_1, cls.vpc_endpoint_2)
+        cls.peering_connection_2 = PeeringConnection(cls.vpc_endpoint_2, cls.vpc_endpoint_1)
+
     def test_update_missing_peerings(self):
         """Test missing peering is udpated"""
-        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
-        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
-        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
+
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
         self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value=set())
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 
         self.disco_vpc_peerings.update_peering_connections(MagicMock())
 
-        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with({peering_connection_1})
-        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with({peering_connection_1})
+        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with({self.peering_connection_1})
+        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with({self.peering_connection_1})
 
     def test_not_update_existing_peerings_1(self):
         """Test existing peering is not udpated (configured peering source & target match with existing)"""
-        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
-        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
-        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
-        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={peering_connection_1})
+
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={self.peering_connection_1})
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 
@@ -130,12 +138,9 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
 
     def test_not_update_existing_peerings_2(self):
         """Test existing peering is not udpated (configured peering source & target opposite of existing)"""
-        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
-        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
-        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
-        peering_connection_2 = PeeringConnection(vpc_endpoint_2, vpc_endpoint_1)
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
-        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={peering_connection_2})
+
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={self.peering_connection_2})
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 

--- a/test/unit/test_disco_vpc_peerings.py
+++ b/test/unit/test_disco_vpc_peerings.py
@@ -99,8 +99,8 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
         self.assertItemsEqual(actual, expected)
 
 
-class DiscoVPCPeeringsTests2(unittest.TestCase):
-    """Test DiscoVPCPeerings"""
+class DiscoVPCPeeringsUpdateTests(unittest.TestCase):
+    """Test DiscoVPCPeerings during VPC update"""
 
     @classmethod
     def setUpClass(cls):
@@ -113,21 +113,33 @@ class DiscoVPCPeeringsTests2(unittest.TestCase):
     def test_update_missing_peerings(self):
         """Test missing peering is udpated"""
 
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
-        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value=set())
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(
+            return_value={self.peering_connection_1}
+        )
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(
+            return_value=set()
+        )
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 
         self.disco_vpc_peerings.update_peering_connections(MagicMock())
 
-        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with({self.peering_connection_1})
-        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with({self.peering_connection_1})
+        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with(
+            {self.peering_connection_1}
+        )
+        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with(
+            {self.peering_connection_1}
+        )
 
     def test_not_update_existing_peerings_1(self):
         """Test existing peering is not udpated (configured peering source & target match with existing)"""
 
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
-        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={self.peering_connection_1})
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(
+            return_value={self.peering_connection_1}
+        )
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(
+            return_value={self.peering_connection_1}
+        )
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 
@@ -139,8 +151,12 @@ class DiscoVPCPeeringsTests2(unittest.TestCase):
     def test_not_update_existing_peerings_2(self):
         """Test existing peering is not udpated (configured peering source & target opposite of existing)"""
 
-        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={self.peering_connection_1})
-        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={self.peering_connection_2})
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(
+            return_value={self.peering_connection_1}
+        )
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(
+            return_value={self.peering_connection_2}
+        )
         self.disco_vpc_peerings._create_peering_connections = MagicMock()
         self.disco_vpc_peerings._create_peering_routes = MagicMock()
 

--- a/test/unit/test_disco_vpc_peerings.py
+++ b/test/unit/test_disco_vpc_peerings.py
@@ -6,7 +6,7 @@ from mock import MagicMock, patch
 from moto import mock_ec2
 
 from disco_aws_automation import DiscoVPC
-from disco_aws_automation.disco_vpc_peerings import DiscoVPCPeerings, PeeringConnection
+from disco_aws_automation.disco_vpc_peerings import DiscoVPCPeerings, PeeringConnection, PeeringEndpoint
 
 from test.helpers.patch_disco_aws import get_mock_config
 
@@ -97,3 +97,49 @@ class DiscoVPCPeeringsTests(unittest.TestCase):
         ]
 
         self.assertItemsEqual(actual, expected)
+
+    def test_update_missing_peerings(self):
+        """Test missing peering is udpated"""
+        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
+        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
+        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value=set())
+        self.disco_vpc_peerings._create_peering_connections = MagicMock()
+        self.disco_vpc_peerings._create_peering_routes = MagicMock()
+
+        self.disco_vpc_peerings.update_peering_connections(MagicMock())
+
+        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with({peering_connection_1})
+        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with({peering_connection_1})
+
+    def test_not_update_existing_peerings_1(self):
+        """Test existing peering is not udpated (configured peering source & target match with existing)"""
+        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
+        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
+        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={peering_connection_1})
+        self.disco_vpc_peerings._create_peering_connections = MagicMock()
+        self.disco_vpc_peerings._create_peering_routes = MagicMock()
+
+        self.disco_vpc_peerings.update_peering_connections(MagicMock())
+
+        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with(set())
+        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with(set())
+
+    def test_not_update_existing_peerings_2(self):
+        """Test existing peering is not udpated (configured peering source & target opposite of existing)"""
+        vpc_endpoint_1 = PeeringEndpoint('test-env1', 'test-type', 'intranet', {'VpcId': 'vpc-1234'})
+        vpc_endpoint_2 = PeeringEndpoint('test-env2', 'test-type', 'intranet', {'VpcId': 'vpc-5678'})
+        peering_connection_1 = PeeringConnection(vpc_endpoint_1, vpc_endpoint_2)
+        peering_connection_2 = PeeringConnection(vpc_endpoint_2, vpc_endpoint_1)
+        self.disco_vpc_peerings._get_peerings_from_config = MagicMock(return_value={peering_connection_1})
+        self.disco_vpc_peerings._get_existing_peerings = MagicMock(return_value={peering_connection_2})
+        self.disco_vpc_peerings._create_peering_connections = MagicMock()
+        self.disco_vpc_peerings._create_peering_routes = MagicMock()
+
+        self.disco_vpc_peerings.update_peering_connections(MagicMock())
+
+        self.disco_vpc_peerings._create_peering_connections.assert_called_once_with(set())
+        self.disco_vpc_peerings._create_peering_routes.assert_called_once_with(set())


### PR DESCRIPTION
When running `disco_vpc_ui.py update`, the code would attempt to create another VPC peering between two VPCs if peering direction in disco_vpc.ini is the opposite.

*Example:*
```
disco_vpc_ui.py peerings --list
pcx-7069e219   active   test-peering-1<->test-peering-2 10.254.124.0/22<->10.253.92.0/22
```
*Note: current VPC peering has as requester test-peering-1, and as accepter test-peering-2*

**disco_vpc.ini**
```
connection_12=test-peering-2:sandbox/intranet test-peering-1:sandbox/intranet
connection_13=test-peering-2:sandbox/maintenance test-peering-1:sandbox/intranet
```
*Note: configured VPC peering has as requester test-peering-2, and as accepter is test-peering-1*