### PR TITLE
dont modify spotinst instance type

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -248,7 +248,7 @@ class DiscoElastigroup(BaseGroup):
             group = existing_groups[0]
             roll_needed = self._modify_group(
                 group, desired_size=desired_size, min_size=min_size, max_size=max_size,
-                instance_type=instance_type, load_balancers=load_balancers, image_id=image_id, tags=tags,
+                load_balancers=load_balancers, image_id=image_id, tags=tags,
                 instance_profile_name=instance_profile_name, block_device_mappings=block_device_mappings,
                 spotinst_reserve=spotinst_reserve
             )
@@ -315,7 +315,7 @@ class DiscoElastigroup(BaseGroup):
         return {'name': new_group_name}
 
     def _modify_group(self, existing_group, desired_size=None, min_size=None, max_size=None,
-                      instance_type=None, load_balancers=None, image_id=None, tags=None,
+                      load_balancers=None, image_id=None, tags=None,
                       instance_profile_name=None, block_device_mappings=None, spotinst_reserve=None):
         new_config = copy.deepcopy(existing_group)
 
@@ -329,9 +329,6 @@ class DiscoElastigroup(BaseGroup):
             new_config['capacity']['maximum'] = max_size
         if desired_size is not None:
             new_config['capacity']['target'] = desired_size
-        if instance_type is not None:
-            instance_type_config = self._get_instance_type_config(instance_type)
-            new_config['compute']['instanceTypes'] = instance_type_config
         if load_balancers:
             launch_spec = new_config['compute']['launchSpecification']
             launch_spec['loadBalancersConfig'] = self._get_load_balancer_config(load_balancers)

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -1,4 +1,5 @@
 """Contains SpotinstClient class for taking to the Spotinst REST API"""
+import logging
 import requests
 from requests import ReadTimeout
 
@@ -6,6 +7,7 @@ from disco_aws_automation.exceptions import SpotinstApiException, SpotinstRateEx
 from disco_aws_automation.resource_helper import Jitter
 
 SPOTINST_API_HOST = 'https://api.spotinst.io'
+logger = logging.getLogger(__name__)
 
 
 class SpotinstClient(object):
@@ -131,6 +133,10 @@ class SpotinstClient(object):
             try:
                 return fun(*args, **kwargs)
             except SpotinstRateExceededException:
+                if logging.getLogger().level == logging.DEBUG:
+                    logger.exception("Failed to run %s.", fun)
+
                 if time_passed > max_time:
                     raise
+
                 time_passed = jitter.backoff()

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -1,7 +1,7 @@
 """Contains SpotinstClient class for taking to the Spotinst REST API"""
 import logging
 import requests
-from requests import ReadTimeout
+from requests.exceptions import ReadTimeout
 
 from disco_aws_automation.exceptions import SpotinstApiException, SpotinstRateExceededException
 from disco_aws_automation.resource_helper import Jitter

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.32"
+__version__ = "2.0.33"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/requirements.pip
+++ b/requirements.pip
@@ -11,6 +11,6 @@ netaddr>=0.7.12,<1
 python-dateutil>=2.4.0,<3
 semantic_version>=2.4.2
 requests_aws4auth<2
-requests>2.14.2,<3
+requests>=2.14.2,<3
 # Since aws ES is 1.5 we must pin elasticsearch-py as follows:
 elasticsearch>=1.0.0,<2.0.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -11,5 +11,6 @@ netaddr>=0.7.12,<1
 python-dateutil>=2.4.0,<3
 semantic_version>=2.4.2
 requests_aws4auth<2
+requests>2.14.2,<3
 # Since aws ES is 1.5 we must pin elasticsearch-py as follows:
 elasticsearch>=1.0.0,<2.0.0

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -211,35 +211,6 @@ class DiscoElastigroupTests(TestCase):
         })
         self.assertEqual(group['name'], 'mhcfoo')
 
-    def test_update_instance_type(self):
-        """Verifies changing instance type an existing group"""
-        group = self.mock_elastigroup(hostclass='mhcfoo')
-        self.elastigroup.spotinst_client.get_groups.return_value = [group]
-
-        self.elastigroup.create_or_update_group(
-            hostclass="mhcfoo",
-            spotinst=True,
-            instance_type="m3.medium:m4.large"
-        )
-
-        expected_request = {
-            'group': {
-                'name': ANY,
-                'capacity': ANY,
-                'compute': {
-                    'instanceTypes': {
-                        'spot': ['m3.medium', 'm4.large'],
-                        'ondemand': 'm3.medium'
-                    },
-                    'availabilityZones': ANY,
-                    'launchSpecification': ANY
-                },
-                'scheduling': ANY
-            }
-        }
-
-        self.elastigroup.spotinst_client.update_group.assert_called_once_with(group['id'], expected_request)
-
     def test_update_image_id(self):
         """Verifies updating AMI of an existing group"""
         group = self.mock_elastigroup(hostclass='mhcfoo')

--- a/test/unit/test_spotinst_client.py
+++ b/test/unit/test_spotinst_client.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import requests_mock
 from mock import patch
-from requests import ReadTimeout
+from requests.exceptions import ReadTimeout
 
 from disco_aws_automation.exceptions import SpotinstRateExceededException
 from disco_aws_automation.spotinst_client import SpotinstClient


### PR DESCRIPTION
Remove option to modify instance type for existing Elastigroups.
This option doesn't exist for regular ASGs. There is an issue where
instance type will default to the default instance type if not passing
in a instance type when modifying the group.