### PR TITLE
Support Splitlines in disco_vpc.ini

### DIFF
--- a/disco_aws_automation/disco_vpc_gateways.py
+++ b/disco_aws_automation/disco_vpc_gateways.py
@@ -50,14 +50,14 @@ class DiscoVPCGateways(object):
         if internet_gateway:
             igw_routes = self.disco_vpc.get_config("{0}_igw_routes".format(network_name))
             if igw_routes:
-                igw_routes = igw_routes.split(" ")
+                igw_routes = igw_routes.split()
                 for igw_route in igw_routes:
                     route_tuples.append((igw_route, internet_gateway['InternetGatewayId']))
 
         if vpn_gateway:
             vgw_routes = self.disco_vpc.get_config("{0}_vgw_routes".format(network_name))
             if vgw_routes:
-                vgw_routes = vgw_routes.split(" ")
+                vgw_routes = vgw_routes.split()
                 for vgw_route in vgw_routes:
                     route_tuples.append((vgw_route, vpn_gateway['VpnGatewayId']))
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
It's legitimate to split an entry in an `.ini` file over multiple lines.
We'd really like to do this for some of the configuration in
disco_vpc.ini, so let's support that in our parsing of that file.

Now we'll split on all whitespace for the gateway options, which will
remove both the spaces as well as the newline characters.