### PR TITLE
Added vpc_exists check on vpc creation

### DIFF
--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -476,6 +476,7 @@ class DiscoVPC(object):
 
         # Create the new VPC
         self.vpc = throttled_call(self.boto3_ec2.create_vpc, CidrBlock=str(vpc_cidr))['Vpc']
+        throttled_call(self.boto3_ec2.get_waiter('vpc_exists').wait, VpcIds=[self.vpc['VpcId']])
         throttled_call(self.boto3_ec2.get_waiter('vpc_available').wait, VpcIds=[self.vpc['VpcId']])
 
         # Add tags to VPC

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.36"
+__version__ = "2.0.37"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Sometimes it take time for `VpcId` to become available, which makes check for `vpc_available` to fail.