### PR TITLE
Al 1254 add previous ami to socify event

### DIFF
--- a/disco_aws_automation/socify_helper.py
+++ b/disco_aws_automation/socify_helper.py
@@ -12,12 +12,10 @@ logger = logging.getLogger(__name__)
 
 SocifyConfig = {
     "EVENT": {
-        "basePath": "/event",
-        "use_data": True
+        "basePath": "/event"
     },
     "VALIDATE": {
-        "basePath": "/validate",
-        "use_data": False
+        "basePath": "/validate"
     }
 }
 
@@ -65,13 +63,17 @@ class SocifyHelper(object):
         :param kwargs:  additional named arguments used to populate the data section of the json
         :return: a dictionary containing the socify event data
         """
-        event_info = {'status': status}
+        event_info = {'amiId': self._ami_id}
+        if status:
+            event_info['status'] = status
+
         if self._sub_command:
             event_info['sub_cmd'] = self._sub_command
+
         event_info.update(kwargs)
         return event_info
 
-    def _build_json(self, function_name, status=None, **kwargs):
+    def _build_json(self, status=None, **kwargs):
         """
         Build the event JSON for the Socify Event associated to the executed command
         :param function_name: The Socify function name which will be invoked
@@ -79,13 +81,11 @@ class SocifyHelper(object):
         :param kwargs:  additional named arguments used to populate the data section of the json
         :return: The Event JSON for the associated Event
         """
-        event_json = {"ticketId": self._ticket_id,
-                      "cmd": self._command,
-                      "amiId": self._ami_id}
+        event_json = {'ticketId': self._ticket_id,
+                      'cmd': self._command}
 
-        # Add data section if required
-        if SocifyConfig[function_name]["use_data"]:
-            event_json["data"] = self._build_json_data(status, **kwargs)
+        # Add data section
+        event_json['data'] = self._build_json_data(status, **kwargs)
 
         return event_json
 
@@ -105,7 +105,7 @@ class SocifyHelper(object):
         """
         url = self._build_url(function_name)
 
-        data = self._build_json(function_name, status, **kwargs)
+        data = self._build_json(status, **kwargs)
         headers = {'Content-Type': 'application/json'}
         return requests.post(url=url, headers=headers, json=data)
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.21"
+__version__ = "2.0.22"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -161,6 +161,16 @@ class DiscoDeployTests(TestCase):
         self._amis_by_name[ami.name] = ami
         return ami
 
+    def init_latest_running_amis(self):
+        '''Create the mock result for DiscoDeploy.get_latest_running_amis'''
+        amis = {
+            "mhcintegrated": self._amis_by_name['mhcintegrated 2'],
+            "mhcfoo": self._amis_by_name['mhcfoo 4'],
+            "mhcbluegreen": self._amis_by_name['mhcbluegreen 1'],
+            "mhcbluegreennondeployable": self._amis_by_name['mhcbluegreennondeployable 1']
+        }
+        self._ci_deploy.get_latest_running_amis = MagicMock(return_value=amis)
+
     def setUp(self):
         self._environment_name = "foo"
         self._disco_group = create_autospec(DiscoGroup, instance=True)
@@ -200,6 +210,7 @@ class DiscoDeployTests(TestCase):
         self.add_ami('mhcbluegreennondeployable 2', 'untested')
         self.add_ami('mhctimedautoscale 1', 'untested')
         self._ci_deploy._disco_bake.list_amis = MagicMock(return_value=self._amis)
+        self.init_latest_running_amis()
 
     def test_filter_with_ami_restriction(self):
         '''Tests that filter on ami works when ami is set'''

--- a/test/unit/test_socify_helper.py
+++ b/test/unit/test_socify_helper.py
@@ -69,12 +69,12 @@ class SocifyHelperTest(TestCase):
 
     def test_build_json(self):
         """Test socify build event json data"""
-        data = self._soc_helper._build_json("EVENT", SocifyHelper.SOC_EVENT_OK, hostclass="myhostclass",
+        data = self._soc_helper._build_json(SocifyHelper.SOC_EVENT_OK, hostclass="myhostclass",
                                             msg="test was successfull")
         res_data = {"ticketId": "AL-1102",
                     "cmd": "ExampleEvent",
-                    "amiId": "ami_12345",
                     "data": {"status": SocifyHelper.SOC_EVENT_OK,
+                             "amiId": "ami_12345",
                              "hostclass": "myhostclass",
                              "msg": "test was successfull"}}
         self.assertEqual(data, res_data)
@@ -82,12 +82,12 @@ class SocifyHelperTest(TestCase):
     def test_build_json_with_sub_command(self):
         """Test socify build event json data"""
         self._soc_helper._sub_command = 'mySubCommand'
-        data = self._soc_helper._build_json("EVENT", SocifyHelper.SOC_EVENT_OK, hostclass="myhostclass",
+        data = self._soc_helper._build_json(SocifyHelper.SOC_EVENT_OK, hostclass="myhostclass",
                                             msg="test was successfull")
         res_data = {"ticketId": "AL-1102",
                     "cmd": "ExampleEvent",
-                    "amiId": "ami_12345",
                     "data": {"status": SocifyHelper.SOC_EVENT_OK,
+                             "amiId": "ami_12345",
                              "sub_cmd": "mySubCommand",
                              "hostclass": "myhostclass",
                              "msg": "test was successfull"}}


### PR DESCRIPTION
- Send previous AMI ID when invoking Socify Event
- Move the AMI ID to the data section of the Socify Json Object
