### PR TITLE
Fix Subnet Tags KeyError

### DIFF
--- a/disco_aws_automation/disco_rds.py
+++ b/disco_aws_automation/disco_rds.py
@@ -499,7 +499,7 @@ class DiscoRDS(object):
         subnet_ids = []
         for subnet in subnets:
             tags = tag2dict(subnet['Tags'])
-            if tags['meta_network'] == 'intranet':
+            if tags.get('meta_network') == 'intranet':
                 subnet_ids.append(str(subnet['SubnetId']))
         return subnet_ids
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.27"
+__version__ = "2.0.28"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -8,7 +8,7 @@ nose-cov>=1.5,<2
 mock>=1.0.1,<2
 coverage<4
 # Additional libraries
-moto>=0.4.30
+moto>=0.4.30,<1
 six>=1.7.3
 requests-mock>=1.3.0,<2
 parameterized>=0.6.1,<1


### PR DESCRIPTION
Not all of our subnets are tagged with their meta_network. For example,
the AlertLogic subnet. So let's handle the case where the subnet does
not have a meta_network tag.