### PR TITLE
Spotinst improvements

### DIFF
--- a/disco_aws_automation/base_group.py
+++ b/disco_aws_automation/base_group.py
@@ -87,7 +87,7 @@ class BaseGroup(object):
                                associate_public_ip_address=None, user_data=None, tags=None,
                                instance_profile_name=None, block_device_mappings=None, group_name=None,
                                create_if_exists=False, termination_policies=None, spotinst=False,
-                               spotinst_reserve=None, roll_if_needed=False):
+                               spotinst_reserve=None):
         """
         Create a new autoscaling group or update an existing one
         """

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -341,7 +341,7 @@ class DiscoAutoscale(BaseGroup):
                                associate_public_ip_address=None, user_data=None, tags=None,
                                instance_profile_name=None, block_device_mappings=None, group_name=None,
                                create_if_exists=False, termination_policies=None, spotinst=False,
-                               spotinst_reserve=None, roll_if_needed=False):
+                               spotinst_reserve=None):
         """
         Create a new autoscaling group or update an existing one
         """

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -348,8 +348,7 @@ class DiscoAWS(object):
     def provision(self, ami, hostclass=None, owner=None, instance_type=None, monitoring_enabled=True,
                   extra_space=None, extra_disk=None, iops=None, no_destroy=False, min_size=None,
                   desired_size=None, max_size=None, testing=False, termination_policies=None, chaos=None,
-                  create_if_exists=False, group_name=None, spotinst=False, spotinst_reserve=None,
-                  roll_if_needed=False):
+                  create_if_exists=False, group_name=None, spotinst=False, spotinst_reserve=None):
         # TODO move key, instance_type, monitoring enabled, extra_space, extra_disk into config file.
         # Pylint thinks this function has too many arguments and too many local variables
         # pylint: disable=R0913, R0914
@@ -426,8 +425,7 @@ class DiscoAWS(object):
             termination_policies=termination_policies,
             group_name=group_name,
             spotinst=is_spotinst,
-            spotinst_reserve=spotinst_reserve,
-            roll_if_needed=roll_if_needed
+            spotinst_reserve=spotinst_reserve
         )
 
         self.create_scaling_schedule(min_size, desired_size, max_size, group_name=group['name'])
@@ -626,7 +624,7 @@ class DiscoAWS(object):
             self.log_metrics.delete_log_groups(hostclass)
 
     def spinup(self, hostclass_dicts, stage=None, no_smoke=False, testing=False, create_if_exists=False,
-               group_name=None, roll_if_needed=False):
+               group_name=None):
         # Pylint thinks this function has too many local variables
         # pylint: disable=R0914,R0912
         """
@@ -698,8 +696,7 @@ class DiscoAWS(object):
                     create_if_exists=create_if_exists,
                     group_name=group_name,
                     spotinst=hdict.get("spotinst"),
-                    spotinst_reserve=hdict.get('spotinst_reserve'),
-                    roll_if_needed=roll_if_needed
+                    spotinst_reserve=hdict.get('spotinst_reserve')
                 )
                 for (hostclass, termination_policies, hdict) in hostclass_iter]
 

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -390,8 +390,7 @@ class DiscoDeploy(object):
                 if deployable and self._set_testing_mode(hostclass, group_instances, False):
                     logger.info("Successfully left testing mode for group %s", new_group['name'])
                     # Update ASG to exit testing mode and attach to the normal ELB if applicable.
-                    self._disco_aws.spinup([new_group_config], group_name=new_group['name'],
-                                           roll_if_needed=True)
+                    self._disco_aws.spinup([new_group_config], group_name=new_group['name'])
                     if uses_elb:
                         try:
                             # get the list of instance Ids again because they might have changed after

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -7,8 +7,6 @@ import os
 from base64 import b64encode
 from itertools import groupby
 
-import boto3
-
 from disco_aws_automation.resource_helper import throttled_call, tag2dict
 from .spotinst_client import SpotinstClient
 from .base_group import BaseGroup

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -24,7 +24,6 @@ class DiscoElastigroup(BaseGroup):
 
     def __init__(self, environment_name):
         self.environment_name = environment_name
-        self.boto3_autoscale = boto3.client('ec2')
 
         if os.environ.get('SPOTINST_TOKEN'):
             self.spotinst_client = SpotinstClient(os.environ.get('SPOTINST_TOKEN'))

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -160,7 +160,7 @@ class DiscoGroup(BaseGroup):
                                associate_public_ip_address=None, user_data=None, tags=None,
                                instance_profile_name=None, block_device_mappings=None, group_name=None,
                                create_if_exists=False, termination_policies=None, spotinst=False,
-                               spotinst_reserve=None, roll_if_needed=False):
+                               spotinst_reserve=None):
         """
         Create a new autoscaling group or update an existing one
         """
@@ -200,8 +200,7 @@ class DiscoGroup(BaseGroup):
             create_if_exists=create_if_exists,
             termination_policies=termination_policies,
             spotinst=spotinst,
-            spotinst_reserve=spotinst_reserve,
-            roll_if_needed=roll_if_needed
+            spotinst_reserve=spotinst_reserve
         )
 
     def clean_configs(self):

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -59,21 +59,46 @@ class SpotinstClient(object):
         """
         self._make_throttled_request(path='aws/ec2/group/%s' % group_id, method='delete')
 
