### PR TITLE
dont roll Elastigroups when updating ELB

### DIFF
--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -398,13 +398,6 @@ class DiscoDeploy(object):
                     self._disco_aws.spinup([new_group_config], group_name=new_group['name'])
                     if uses_elb:
                         try:
-                            # get the list of instance Ids again because they might have changed after
-                            # updating the group (this happens for Spotinst but not for regular ASGs)
-                            group_instance_ids = [
-                                inst['instance_id']
-                                for inst in self._disco_group.get_instances(group_name=new_group['name'])
-                            ]
-
                             # Wait until the new ASG is registered and marked as healthy by ELB.
                             self._disco_elb.wait_for_instance_health_state(hostclass=hostclass,
                                                                            instance_ids=group_instance_ids)

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -521,9 +521,6 @@ class DiscoElastigroup(BaseGroup):
 
         self.spotinst_client.update_group(existing_group['id'], group_config)
 
-        if new_lbs or extras:
-            self._roll_group(existing_group['id'], health_check_type='ELB', wait=True)
-
         return new_lbs, extras
 
     def get_launch_config(self, hostclass=None, group_name=None):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.8"
+__version__ = "2.1.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Spotinst recently made a change so that we don't need to roll a Elastigroup
when updating its ELB so change disco_deploy and disco_elastigroup to not do it

Also added some more unit tests