### PR TITLE
NOM3248 DNO on PROD: Backup strategy

### DIFF
--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -127,6 +127,11 @@ class DynamoDbBackupCommand(CliCommand):
             backup_restore_parser.add_argument("--metanetwork", metavar="NAME",
                                                help="Metanetwork in which to launch pipeline assets")
 
+        backup_parser.add_argument("--backup_period", metavar="PERIOD",
+                                   help="Set period to backup schedule. \n"
+                                        "The format is: \"N [minutes|hours|days|weeks|months]\"\n"
+                                        "Example: --backup_period \"1 hours\"")
+
         restore_parser.add_argument("--from", dest="backup_dir",
                                     help="Previous backup to restore from (default: latest)")
         list_parser = subsub.add_parser("list", help="List existing backups")
@@ -151,7 +156,7 @@ class DynamoDbBackupCommand(CliCommand):
 
     def _create_backup(self, mgr):
         mgr.create_backup(self.args.table_name, force_update=self.args.force_reload,
-                          metanetwork=self.args.metanetwork)
+                          metanetwork=self.args.metanetwork, backup_period=self.args.backup_period)
 
     def _list(self, mgr):
         backups = mgr.list_backups(self.config.environment, self.args.table_name)

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -94,8 +94,7 @@ class AsiaqDataPipeline(object):
         return _optional_list_to_dict(self._param_values)
 
     def update_content(self, contents=None, parameter_definitions=None, param_values=None,
-                       template_name=None, log_location=None, subnet_id=None,
-                       backup_period=None):
+                       template_name=None, log_location=None, subnet_id=None):
         """
         Set the pipeline content (pipeline nodes, parameters and values) for this pipeline.
 
@@ -106,7 +105,6 @@ class AsiaqDataPipeline(object):
         if template_name:
             contents, parameter_definitions = _read_template(template_name)
         _update_defaults(contents, log_location, subnet_id)
-        _update_schedule(contents, backup_period)
         self._objects = contents
         self._params = parameter_definitions
         if param_values is not None:
@@ -127,11 +125,10 @@ class AsiaqDataPipeline(object):
 
     @classmethod
     def from_template(cls, template_name, name, description, tags=None, param_values=None,
-                      log_location=None, subnet_id=None, backup_period=None):
+                      log_location=None, subnet_id=None):
         """Create a new AsiaqDataPipeline object, populated from template in the configuration directory."""
         boto_objects, boto_parameters = _read_template(template_name)
         _update_defaults(boto_objects, log_location, subnet_id)
-        _update_schedule(boto_objects, backup_period)
         return cls(contents=boto_objects, parameter_definitions=boto_parameters,
                    name=name, description=description, tags=tags, param_values=param_values)
 
@@ -249,8 +246,7 @@ class AsiaqDataPipelineManager(object):
         self._dp_client.delete_pipeline(pipelineId=pipeline._id)
 
     def fetch_or_create(self, template_name, pipeline_name, pipeline_description, tags, log_location,
-                        force_update=False, metanetwork=None, availability_zone=None,
-                        backup_period=None):
+                        force_update=False, metanetwork=None, availability_zone=None):
         """
         If a pipeline with the given tags exists, return it; if not, create one with the given tags
         and name based on the provided pipeline, save it, and return it.
@@ -277,9 +273,8 @@ class AsiaqDataPipelineManager(object):
                 _LOG.info("Re-loading content of pipeline %s from template %s", pipeline._id, template_name)
                 if metanetwork:
                     subnet_id = self._find_subnet_id(metanetwork, availability_zone)
-                pipeline.update_content(template_name=template_name,
-                                        log_location=log_location, subnet_id=subnet_id,
-                                        backup_period=backup_period)
+                pipeline.update_content(template_name=template_name, log_location=log_location,
+                                        subnet_id=subnet_id)
                 self.save(pipeline)
             else:
                 self.fetch_content(pipeline)
@@ -288,8 +283,7 @@ class AsiaqDataPipelineManager(object):
                 subnet_id = self._find_subnet_id(metanetwork, availability_zone)
             pipeline = AsiaqDataPipeline.from_template(
                 template_name, pipeline_name, description=pipeline_description,
-                log_location=log_location, tags=tags, subnet_id=subnet_id,
-                backup_period=backup_period)
+                log_location=log_location, tags=tags, subnet_id=subnet_id)
             self.save(pipeline)
             _LOG.info("Created new pipeline %s", pipeline._id)
         return pipeline
