### PR TITLE
Add --deployable option to deploy test/update

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.1.15"
+__version__ = "2.2.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -1424,7 +1424,7 @@ class DiscoDeployTests(TestCase):
             dry_run=False
         )
 
-    def test_deployable_option_overrides_in_test(self):
+    def test_deployable_option_in_test(self):
         """Tests that providing a deployable option overrides in test"""
         self._ci_deploy.handle_blue_green_ami = MagicMock()
 
@@ -1442,18 +1442,12 @@ class DiscoDeployTests(TestCase):
             force_deployable=True
         )
 
-        self._ci_deploy.handle_blue_green_ami.assert_has_calls(
-            [
-                 call(
-                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False
-                 ),
-                 call(
-                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True
-                 )
-            ]
-        )
+        self._ci_deploy.handle_blue_green_ami.assert_has_calls([
+            call(ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False),
+            call(ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True)
+        ])
 
-    def test_deployable_option_overrides_in_update(self):
+    def test_deployable_option_in_update(self):
         """Tests that providing a deployable option overrides in update"""
         self._ci_deploy.handle_blue_green_ami = MagicMock()
 
@@ -1471,16 +1465,10 @@ class DiscoDeployTests(TestCase):
             force_deployable=True
         )
 
-        self._ci_deploy.handle_blue_green_ami.assert_has_calls(
-            [
-                 call(
-                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False
-                 ),
-                 call(
-                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True
-                 )
-            ]
-        )
+        self._ci_deploy.handle_blue_green_ami.assert_has_calls([
+            call(ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False),
+            call(ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True)
+        ])
 
     def test_test_get_ami_to_deploy_hostclass(self):
         """Test DiscoDeployTestHelper get_ami_to_deploy for specific host return non private ami"""

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -13,7 +13,7 @@ import requests_mock
 import requests
 
 import boto.ec2.instance
-from mock import MagicMock, create_autospec, call, patch
+from mock import MagicMock, create_autospec, call, patch, ANY
 
 from disco_aws_automation import DiscoDeploy, DiscoAWS, DiscoGroup, DiscoBake, DiscoELB
 from disco_aws_automation.disco_constants import DEPLOYMENT_STRATEGY_BLUE_GREEN
@@ -1422,6 +1422,64 @@ class DiscoDeployTests(TestCase):
             ami=self._amis_by_name['mhcfoo 4'],
             deployment_strategy="foobar",
             dry_run=False
+        )
+
+    def test_deployable_option_overrides_in_test(self):
+        """Tests that providing a deployable option overrides in test"""
+        self._ci_deploy.handle_blue_green_ami = MagicMock()
+
+        self._ci_deploy.test_ami(
+            ami=self._amis_by_name['mhcfoo 4'],
+            deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+            dry_run=False,
+            force_deployable=False
+        )
+
+        self._ci_deploy.test_ami(
+            ami=self._amis_by_name['mhcfoo 4'],
+            deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+            dry_run=False,
+            force_deployable=True
+        )
+
+        self._ci_deploy.handle_blue_green_ami.assert_has_calls(
+            [
+                 call(
+                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False
+                 ),
+                 call(
+                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True
+                 )
+            ]
+        )
+
+    def test_deployable_option_overrides_in_update(self):
+        """Tests that providing a deployable option overrides in update"""
+        self._ci_deploy.handle_blue_green_ami = MagicMock()
+
+        self._ci_deploy.update_ami(
+            ami=self._amis_by_name['mhcfoo 4'],
+            deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+            dry_run=False,
+            force_deployable=False
+        )
+
+        self._ci_deploy.update_ami(
+            ami=self._amis_by_name['mhcfoo 4'],
+            deployment_strategy=DEPLOYMENT_STRATEGY_BLUE_GREEN,
+            dry_run=False,
+            force_deployable=True
+        )
+
+        self._ci_deploy.handle_blue_green_ami.assert_has_calls(
+            [
+                 call(
+                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=False
+                 ),
+                 call(
+                    ANY, dry_run=ANY, old_group=ANY, pipeline_dict=ANY, run_tests=ANY, deployable=True
+                 )
+            ]
         )
 
     def test_test_get_ami_to_deploy_hostclass(self):


### PR DESCRIPTION
Added support for a --deployable option to test/update to overwrite the
deployable configuration defined in the pipeline. The intention is to
make it possible to have a pipeline entry that is normally marked as
deployable=false, but at runtime override that to force a deployment of
a new AMI.