### PR TITLE
Updating spotinst should update ELB

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -283,7 +283,8 @@ class DiscoElastigroup(BaseGroup):
             self._modify_group(
                 group, desired_size=desired_size, min_size=min_size, max_size=max_size,
                 image_id=image_id, tags=tags, instance_profile_name=instance_profile_name,
-                block_device_mappings=block_device_mappings, spotinst_reserve=spotinst_reserve
+                block_device_mappings=block_device_mappings, spotinst_reserve=spotinst_reserve,
+                load_balancers=load_balancers
             )
 
             return {'name': group['name']}
@@ -345,7 +346,7 @@ class DiscoElastigroup(BaseGroup):
 
     def _modify_group(self, existing_group, desired_size=None, min_size=None, max_size=None,
                       image_id=None, tags=None, instance_profile_name=None, block_device_mappings=None,
-                      spotinst_reserve=None):
+                      spotinst_reserve=None, load_balancers=None):
         new_config = copy.deepcopy(existing_group)
 
         if min_size is not None:
@@ -378,6 +379,9 @@ class DiscoElastigroup(BaseGroup):
         group_id = new_config.pop('id')
 
         self.spotinst_client.update_group(group_id, {'group': new_config})
+
+        if load_balancers:
+            self.update_elb(load_balancers, group_name=existing_group['name'])
 
     def _delete_group(self, group_id):
         """Delete an elastigroup by group id"""

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -147,7 +147,7 @@ class SpotinstClient(object):
             errors = ret['response'].get('errors')
 
             for error in errors:
-                if error.get('code') == 'RequestLimitExceeded':
+                if error.get('code') in ("Throttling", "RequestLimitExceeded"):
                     raise SpotinstRateExceededException("Rate exceeded while calling {0} {1}"
                                                         .format(method, path))
 

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -145,6 +145,12 @@ class SpotinstClient(object):
             status = ret['response']['status']
             req_id = ret['request']['id']
             errors = ret['response'].get('errors')
+
+            for error in errors:
+                if error.get('code') == 'RequestLimitExceeded':
+                    raise SpotinstRateExceededException("Rate exceeded while calling {0} {1}"
+                                                        .format(method, path))
+
             raise SpotinstApiException(
                 "Unknown Spotinst API error encountered: {0} {1}. RequestId {2}"
                 .format(status, errors, req_id)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -355,7 +355,11 @@ class DiscoElastigroupTests(TestCase):
         group = self.mock_elastigroup(hostclass='mhcfoo')
         self.elastigroup.spotinst_client.get_groups.return_value = [group]
 
-        self.elastigroup.create_or_update_group(hostclass="mhcfoo", load_balancers=["elb-newelb"], spotinst=True)
+        self.elastigroup.create_or_update_group(
+            hostclass="mhcfoo",
+            load_balancers=["elb-newelb"],
+            spotinst=True
+        )
 
         self.elastigroup.spotinst_client.roll_group.assert_called_once_with(group['id'], ANY, ANY, 'ELB')
 

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -350,6 +350,15 @@ class DiscoElastigroupTests(TestCase):
 
         self.elastigroup.spotinst_client.update_group.assert_called_once_with(group['id'], expected_request)
 
+    def test_update_group_update_elb(self):
+        """Verifies updating group also updates ELB"""
+        group = self.mock_elastigroup(hostclass='mhcfoo')
+        self.elastigroup.spotinst_client.get_groups.return_value = [group]
+
+        self.elastigroup.create_or_update_group(hostclass="mhcfoo", load_balancers=["elb-newelb"], spotinst=True)
+
+        self.elastigroup.spotinst_client.roll_group.assert_called_once_with(group['id'], ANY, ANY, 'ELB')
+
     def test_create_recurring_group_action(self):
         """Verifies recurring actions are created for Elastigroups"""
         group = self.mock_elastigroup(hostclass='mhcfoo')

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -349,6 +349,7 @@ class DiscoElastigroupTests(TestCase):
         }
 
         self.elastigroup.spotinst_client.update_group.assert_called_once_with(group['id'], expected_request)
+        self.elastigroup.spotinst_client.roll_group.assert_called_once_with(group['id'], ANY, ANY, 'ELB')
 
     def test_update_group_update_elb(self):
         """Verifies updating group also updates ELB"""
@@ -361,6 +362,22 @@ class DiscoElastigroupTests(TestCase):
             spotinst=True
         )
 
+        expected_request = {
+            'group': {
+                'compute': {
+                    'launchSpecification': {
+                        'loadBalancersConfig': {
+                            'loadBalancers': [{
+                                'name': 'elb-newelb',
+                                'type': 'CLASSIC'
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+
+        self.elastigroup.spotinst_client.update_group.assert_called_with(group['id'], expected_request)
         self.elastigroup.spotinst_client.roll_group.assert_called_once_with(group['id'], ANY, ANY, 'ELB')
 
     def test_create_recurring_group_action(self):

--- a/tests/unit/test_spotinst_client.py
+++ b/tests/unit/test_spotinst_client.py
@@ -248,7 +248,24 @@ class DiscoSpotinstClientTests(TestCase):
         responses = [
             {'status_code': 429},
             {'exc': ReadTimeout},
-            {'status_code': 429},
+            {
+                'status_code': 400,
+                'json': {
+                    'request': {
+                        'id': 'b4415046-bb2d-4338-9b8a-73a405a6fe0c'
+                    },
+                    'response': {
+                        'status': '',
+                        'errors': [{
+                            'message': 'Cant validate AMI',
+                            'code': 'CANT_VALIDATE_IMAGE'
+                        }, {
+                            'message': 'Request limit exceeded',
+                            'code': 'RequestLimitExceeded'
+                        }]
+                    }
+                }
+            },
             {'exc': ConnectTimeout},
             {'exc': ConnectionError},
             {'json': {


### PR DESCRIPTION
Fixes a bug where modifying a Spotinst Elastigroup won't make it use latest ELB because group doesn't get rolled