@@ -446,21 +440,3 @@ def _update_defaults(pipeline_objects, log_location=None, subnet_id=None):
         new_fields[DataPipelineConsts.SUBNET_ID_FIELD] = subnet_id
     if new_fields:
         add_default_object_fields(pipeline_objects, new_fields)
-
-
-def _update_schedule(pipeline_objects, backup_period=None):
-    """
-    Update backup pipeline daily schedule and set backup_period. By default backup
-    period is 1 day
-    :param pipeline_objects:
-    :param backup_period:
-    :return:
-    """
-    if backup_period:
-        for pipeline_object in pipeline_objects:
-            if pipeline_object['id'] == DataPipelineConsts.DAILY_SCHEDULE:
-                fields = pipeline_object['fields']
-                for field in fields:
-                    if field['key'] == DataPipelineConsts.BACKUP_PERIOD:
-                        _LOG.info("Setting backup period to: %s", backup_period)
-                        field['stringValue'] = backup_period

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -94,8 +94,7 @@ class AsiaqDataPipeline(object):
         return _optional_list_to_dict(self._param_values)
 
     def update_content(self, contents=None, parameter_definitions=None, param_values=None,
-                       template_name=None, log_location=None, subnet_id=None,
-                       backup_period=None):
+                       template_name=None, log_location=None, subnet_id=None):
         """
         Set the pipeline content (pipeline nodes, parameters and values) for this pipeline.
 
@@ -106,7 +105,6 @@ class AsiaqDataPipeline(object):
         if template_name:
             contents, parameter_definitions = _read_template(template_name)
         _update_defaults(contents, log_location, subnet_id)
-        _update_daily_schedule(contents, backup_period)
         self._objects = contents
         self._params = parameter_definitions
         if param_values is not None:
@@ -176,7 +174,7 @@ class AsiaqDataPipelineManager(object):
             param_values=contents.get('parameterValues')
         )
 
-    def fetch_content(self, pipeline, backup_period=None):
+    def fetch_content(self, pipeline):
         "Populate the pipeline content fields of this pipeline object with the information fetched from AWS."
         if pipeline.has_content():
             raise DataPipelineStateException(
@@ -187,8 +185,7 @@ class AsiaqDataPipelineManager(object):
                                     pipelineId=pipeline._id, version='latest')
         pipeline.update_content(definition['pipelineObjects'],
                                 definition.get('parameterObjects'),
-                                definition.get('parameterValues'),
-                                backup_period=backup_period)
+                                definition.get('parameterValues'))
 
     def search_descriptions(self, name=None, tags=None):
         """
@@ -280,11 +277,10 @@ class AsiaqDataPipelineManager(object):
                 if metanetwork:
                     subnet_id = self._find_subnet_id(metanetwork, availability_zone)
                 pipeline.update_content(template_name=template_name,
-                                        log_location=log_location, subnet_id=subnet_id,
-                                        backup_period=backup_period)
+                                        log_location=log_location, subnet_id=subnet_id)
                 self.save(pipeline)
             else:
-                self.fetch_content(pipeline, backup_period=backup_period)
+                self.fetch_content(pipeline)
         else:
             if metanetwork:
                 subnet_id = self._find_subnet_id(metanetwork, availability_zone)

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -271,8 +271,8 @@ class AsiaqDataPipelineManager(object):
                 _LOG.info("Re-loading content of pipeline %s from template %s", pipeline._id, template_name)
                 if metanetwork:
                     subnet_id = self._find_subnet_id(metanetwork, availability_zone)
-                pipeline.update_content(template_name=template_name, log_location=log_location,
-                                        subnet_id=subnet_id)
+                pipeline.update_content(template_name=template_name,
+                                        log_location=log_location, subnet_id=subnet_id)
                 self.save(pipeline)
             else:
                 self.fetch_content(pipeline)

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -266,7 +266,6 @@ class AsiaqDataPipelineManager(object):
         searched = self.search_descriptions(tags=tags)
         subnet_id = None
         if searched:
