### PR TITLE
Fix Error From Spotinst's Documentation

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -460,10 +460,10 @@ class DiscoElastigroup(BaseGroup):
             }
 
             if min_size:
-                task['scaleMinCapcity'] = min_size
+                task['scaleMinCapacity'] = min_size
 
             if max_size:
-                task['scaleMaxCapcity'] = max_size
+                task['scaleMaxCapacity'] = max_size
 
             if desired_capacity:
                 task['scaleTargetCapacity'] = desired_capacity

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.14"
+__version__ = "2.1.15"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_elastigroup.py
+++ b/tests/unit/test_disco_elastigroup.py
@@ -68,7 +68,7 @@ class DiscoElastigroupTests(TestCase):
                 "tasks": [{
                     'taskType': 'scale',
                     'cronExpression': '12 0 * * *',
-                    'scaleMinCapcity': 5
+                    'scaleMinCapacity': 5
                 }]
             }
         }
@@ -411,11 +411,11 @@ class DiscoElastigroupTests(TestCase):
                     'tasks': [{
                         'taskType': 'scale',
                         'cronExpression': '12 0 * * *',
-                        'scaleMinCapcity': 5
+                        'scaleMinCapacity': 5
                     }, {
                         'taskType': 'scale',
                         'cronExpression': '0 0 * * *',
-                        'scaleMinCapcity': 1
+                        'scaleMinCapacity': 1
                     }]
                 }
             }


### PR DESCRIPTION
The Spotinst documentation leaves out the `a` for these two keys.
Correcting this ommission.