-    def roll_group(self, group_id, batch_percentage, grace_period):
+    def roll_group(self, group_id, batch_percentage, grace_period, health_check_type):
         """
         Spin up a new set of instances and then shutdown the old instances
         :param str group_id: Id of Elastigroup to perform roll operation on
         :param int batch_percentage: Percentage of the group to roll at a time
         :param int grace_period: Amount of time in seconds to wait for instances to pass health checks
+        :param str health_check_type: Type of health check to use. Available options are ELB, TARGET_GROUP,
+                                      MLB, HCS, EC2, NONE
         """
         request = {
             "batchSizePercentage": batch_percentage,
             "gracePeriod": grace_period,
             "strategy": {
-                "action": "REPLACE_SERVER"
+                "action": "REPLACE_SERVER",
+                "healthCheckType": health_check_type
             }
         }
         self._make_throttled_request(path='aws/ec2/group/%s/roll' % group_id, data=request, method='put')
+
+    def get_deployments(self, group_id):
+        """
+        Get list of current and past deployements for a Elastigroup
+        :param str group_id:
+        :return list[dict]:
+        """
+        response = self._make_throttled_request(path='aws/ec2/group/%s/roll' % group_id, method='get')
+        return response['response']['items']
+
+    def get_roll_status(self, group_id, deploy_id):
+        """
+        Get info about a specific deployment for a group
+        :param str group_id:
+        :param str deploy_id:
+        :return dict:
+        """
+        response = self._make_throttled_request(
+            path='aws/ec2/group/%s/roll/%s' % (group_id, deploy_id),
+            method='get'
+        )
+        return response['response']['items'][0]
 
     def _make_throttled_request(self, method, path, params=None, data=None):
         return self._throttle_spotinst_call(self._make_request, method, path, params, data)

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -1,7 +1,7 @@
 """Contains SpotinstClient class for taking to the Spotinst REST API"""
 import logging
 import requests
-from requests.exceptions import ReadTimeout
+from requests.exceptions import Timeout, ConnectionError
 
 from disco_aws_automation.exceptions import SpotinstApiException, SpotinstRateExceededException
 from disco_aws_automation.resource_helper import Jitter
@@ -101,7 +101,7 @@ class SpotinstClient(object):
                 },
                 timeout=60
             )
-        except ReadTimeout:
+        except (ConnectionError, Timeout):
             raise SpotinstRateExceededException("Rate exceeded while calling {0} {1}".format(method, path))
 
         if response.status_code == 401:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.39"