-
             if len(searched) > 1:
                 raise DataPipelineStateException(
                     "Expected one pipeline with tags %s, found %s" % (tags, len(searched)))

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -94,7 +94,8 @@ class AsiaqDataPipeline(object):
         return _optional_list_to_dict(self._param_values)
 
     def update_content(self, contents=None, parameter_definitions=None, param_values=None,
-                       template_name=None, log_location=None, subnet_id=None):
+                       template_name=None, log_location=None, subnet_id=None,
+                       backup_period=None):
         """
         Set the pipeline content (pipeline nodes, parameters and values) for this pipeline.
 
@@ -105,6 +106,7 @@ class AsiaqDataPipeline(object):
         if template_name:
             contents, parameter_definitions = _read_template(template_name)
         _update_defaults(contents, log_location, subnet_id)
+        _update_daily_schedule(contents, backup_period)
         self._objects = contents
         self._params = parameter_definitions
         if param_values is not None:
@@ -276,7 +278,8 @@ class AsiaqDataPipelineManager(object):
                 if metanetwork:
                     subnet_id = self._find_subnet_id(metanetwork, availability_zone)
                 pipeline.update_content(template_name=template_name,
-                                        log_location=log_location, subnet_id=subnet_id)
+                                        log_location=log_location, subnet_id=subnet_id,
+                                        backup_period=backup_period)
                 self.save(pipeline)
             else:
                 self.fetch_content(pipeline)

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -106,7 +106,7 @@ class AsiaqDataPipeline(object):
         if template_name:
             contents, parameter_definitions = _read_template(template_name)
         _update_defaults(contents, log_location, subnet_id)
-        _update_daily_schedule(contents, backup_period)
+        _update_schedule(contents, backup_period)
         self._objects = contents
         self._params = parameter_definitions
         if param_values is not None:
@@ -131,7 +131,7 @@ class AsiaqDataPipeline(object):
         """Create a new AsiaqDataPipeline object, populated from template in the configuration directory."""
         boto_objects, boto_parameters = _read_template(template_name)
         _update_defaults(boto_objects, log_location, subnet_id)
-        _update_daily_schedule(boto_objects, backup_period)
+        _update_schedule(boto_objects, backup_period)
         return cls(contents=boto_objects, parameter_definitions=boto_parameters,
                    name=name, description=description, tags=tags, param_values=param_values)
 
@@ -448,7 +448,7 @@ def _update_defaults(pipeline_objects, log_location=None, subnet_id=None):
         add_default_object_fields(pipeline_objects, new_fields)
 
 
-def _update_daily_schedule(pipeline_objects, backup_period=None):
+def _update_schedule(pipeline_objects, backup_period=None):
     """
     Update backup pipeline daily schedule and set backup_period. By default backup
     period is 1 day

--- a/disco_aws_automation/disco_datapipeline.py
+++ b/disco_aws_automation/disco_datapipeline.py
@@ -25,8 +25,6 @@ class DataPipelineConsts(object):
     TEMPLATE_DIR = "datapipeline_templates"
     LOG_LOCATION_FIELD = "pipelineLogUri"
     SUBNET_ID_FIELD = 'subnetId'
-    BACKUP_PERIOD = 'period'
-    DAILY_SCHEDULE = 'DailySchedule'
 
 
 class DataPipelineMetadata(object):

--- a/disco_aws_automation/disco_dynamodb.py
+++ b/disco_aws_automation/disco_dynamodb.py
@@ -203,11 +203,12 @@ class AsiaqDynamoDbBackupManager(object):
                                              pipeline_description=pipeline_description,
                                              log_location=self._s3_url("logs"),
                                              metanetwork=metanetwork,
-                                             force_update=force_update,
-                                             backup_period=backup_period)
+                                             force_update=force_update)
         if start:
             param_values = self._get_table_params(table_name)
             param_values['myOutputS3Loc'] = self._s3_url(env, table_name)
+            if backup_period:
+                param_values['myDDBSchedulePeriod'] = backup_period
             start_resp = self._mgr.start(pipeline, param_values)
             self.logger.debug("Started pipeline, got response %s", start_resp)
 

