### PR TITLE
Handle spotinst timeout error

### DIFF
--- a/disco_aws_automation/exceptions.py
+++ b/disco_aws_automation/exceptions.py
@@ -189,3 +189,7 @@ class UnknownDeploymentStrategyException(Exception):
 
 class SpotinstApiException(Exception):
     """Raised if Spotinst API problem encountered"""
+
+
+class SpotinstRateExceededException(Exception):
+    """Raised if Spotinst API throttled a request"""

--- a/disco_aws_automation/resource_helper.py
+++ b/disco_aws_automation/resource_helper.py
@@ -221,9 +221,10 @@ class Jitter(object):
     """
     BASE = 3
 
-    def __init__(self):
+    def __init__(self, min_wait=0):
         self._time_passed = 0
         self._cycle = 0
+        self._min_wait = min_wait
 
     def backoff(self):
         """
@@ -232,7 +233,7 @@ class Jitter(object):
         The minimum value 'cycle' can take is 1
         """
         self._cycle += 1
-        new_interval = min(MAX_POLL_INTERVAL, randint(Jitter.BASE, self._cycle * 3))
+        new_interval = self._min_wait + min(MAX_POLL_INTERVAL, randint(Jitter.BASE, self._cycle * 3))
         time.sleep(new_interval)
         self._time_passed += new_interval
         return self._time_passed

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -124,7 +124,7 @@ class SpotinstClient(object):
 
     def _throttle_spotinst_call(self, fun, *args, **kwargs):
         max_time = 5 * 60
-        jitter = Jitter(min_wait=60) # wait atleast 60 seconds because our rate limit resets then
+        jitter = Jitter(min_wait=60)  # wait atleast 60 seconds because our rate limit resets then
         time_passed = 0
 
         while True:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.28"
+__version__ = "2.0.29"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.29"
+__version__ = "2.0.30"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.30"
+__version__ = "2.0.31"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,1 @@
+tasks/lint/pylintrc


### PR DESCRIPTION
Spotinst is currently having issues where requests will just hang until they timeout. They are hanging for up to 15mins so set a reasonable timeout in requests so we don't wait that long and then catch those exceptions.

Added retry logic to automatically keep retrying with jitter. This will happen either when Spotinst throws a rate exceeded error (http code 429) or if the request hangs.