+__version__ = "2.1.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.38"
+__version__ = "2.0.39"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/test/unit/test_disco_deploy.py
+++ b/test/unit/test_disco_deploy.py
@@ -505,7 +505,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'min_size': 2, 'desired_size': 2, 'max_size': 2,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
-                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name, roll_if_needed=True)])
+                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
         self._disco_group.delete_groups.assert_not_called()
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
@@ -554,7 +554,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
-                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name, roll_if_needed=True)])
+                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
         self._disco_group.delete_groups.assert_called_once_with(group_name=old_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
@@ -632,7 +632,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'min_size': 2, 'desired_size': 3, 'max_size': 4,
                     'integration_test': "blue_green_service", 'smoke_test': 'no',
-                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name, roll_if_needed=True)])
+                    'hostclass': 'mhcbluegreen'}], group_name=new_group.name)])
         self._disco_group.delete_groups.assert_called_once_with(group_name=new_group.name, force=True)
         self._disco_elb.delete_elb.assert_called_once_with("mhcbluegreen", testing=True)
 
@@ -831,8 +831,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
                     'min_size': 3, 'desired_size': 6, 'max_size': 6}],
-                  group_name=new_group.name,
-                  roll_if_needed=True)])
+                  group_name=new_group.name)])
         self._disco_aws.create_scaling_schedule.assert_called_once_with(
             min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
             desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',
@@ -866,8 +865,7 @@ class DiscoDeployTests(TestCase):
              call([{'ami': 'ami-12345678', 'sequence': 1, 'deployable': 'yes',
                     'integration_test': None, 'smoke_test': 'no', 'hostclass': 'mhctimedautoscale',
                     'min_size': 2, 'desired_size': 3, 'max_size': 4}],
-                  group_name=new_group.name,
-                  roll_if_needed=True)])
+                  group_name=new_group.name)])
         self._disco_aws.create_scaling_schedule.assert_called_once_with(
             min_size='3@30 16 * * 1-5:4@00 17 * * 1-5',
             desired_size='5@30 16 * * 1-5:6@00 17 * * 1-5',

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -448,3 +448,37 @@ class DiscoElastigroupTests(TestCase):
         self.elastigroup = DiscoElastigroup(ENVIRONMENT_NAME)
 
         self.assertFalse(self.elastigroup.is_spotinst_enabled())
+
+    def test_get_instances(self):
+        """Testing getting list of instances for a Elastigroup"""
+        self.elastigroup.boto3_ec.describe_instances = MagicMock(return_value={
+            'Reservations': [{
+                'Instances': [{
+                    'InstanceId': 'i-2345',
+                    'Tags': [{
+                        'Key': 'group_name',
+                        'Value': 'mhcfoo_1234'
+                    }]
+                }]
+            }],
+            'NextToken': None
+        })
+
+        instances = self.elastigroup.get_instances()
+
+        self.elastigroup.boto3_ec.describe_instances.assert_called_once_with(
+            Filters=[
+                {'Name': 'tag:spotinst', 'Values': ['True']},
+                {'Name': 'tag:environment', 'Values': ['moon']},
+                {
+                    'Name': 'instance-state-name',
+                    'Values': ['pending', 'running', 'shutting-down', 'stopping', 'stopped']
+                }
+            ])
+
+        expected = [{
+            'instance_id': 'i-2345',
+            'group_name': 'mhcfoo_1234'
+        }]
+
+        self.assertEqual(expected, instances)

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -181,7 +181,7 @@ class DiscoElastigroupTests(TestCase):
                     'launchSpecification': {
                         "iamRole": None,
                         'userData': None,
-                        'tags': None,
+                        'tags': [{'tagKey': 'spotinst', 'tagValue': 'True'}],
                         'blockDeviceMappings': None,
                         'imageId': None,
                         'networkInterfaces': None,

--- a/test/unit/test_disco_elastigroup.py
+++ b/test/unit/test_disco_elastigroup.py
@@ -181,7 +181,8 @@ class DiscoElastigroupTests(TestCase):
                     'launchSpecification': {
                         "iamRole": None,
                         'userData': None,
-                        'tags': [{'tagKey': 'spotinst', 'tagValue': 'True'}],
+                        'tags': [{'tagKey': 'group_name', 'tagValue': ANY},
+                                 {'tagKey': 'spotinst', 'tagValue': 'True'}],
                         'blockDeviceMappings': None,
                         'imageId': None,
                         'networkInterfaces': None,

--- a/test/unit/test_spotinst_client.py
+++ b/test/unit/test_spotinst_client.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import requests_mock
 from mock import patch
-from requests.exceptions import ReadTimeout
+from requests.exceptions import ReadTimeout, ConnectTimeout, ConnectionError
 
 from disco_aws_automation.exceptions import SpotinstRateExceededException
 from disco_aws_automation.spotinst_client import SpotinstClient
@@ -177,8 +177,8 @@ class DiscoSpotinstClientTests(TestCase):
             {'status_code': 429},
             {'exc': ReadTimeout},
             {'status_code': 429},
-            {'status_code': 429},
-            {'exc': ReadTimeout},
+            {'exc': ConnectTimeout},
+            {'exc': ConnectionError},
             {'json': {
                 'response': {
                     'items': [{

--- a/test/unit/test_spotinst_client.py
+++ b/test/unit/test_spotinst_client.py
@@ -146,9 +146,81 @@ class DiscoSpotinstClientTests(TestCase):
             }
         })
 
-        self.spotinst_client.roll_group('sig-5af12785', 100, 100)
+        self.spotinst_client.roll_group('sig-5af12785', 100, 100, health_check_type='EC2')
 
         self.assertEqual(len(requests.request_history), 1)
+
+    @requests_mock.mock()
+    def test_get_deployments(self, requests):
+        """Test getting a list of deployments for a group"""
+        requests.get('https://api.spotinst.io/aws/ec2/group/sig-5af12785/roll', json={
+            "request": {
+                "id": "3213e42e-455e-4901-a185-cc3eb65fac5f",
+                "url": "/aws/ec2/group/sig-5af12785/roll",
+                "method": "PUT",
+                "time": "2016-02-10T15:49:11.911Z"
+            },
+            "response": {
+                "items": [
+                    {
+                        "id": "sbgd-c47a527a",
+                        "status": "finished",
+                        "progress": {
+                            "unit": "percent",
+                            "value": 100
+                        },
+                        "createdAt": "2017-05-24T12:12:39.000+0000",
+                        "updatedAt": "2017-05-24T12:19:17.000+0000"
+                    },
+                    {
+                        "id": "sbgd-f789ec37",
+                        "status": "in_progress",
+                        "progress": {
+                            "unit": "percent",
+                            "value": 0
+                        },
+                        "createdAt": "2017-05-24T20:13:37.000+0000",
+                        "updatedAt": "2017-05-24T20:15:17.000+0000"
+                    }],
+                "count": 2
+            }
+        })
+
+        deployments = self.spotinst_client.get_deployments('sig-5af12785')
+
+        self.assertEqual(len(requests.request_history), 1)
+        self.assertEqual(len(deployments), 2)
+
+    @requests_mock.mock()
+    def test_get_roll_status(self, requests):
+        """Test getting the status of a deployment"""
+        requests.get('https://api.spotinst.io/aws/ec2/group/sig-5af12785/roll/sbgd-c47a527a', json={
+            "request": {
+                "id": "3213e42e-455e-4901-a185-cc3eb65fac5f",
+                "url": "/aws/ec2/group/sig-5af12785/roll",
+                "method": "PUT",
+                "time": "2016-02-10T15:49:11.911Z"
+            },
+            "response": {
+                "items": [
+                    {
+                        "id": "sbgd-c47a527a",
+                        "status": "finished",
+                        "progress": {
+                            "unit": "percent",
+                            "value": 100
+                        },
+                        "createdAt": "2017-05-24T12:12:39.000+0000",
+                        "updatedAt": "2017-05-24T12:19:17.000+0000"
+                    }],
+                "count": 1
+            }
+        })
+
+        status = self.spotinst_client.get_roll_status('sig-5af12785', 'sbgd-c47a527a')
+
+        self.assertEqual(len(requests.request_history), 1)
+        self.assertEqual(status['status'], 'finished')
 
     # pylint: disable=unused-argument
     @requests_mock.mock()


### PR DESCRIPTION
1. Use Deploy status API for getting status of Elastigroup deployments
2. Don't try to update ELBs with modify_group method. use update_elb instead
3. Tag Elastigroups with Spotinst=True
4. Catch more types of timeout exceptions when calling Spotinst API
5. Use boto to get Spotinst instances instead of Spotinst API due to performance issues