--- a/disco_aws_automation/disco_dynamodb.py
+++ b/disco_aws_automation/disco_dynamodb.py
@@ -217,7 +217,7 @@ class AsiaqDynamoDbBackupManager(object):
         either a particular backup or the latest one.
         """
         env = self.config.environment
-        pipeline_name = "%s %s - restore" % (table_name, env)
+        pipeline_name = "%s restore - %s" % (table_name, env)
         pipeline_description = "DynamoDB backup restore pipeline for %s." % env
         tags = {'environment': env, 'template': self.RESTORE_PIPELINE_TEMPLATE, 'table_name': table_name}
         if not backup_dir:

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.9"
+__version__ = "2.1.10"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.8"
+__version__ = "2.1.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/sample_configuration/datapipeline_templates/dynamodb_backup.json
+++ b/sample_configuration/datapipeline_templates/dynamodb_backup.json
@@ -6,8 +6,8 @@
     "objects": [
         {
             "startAt": "FIRST_ACTIVATION_DATE_TIME",
-            "name": "DailySchedule",
-            "id": "DailySchedule",
+            "name": "SchedulePeriod",
+            "id": "SchedulePeriod",
             "period": "#{myDDBSchedulePeriod}",
             "type": "Schedule"
         },
@@ -16,7 +16,7 @@
             "name": "Default",
             "scheduleType": "CRON",
             "schedule": {
-                "ref": "DailySchedule"
+                "ref": "SchedulePeriod"
             },
             "failureAndRerunMode": "CASCADE",
             "role": "DataPipelineDefaultRole",

--- a/sample_configuration/datapipeline_templates/dynamodb_backup.json
+++ b/sample_configuration/datapipeline_templates/dynamodb_backup.json
@@ -8,7 +8,7 @@
             "startAt": "FIRST_ACTIVATION_DATE_TIME",
             "name": "DailySchedule",
             "id": "DailySchedule",
-            "period": "1 day",
+            "period": "#{myDDBSchedulePeriod}",
             "type": "Schedule"
         },
         {
@@ -90,6 +90,12 @@
             "id": "myOutputS3Loc",
             "type": "AWS::S3::ObjectKey",
             "description": "Output S3 folder"
+        },
+        {
+            "id": "myDDBSchedulePeriod",
+            "type": "String",
+            "description": "DynamoDB schedule period",
+            "default": "1 day"
         }
     ]
 }

--- a/tests/unit/test_disco_datapipeline.py
+++ b/tests/unit/test_disco_datapipeline.py
@@ -140,7 +140,7 @@ class DataPipelineTest(TestCase):
         self.assertEquals(pipeline._name, "asdf")
         self.assertEquals(pipeline._description, "qwerty")
 
-    def test__from_template__with_backup_period(self):
+    def test__from_template__default_backup_period(self):
         "AsiaqDataPipeline.from_template with backup_period."
         default_period = "1 day"
         pipeline = AsiaqDataPipeline.from_template(
@@ -149,14 +149,6 @@ class DataPipelineTest(TestCase):
         self.assertEquals("DailySchedule", actual_pipeline_schedule['id'])
         actual_schedule_fields = actual_pipeline_schedule['fields']
         self.assertEquals(default_period, actual_schedule_fields[0]['stringValue'])
-        expected_backup_period = "6 hours"
-        pipeline = AsiaqDataPipeline.from_template(
-            name="asdf", description="qwerty", template_name="dynamodb_backup",
-            backup_period=expected_backup_period
-        )
-        actual_pipeline_schedule = pipeline._objects[0]
-        actual_schedule_fields = actual_pipeline_schedule['fields']
-        self.assertEquals(expected_backup_period, actual_schedule_fields[0]['stringValue'])
 
     def test__from_template__log_and_subnet_fields__fields_set(self):
         "AsiaqDataPipeline.from_template with a log location and subnet ID"
@@ -208,26 +200,6 @@ class DataPipelineTest(TestCase):
             [{'id': 'this', 'stringValue': 'will not'}, {'id': 'be', 'stringValue': 'overwritten'}],
             pipeline._param_values
         )
-
-    def test__update_content_with_backup_period(self):
-        "AsiaqDataPipeline.update_content with backup_period."
-        pipeline = AsiaqDataPipeline(name="asdf", description="qwerty")
-        origin_pipeline_objects = [{"fields": [{"stringValue": "2 hours", "key": "period"}],
-                                    "id": "DailySchedule", "name": "DailySchedule"}]
-        expected_backup_period = "2 hours"
-        param_defs = Mock()
-        pipeline.update_content(origin_pipeline_objects, param_defs)
-        for actual_pipeline_object in pipeline._objects:
-            actual_fields = actual_pipeline_object['fields']
-            for actual_field in actual_fields:
-                self.assertEquals(actual_field['stringValue'], expected_backup_period)
-        expected_backup_period = "3 hours"
-        pipeline.update_content(origin_pipeline_objects, param_defs,
-                                backup_period=expected_backup_period)
-        for actual_pipeline_object in pipeline._objects:
-            actual_fields = actual_pipeline_object['fields']
-            for actual_field in actual_fields:
-                self.assertEquals(actual_field['stringValue'], expected_backup_period)
 
     def test__update_content__old_values_new_empty__values_cleared(self):
         "AsiaqDataPipeline.update_content does not overwrite parameter values when not appropriate"

--- a/tests/unit/test_disco_datapipeline.py
+++ b/tests/unit/test_disco_datapipeline.py
@@ -136,7 +136,7 @@ class DataPipelineTest(TestCase):
         self.assertFalse(pipeline.is_persisted())
         self.assertTrue(pipeline.has_content())
         # nasty cherry-pick:
-        self.assertEquals("DailySchedule", pipeline._objects[0]['id'])
+        self.assertEquals("SchedulePeriod", pipeline._objects[0]['id'])
         self.assertEquals(pipeline._name, "asdf")
         self.assertEquals(pipeline._description, "qwerty")
 
@@ -647,7 +647,7 @@ class PipelineUtilityTest(TestCase):
             {'id': 'foo', 'name': 'bar', 'fields': []},
             {'id': 'Default', 'name': 'Deffy', 'fields': [
                 {'key': 'pipelineLogUri', 'stringValue': 's3://stupid-bucket'},
-                {'key': 'scheduleType', 'refValue': 'DailySchedule'}
+                {'key': 'scheduleType', 'refValue': 'SchedulePeriod'}
             ]},
             {'id': 'bar', 'name': 'baz', 'fields': []}
         ]
@@ -662,7 +662,7 @@ class PipelineUtilityTest(TestCase):
         object_list = [
             {'id': 'foo', 'name': 'bar', 'fields': []},
             {'id': 'Default', 'name': 'Deffy', 'fields': [
-                {'key': 'scheduleType', 'refValue': 'DailySchedule'}
+                {'key': 'scheduleType', 'refValue': 'SchedulePeriod'}
             ]},
             {'id': 'bar', 'name': 'baz', 'fields': []}
         ]
@@ -677,7 +677,7 @@ class PipelineUtilityTest(TestCase):
         "add_default_object_fields: existing log location gets updated, new field gets added"
         default_fields = [
             {'key': 'pipelineLogUri', 'stringValue': 's3://stupid-bucket'},
-            {'key': 'scheduleType', 'refValue': 'DailySchedule'}
+            {'key': 'scheduleType', 'refValue': 'SchedulePeriod'}
         ]
         object_list = [
             {'id': 'foo', 'name': 'bar', 'fields': []},

--- a/tests/unit/test_disco_datapipeline.py
+++ b/tests/unit/test_disco_datapipeline.py
@@ -140,15 +140,14 @@ class DataPipelineTest(TestCase):
         self.assertEquals(pipeline._name, "asdf")
         self.assertEquals(pipeline._description, "qwerty")
 
-    def test__from_template__default_backup_period(self):
-        "AsiaqDataPipeline.from_template with backup_period."
-        default_period = "1 day"
+    def test__from_template__backup_period_value(self):
+        "AsiaqDataPipeline.from_template test if from_template contains myDDBSchedulePeriod."
+        expected_period_value = "#{myDDBSchedulePeriod}"
         pipeline = AsiaqDataPipeline.from_template(
             name="asdf", description="qwerty", template_name="dynamodb_backup")
         actual_pipeline_schedule = pipeline._objects[0]
-        self.assertEquals("DailySchedule", actual_pipeline_schedule['id'])
         actual_schedule_fields = actual_pipeline_schedule['fields']
-        self.assertEquals(default_period, actual_schedule_fields[0]['stringValue'])
+        self.assertEquals(expected_period_value, actual_schedule_fields[0]['stringValue'])
 
     def test__from_template__log_and_subnet_fields__fields_set(self):
         "AsiaqDataPipeline.from_template with a log location and subnet ID"


### PR DESCRIPTION
Jira ticket for this pull request is [NOM3248](https://amplify-litco.atlassian.net/browse/NOM-3248?inbox=true). DNO backup has to be every 6 hours. This pull request is opened to add parameter for asiaq_cli.py which will give opportunity to set backup period into backup pipeline during back up creation through jenkins. Jenkins job which creates back pipeline could found here - [dynamodb_backup](https://astro-jenkins.mc.wgenhq.net/jenkins/job/dynamodb-backup/). In this jenkins job could be added parameter which will represent backup period and used to set it into pipeline.
Also in the pull request was added changes for formatting restore pipeline name, because it missed table name, which could be confusing.

Related pull request is - [asiaq_astro_config/1757](https://github.com/amplifylitco/asiaq_astro_config/pull/1757).