### PR TITLE
Small spotinst tweaks

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -14,7 +14,8 @@ from .exceptions import TooManyAutoscalingGroups, SpotinstException, TimeoutErro
 
 logger = logging.getLogger(__name__)
 
-GROUP_ROLL_TIMEOUT = 300
+# max time to wait in seconds for instances to become healthy after a roll
+GROUP_ROLL_TIMEOUT = 1200
 
 
 class DiscoElastigroup(BaseGroup):
@@ -642,7 +643,7 @@ class DiscoElastigroup(BaseGroup):
 
             while current_time < stop_time:
                 roll_status = self.spotinst_client.get_roll_status(group_id, deploy_id)
-                if roll_status['status'] != 'in_progress':
+                if roll_status['status'] not in ('in_progress', 'starting'):
                     if roll_status['status'] != 'finished':
                         logger.error("Roll of group %s did not complete successfully with status %s",
                                      group_id, roll_status['status'])

--- a/disco_aws_automation/spotinst_client.py
+++ b/disco_aws_automation/spotinst_client.py
@@ -144,7 +144,7 @@ class SpotinstClient(object):
         if response.status_code != 200:
             status = ret['response']['status']
             req_id = ret['request']['id']
-            errors = ret['response'].get('errors')
+            errors = ret['response'].get('errors') or []
 
             for error in errors:
                 if error.get('code') in ("Throttling", "RequestLimitExceeded"):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.6"
+__version__ = "2.1.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -271,7 +271,8 @@ class DiscoElastigroupTests(TestCase):
 
     @parameterized.expand([
         ("53%", 47, None),
-        ("20", None, 20)
+        ("20", None, 20),
+        ("", 100, None)
     ])
     def test_update_spotinst_reserve(self, spotinst_reserve, risk, on_demand_count):
         """Verifies updating risk of an existing group"""


### PR DESCRIPTION
Catch correct status for Elastigroup rolls
Increase grace period for rolls
Don't assume API errors will have a error message