### PR TITLE
AL-1529 SSM Execute Should Handle No Output

### DIFF
--- a/disco_aws_automation/disco_ssm.py
+++ b/disco_aws_automation/disco_ssm.py
@@ -247,7 +247,7 @@ class DiscoSSM(object):
             Prefix=key
         )
 
-        keys_from_command = [entry['Key'] for entry in response['Contents']]
+        keys_from_command = [entry['Key'] for entry in response.get('Contents', [])]
 
         stdout_keys = [key for key in keys_from_command if key.endswith('stdout')]
         stderr_keys = [key for key in keys_from_command if key.endswith('stderr')]

--- a/disco_aws_automation/disco_ssm.py
+++ b/disco_aws_automation/disco_ssm.py
@@ -89,7 +89,7 @@ class DiscoSSM(object):
                 self.s3.head_bucket(Bucket=bucket_name)
                 arguments["OutputS3BucketName"] = bucket_name
             except ClientError:
-                logger.error(
+                logger.warning(
                     "Unable to access S3 bucket '%s', output limited to 2500 characters",
                     bucket_name
                 )

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.7"
+__version__ = "2.1.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_ssm.py
+++ b/tests/unit/test_disco_ssm.py
@@ -187,8 +187,8 @@ def _get_mock_s3():
             return {
                 'Contents': [{'Key': key} for key in data.keys() if key.startswith(Prefix)]
             }
-        else:
-            return {}
+
+        return {}
 
     def _mock_head_bucket(Bucket):
         if Bucket != MOCK_S3_BUCKET_NAME:


### PR DESCRIPTION
If a command does not generate any output, we should handle that case and not fail the command.

Added some unit tests to cover this case.

Also changed a logging statement from error to warning because that's what it really is...