### PR TITLE
AL-1641 Support SSM Docs in Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2333,7 +2333,7 @@ ssm_doc_integration_tests=asiaq-run-tests
   * If provided, Asiaq will execute the provided SSM document with a `mode` variable set to either `on` or `off`, depending on whether or not the instance is entering or exiting testing mode. If this entry is not provided, Asiaq will fallback to executing the `/etc/asiaq/bin/testing_mode.sh` via SSH.
 * ssm_doc_integration_tests
   * If provided, Asiaq will execute the provided SSM document to run integration tests during deployment. The SSM document will be passed several variables:
-    * `runner` will be given the value of `test_command`
+    * `command` will be given the value of `test_command`
     * `user` will be given the value of `test_user`
     * `test` will be given the name of the integration test defined in the pipeline.
   * If not provided, Asiaq will fallback to executing the integration tests via SSH.

--- a/README.md
+++ b/README.md
@@ -2317,6 +2317,8 @@ test_hostclass=mhcfootest
 test_user=integration_tester
 test_command=/opt/asiaq/bin/run_tests.sh
 deployment_strategy=blue_green # One of [blue_green]
+ssm_doc_testing_mode=asiaq-testing-mode
+ssm_doc_integration_tests=asiaq-run-tests
 ```
 
 * test_hostclass
@@ -2327,6 +2329,14 @@ deployment_strategy=blue_green # One of [blue_green]
   * The command to execute the tests on ```test_hostclass``` as the ```test_user```. Typically a shell script with some logic for handling the test argument that is passed to it. The exit code of this command determines whether or not the integration tests were successful.
 * deployment_strategy
   * The deployment strategy to use when deploying a new AMI. The default is currently ```blue_green```.
+* ssm_doc_testing_mode
+  * If provided, Asiaq will execute the provided SSM document with a `mode` variable set to either `on` or `off`, depending on whether or not the instance is entering or exiting testing mode. If this entry is not provided, Asiaq will fallback to executing the `/etc/asiaq/bin/testing_mode.sh` via SSH.
+* ssm_doc_integration_tests
+  * If provided, Asiaq will execute the provided SSM document to run integration tests during deployment. The SSM document will be passed several variables:
+    * `runner` will be given the value of `test_command`
+    * `user` will be given the value of `test_user`
+    * `test` will be given the name of the integration test defined in the pipeline.
+  * If not provided, Asiaq will fallback to executing the integration tests via SSH.
 
 These options can be specified in two places in ```disco_aws.ini```, in the ```[test]``` section or in a given hostclass' section. Below is an example of specifying defaults in the ```[test]``` section and overriding them for the mhcfoo hostclass.
 

--- a/bin/disco_deploy.py
+++ b/bin/disco_deploy.py
@@ -59,7 +59,7 @@ import sys
 
 from docopt import docopt
 
-from disco_aws_automation import DiscoAWS, DiscoGroup, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC
+from disco_aws_automation import DiscoAWS, DiscoGroup, DiscoBake, DiscoDeploy, DiscoELB, DiscoVPC, DiscoSSM
 from disco_aws_automation.disco_aws_util import run_gracefully, is_truthy
 from disco_aws_automation.disco_config import read_config
 from disco_aws_automation.disco_logging import configure_logging
@@ -109,7 +109,7 @@ def run():
     vpc = DiscoVPC.fetch_environment(environment_name=env)
 
     deploy = DiscoDeploy(
-        aws, test_aws, bake, DiscoGroup(env), DiscoELB(vpc),
+        aws, test_aws, bake, DiscoGroup(env), DiscoELB(vpc), DiscoSSM(environment_name=env),
         pipeline_definition=pipeline_definition,
         ami=args.get("--ami"), hostclass=args.get("--hostclass"),
         allow_any_hostclass=args["--allow-any-hostclass"])

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -586,7 +586,7 @@ class DiscoDeploy(object):
                 instance_ids=[instance_id],
                 document_name=ssm_doc_integration_tests,
                 parameters={
-                    "runner": test_command,
+                    "command": test_command,
                     "test": test_name,
                     "user": test_user
                 },

--- a/disco_aws_automation/disco_deploy.py
+++ b/disco_aws_automation/disco_deploy.py
@@ -529,7 +529,7 @@ class DiscoDeploy(object):
                 instance_ids=instance_ids,
                 document_name=ssm_doc_testing_mode,
                 parameters={
-                    "mode": "on" if mode_on else "off"
+                    "mode": ["on" if mode_on else "off"]
                 },
                 comment="Asiaq Deploy is toggling testing mode"
             )
@@ -586,9 +586,9 @@ class DiscoDeploy(object):
                 instance_ids=[instance_id],
                 document_name=ssm_doc_integration_tests,
                 parameters={
-                    "command": test_command,
-                    "test": test_name,
-                    "user": test_user
+                    "command": [test_command],
+                    "test": [test_name],
+                    "user": [test_user]
                 },
                 comment="Asiaq Deploy is running integration tests"
             )

--- a/disco_aws_automation/disco_ssm.py
+++ b/disco_aws_automation/disco_ssm.py
@@ -69,6 +69,11 @@ class DiscoSSM(object):
 
         Optionally takes parameters to pass to the SSM document and an audit comment to indicate why this
         command was run.
+
+        The parameters object is expected to be in the form of:
+        {
+            "key": ["values"...],
+        }
         """
         bucket_name = self.get_s3_bucket_name()
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -1087,9 +1087,9 @@ class DiscoDeployTests(TestCase):
             instance_ids=["i-12345678"],
             document_name=SSM_DOC_INTEGRATION_TESTS,
             parameters={
-                "command": "test_command",
-                "test": "ssm_service",
-                "user": "test_user"
+                "command": ["test_command"],
+                "test": ["ssm_service"],
+                "user": ["test_user"]
             },
             comment=ANY
         )
@@ -1109,7 +1109,7 @@ class DiscoDeployTests(TestCase):
             instance_ids=["i-12345678"],
             document_name=SSM_DOC_TESTING_MODE,
             parameters={
-                "mode": "on"
+                "mode": ["on"]
             },
             comment=ANY
         )

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -1087,7 +1087,7 @@ class DiscoDeployTests(TestCase):
             instance_ids=["i-12345678"],
             document_name=SSM_DOC_INTEGRATION_TESTS,
             parameters={
-                "runner": "test_command",
+                "command": "test_command",
                 "test": "ssm_service",
                 "user": "test_user"
             },


### PR DESCRIPTION
Added support for toggling testing mode and executing integration tests
via SSM documents instead of through SSH. This new behavior is opt-in
and requires two new configuration options be set. Details in the
README.

Open to thoughts on the interface for the SSM documents specified in the README.