### PR TITLE
fix modifying a spotinst group without block device mappings

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -688,4 +688,4 @@ class DiscoElastigroup(BaseGroup):
                     if device.snapshot_id:
                         bdm['ebs']['snapshotId'] = device.snapshot_id
                     bdms.append(bdm)
-        return bdms
+        return bdms or None

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.22"
+__version__ = "2.0.23"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
spotinst wants us to use None instead of a empty list for missing block device mappings