### PR TITLE
Minor cleanup of spotinst code

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -65,8 +65,10 @@ class DiscoElastigroup(BaseGroup):
     def get_existing_groups(self, hostclass=None, group_name=None):
         # get a dict for each group that matches the structure that would be returned by DiscoAutoscale
         # this dict needs to have at least all the fields that the interface specifies
-        groups = [
-            {
+        groups = []
+        for group in self._get_spotinst_groups(hostclass, group_name):
+            launch_spec = group['compute']['launchSpecification']
+            groups.append({
                 'name': group['name'],
                 'min_size': group['capacity']['minimum'],
                 'max_size': group['capacity']['maximum'],
@@ -77,19 +79,16 @@ class DiscoElastigroup(BaseGroup):
                     zone['subnetId'] for zone in group['compute']['availabilityZones']
                 ),
                 'load_balancers': [
-                    elb['name'] for elb
                     # loadBalancers will be None instead of a empty list if there is no ELB
-                    in (group['compute']['launchSpecification']['loadBalancersConfig']['loadBalancers'] or [])
+                    elb['name'] for elb in (launch_spec['loadBalancersConfig']['loadBalancers'] or [])
                 ],
-                'image_id': group['compute']['launchSpecification']['imageId'],
+                'image_id': launch_spec['imageId'],
                 'id': group['id'],
                 'type': 'spot',
                 # blockDeviceMappings will be None instead of a empty list if there is no ELB
-                'blockDeviceMappings': (group['compute']['launchSpecification']['blockDeviceMappings'] or []),
+                'blockDeviceMappings': (launch_spec.get('blockDeviceMappings') or []),
                 'scheduling': group.get('scheduling', {'tasks': []})
-            }
-            for group in self._get_spotinst_groups(hostclass, group_name)
-        ]
+            })
         groups.sort(key=lambda grp: grp['name'], reverse=True)
         return groups
 
@@ -630,6 +629,9 @@ class DiscoElastigroup(BaseGroup):
         self.spotinst_client.roll_group(group_id, batch_percentage, grace_period, health_check_type)
 
         if wait:
+            # wait for the deploy to appear in list
+            time.sleep(10)
+
             deployments = self.spotinst_client.get_deployments(group_id)
             deploy_id = deployments[-1]['id']
 
@@ -642,7 +644,8 @@ class DiscoElastigroup(BaseGroup):
                 roll_status = self.spotinst_client.get_roll_status(group_id, deploy_id)
                 if roll_status['status'] != 'in_progress':
                     if roll_status['status'] != 'finished':
-                        logger.error("Roll of group %s did not complete successfully", group_id)
+                        logger.error("Roll of group %s did not complete successfully with status %s",
+                                     group_id, roll_status['status'])
                     break
 
                 logger.info("Waiting for %s group to roll in order to update settings", group_id)

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
1. Add a short sleep before getting the status Spotinst roll to give Spotinst time to create the roll
2. Print out what the status was of a failed roll to make debugging easier
3. `blockDeviceMappings` can be missing from Spotinst config so handle that