### PR TITLE
fix issue where instance types change m3.large when updating existing group

### DIFF
--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -451,7 +451,17 @@ class DiscoAutoscale(BaseGroup):
         return None
 
     def get_launch_config(self, hostclass=None, group_name=None):
-        """Returns all launch configurations for a hostclass if any exist, None otherwise"""
+        """Return launch config info for a hostclass, None otherwise"""
+        config = self._get_launch_config(hostclass=hostclass, group_name=group_name)
+
+        if config:
+            return {
+                'instance_type': config.instance_type
+            }
+
+        return None
+
+    def _get_launch_config(self, hostclass=None, group_name=None):
         config_list = self.get_launch_configs(hostclass=hostclass, group_name=group_name)
         return config_list[0] if config_list else None
 

--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -220,7 +220,7 @@ class DiscoAWS(object):
     def get_instance_type(self, hostclass):
         """Pull in instance_type existing launch configuration"""
         old_config = self.discogroup.get_launch_config(hostclass=hostclass)
-        return old_config.instance_type if old_config else DEFAULT_INSTANCE_TYPE
+        return old_config['instance_type'] if old_config else DEFAULT_INSTANCE_TYPE
 
     def get_meta_network_by_name(self, meta_network_name):
         """Return meta network instance by meta network name"""
@@ -254,16 +254,11 @@ class DiscoAWS(object):
         Create new BDM if parameters are specified, else create a device
         mapping from existing configuration.
         """
-        old_config = self.discogroup.get_launch_config(hostclass=hostclass)
-        if not old_config or any([extra_space, extra_disk, iops]):
-            block_device_mappings = [self.disco_storage.configure_storage(
-                hostclass=hostclass, ami_id=ami.id,
-                extra_space=extra_space, extra_disk=extra_disk, iops=iops,
-                ephemeral_disk_count=min([self.disco_storage.get_ephemeral_disk_count(i_type)
-                                          for i_type in instance_type.split(':')]))]
-        else:
-            block_device_mappings = [old_config.block_device_mappings]
-        return block_device_mappings
+        return [self.disco_storage.configure_storage(
+            hostclass=hostclass, ami_id=ami.id,
+            extra_space=extra_space, extra_disk=extra_disk, iops=iops,
+            ephemeral_disk_count=min([self.disco_storage.get_ephemeral_disk_count(i_type)
+                                      for i_type in instance_type.split(':')]))]
 
     def create_floating_interfaces(self, meta_network, hostclass):
         """Creates any floating interfaces as needed"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -284,7 +284,7 @@ class DiscoElastigroup(BaseGroup):
                 group, desired_size=desired_size, min_size=min_size, max_size=max_size,
                 image_id=image_id, tags=tags, instance_profile_name=instance_profile_name,
                 block_device_mappings=block_device_mappings, spotinst_reserve=spotinst_reserve,
-                load_balancers=load_balancers
+                load_balancers=load_balancers, instance_type=instance_type
             )
 
             return {'name': group['name']}
@@ -346,7 +346,7 @@ class DiscoElastigroup(BaseGroup):
 
     def _modify_group(self, existing_group, desired_size=None, min_size=None, max_size=None,
                       image_id=None, tags=None, instance_profile_name=None, block_device_mappings=None,
-                      spotinst_reserve=None, load_balancers=None):
+                      spotinst_reserve=None, load_balancers=None, instance_type=None):
         new_config = copy.deepcopy(existing_group)
 
         if min_size is not None:
@@ -369,6 +369,8 @@ class DiscoElastigroup(BaseGroup):
             new_config['compute']['launchSpecification']['iamRole'] = {
                 'name': instance_profile_name
             }
+        if instance_type is not None:
+            new_config['compute']['instanceTypes'] = self._get_instance_type_config(instance_type)
 
         # remove fields that can't be updated
         new_config['capacity'].pop('unit', None)
@@ -524,8 +526,24 @@ class DiscoElastigroup(BaseGroup):
         return new_lbs, extras
 
     def get_launch_config(self, hostclass=None, group_name=None):
-        """Create new launchconfig group name"""
-        raise Exception('Elastigroups don\'t have launch configs')
+        """Return launch config info for a hostclass, None otherwise"""
+        existing_groups = self._get_spotinst_groups(hostclass=hostclass, group_name=group_name)
+
+        if not existing_groups:
+            return None
+
+        on_demand_type = existing_groups[0]['compute']['instanceTypes']['ondemand']
+
+        # the first spot type is always the ondemand type so strip it out to avoid returning it twice
+        spot_types = existing_groups[0]['compute']['instanceTypes']['spot'][1:]
+
+        instance_type = ':'.join([on_demand_type] + spot_types)
+
+        logging.error(instance_type)
+
+        return {
+            'instance_type': instance_type
+        }
 
     def clean_configs(self):
         """Delete unused Launch Configurations in current environment"""

--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -539,8 +539,6 @@ class DiscoElastigroup(BaseGroup):
 
         instance_type = ':'.join([on_demand_type] + spot_types)
 
-        logging.error(instance_type)
-
         return {
             'instance_type': instance_type
         }

--- a/disco_aws_automation/disco_group.py
+++ b/disco_aws_automation/disco_group.py
@@ -150,8 +150,14 @@ class DiscoGroup(BaseGroup):
         )
 
     def get_launch_config(self, hostclass=None, group_name=None):
-        """Create new launchconfig group name"""
-        return self.autoscale.get_launch_config(hostclass, group_name)
+        """Return launch config info for a hostclass, None otherwise"""
+        return self._service_call_for_group(
+            'get_launch_config',
+            _hostclass=hostclass,
+            _group_name=group_name,
+            hostclass=hostclass,
+            group_name=group_name
+        )
 
     # pylint: disable=R0913, R0914
     def create_or_update_group(self, hostclass, desired_size=None, min_size=None, max_size=None,

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.13"
+__version__ = "2.1.14"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -558,7 +558,7 @@ class DiscoElastigroupTests(TestCase):
         self.assertEqual(expected, instances)
 
     def test_get_launch_config(self):
-        """Verifies Elastigroups are scaled down"""
+        """Testing getting launch config for a hostclass"""
         group = self.mock_elastigroup(hostclass='mhcfoo')
         self.elastigroup.spotinst_client.get_groups.return_value = [group]
 

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -358,8 +358,8 @@ class DiscoElastigroupTests(TestCase):
 
         self.elastigroup.spotinst_client.update_group.assert_called_once_with(group['id'], expected_request)
 
-        self.assertEquals({'elb-newelb'}, new_elbs)
-        self.assertEquals({'elb-1234'}, extras)
+        self.assertEqual({'elb-newelb'}, new_elbs)
+        self.assertEqual({'elb-1234'}, extras)
 
     def test_update_elb_missing_group(self):
         """Test updating ELB for group that doesn't exist"""
@@ -367,8 +367,8 @@ class DiscoElastigroupTests(TestCase):
 
         new_elbs, extras = self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
 
-        self.assertEquals(set(), new_elbs)
-        self.assertEquals(set(), extras)
+        self.assertEqual(set(), new_elbs)
+        self.assertEqual(set(), extras)
 
     def test_update_group_update_elb(self):
         """Verifies updating group also updates ELB"""
@@ -564,4 +564,4 @@ class DiscoElastigroupTests(TestCase):
 
         launch_config = self.elastigroup.get_launch_config(hostclass='mhcfoo')
 
-        self.assertEquals({'instance_type': 'm4.large'}, launch_config)
+        self.assertEqual({'instance_type': 'm4.large'}, launch_config)

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -35,6 +35,12 @@ class DiscoElastigroupTests(TestCase):
             },
             "compute": {
                 "product": "Linux/UNIX",
+                "instanceTypes": {
+                    "ondemand": "m4.large",
+                    "spot": [
+                        "m4.large"
+                    ]
+                },
                 "launchSpecification": {
                     "imageId": ami_id,
                     "loadBalancersConfig": {
@@ -228,6 +234,7 @@ class DiscoElastigroupTests(TestCase):
                 'name': ANY,
                 'capacity': ANY,
                 'compute': {
+                    'instanceTypes': ANY,
                     'availabilityZones': ANY,
                     'launchSpecification': {
                         'blockDeviceMappings': ANY,
@@ -332,7 +339,7 @@ class DiscoElastigroupTests(TestCase):
         group = self.mock_elastigroup(hostclass='mhcfoo')
         self.elastigroup.spotinst_client.get_groups.return_value = [group]
 
-        self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
+        new_elbs, extras = self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
 
         expected_request = {
             'group': {
@@ -350,6 +357,18 @@ class DiscoElastigroupTests(TestCase):
         }
 
         self.elastigroup.spotinst_client.update_group.assert_called_once_with(group['id'], expected_request)
+
+        self.assertEquals({'elb-newelb'}, new_elbs)
+        self.assertEquals({'elb-1234'}, extras)
+
+    def test_update_elb_missing_group(self):
+        """Test updating ELB for group that doesn't exist"""
+        self.elastigroup.spotinst_client.get_groups.return_value = []
+
+        new_elbs, extras = self.elastigroup.update_elb(['elb-newelb'], hostclass='mhcfoo')
+
+        self.assertEquals(set(), new_elbs)
+        self.assertEquals(set(), extras)
 
     def test_update_group_update_elb(self):
         """Verifies updating group also updates ELB"""
@@ -537,3 +556,12 @@ class DiscoElastigroupTests(TestCase):
         }]
 
         self.assertEqual(expected, instances)
+
+    def test_get_launch_config(self):
+        """Verifies Elastigroups are scaled down"""
+        group = self.mock_elastigroup(hostclass='mhcfoo')
+        self.elastigroup.spotinst_client.get_groups.return_value = [group]
+
+        launch_config = self.elastigroup.get_launch_config(hostclass='mhcfoo')
+
+        self.assertEquals({'instance_type': 'm4.large'}, launch_config)


### PR DESCRIPTION
Asiaq was trying to read the existing instance type of a group from its launch config
but Elastigroups don't have launch configs so it was failing and returning the default.
This caused a number of problems so implement the get_launch_config method of Elastigroups
to return the instance type for the rest of Asiaq to use.

Also add back support for modifying instance type of existing groups that was disabled previously
which tracking down this bug