### PR TITLE
Add --snapshot-id option to update in disco_snapshots.py

### DIFF
--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -68,6 +68,7 @@ def get_parser():
         'update', help='Update snapshot used by new instances in a hostclass')
     parser_update.set_defaults(mode="update")
     parser_update.add_argument('--hostclass', dest='hostclass', required=True, type=str, default=None)
+    parser_update.add_argument('--snapshot-id', dest='snapshot_id', required=False, type=str, default=None)
 
     return parser
 
@@ -125,7 +126,10 @@ def run():
         for snapshot_id in args.snapshots:
             aws.disco_storage.delete_snapshot(snapshot_id)
     elif args.mode == "update":
-        snapshot = aws.disco_storage.get_latest_snapshot(args.hostclass)
+        if args.snapshot_id is None:
+            snapshot = aws.disco_storage.get_latest_snapshot(args.hostclass)
+        else:
+            snapshot = aws.disco_storage.get_snapshot_from_id(args.snapshot_id)
         aws.discogroup.update_snapshot(snapshot.id, snapshot.volume_size, hostclass=args.hostclass)
 
 if __name__ == "__main__":

--- a/bin/disco_snapshot.py
+++ b/bin/disco_snapshot.py
@@ -126,10 +126,10 @@ def run():
         for snapshot_id in args.snapshots:
             aws.disco_storage.delete_snapshot(snapshot_id)
     elif args.mode == "update":
-        if args.snapshot_id is None:
-            snapshot = aws.disco_storage.get_latest_snapshot(args.hostclass)
-        else:
+        if args.snapshot_id:
             snapshot = aws.disco_storage.get_snapshot_from_id(args.snapshot_id)
+        else:
+            snapshot = aws.disco_storage.get_latest_snapshot(args.hostclass)
         aws.discogroup.update_snapshot(snapshot.id, snapshot.volume_size, hostclass=args.hostclass)
 
 if __name__ == "__main__":

--- a/disco_aws_automation/disco_autoscale.py
+++ b/disco_aws_automation/disco_autoscale.py
@@ -624,7 +624,7 @@ class DiscoAutoscale(BaseGroup):
 
     def update_snapshot(self, snapshot_id, snapshot_size, hostclass=None, group_name=None):
         """Updates all of a hostclasses existing autoscaling groups to use a different snapshot"""
-        launch_config = self.get_launch_config(hostclass=hostclass, group_name=group_name)
+        launch_config = self._get_launch_config(hostclass=hostclass, group_name=group_name)
         if not launch_config:
             raise Exception("Can't locate hostclass {0}".format(hostclass or group_name))
         snapshot_bdm = launch_config.block_device_mappings[

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -364,11 +364,6 @@ class DiscoStorage(object):
         return snapshot.id
 
     def get_snapshot_from_id(self, snapshot_id):
-        """
-        Lists all EBS snapshots associated with a hostclass, sorted by hostclass name and start_time
-
-        :param hostclasses if not None, restrict results to specific hostclasses
-        """
+        """For a given snapshot id return the boto2 snapshot object"""
         return throttled_call(self.connection.get_all_snapshots,
-                              snapshot_ids=[snapshot_id],
-                              filters={'tag:env': self.environment_name})[0]
+                              snapshot_ids=[snapshot_id])[0]

--- a/disco_aws_automation/disco_storage.py
+++ b/disco_aws_automation/disco_storage.py
@@ -362,3 +362,13 @@ class DiscoStorage(object):
         throttled_call(snapshot.add_tags, tags=tags)
 
         return snapshot.id
+
+    def get_snapshot_from_id(self, snapshot_id):
+        """
+        Lists all EBS snapshots associated with a hostclass, sorted by hostclass name and start_time
+
+        :param hostclasses if not None, restrict results to specific hostclasses
+        """
+        return throttled_call(self.connection.get_all_snapshots,
+                              snapshot_ids=[snapshot_id],
+                              filters={'tag:env': self.environment_name})[0]

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_autoscale.py
+++ b/tests/unit/test_autoscale.py
@@ -352,7 +352,7 @@ class DiscoAutoscaleTests(TestCase):
 
     def test_update_snapshot_using_latest(self):
         """Calling update_snapshot when already running latest snapshot does nothing"""
-        self._autoscale.get_launch_config = MagicMock(
+        self._autoscale._get_launch_config = MagicMock(
             return_value=self.mock_launchconfig(self._autoscale.environment_name, "mhcfoo"))
         self._autoscale.modify_group = MagicMock()
         self._autoscale.update_snapshot("snap-12345678", 99, hostclass="mhcfoo")
@@ -361,7 +361,7 @@ class DiscoAutoscaleTests(TestCase):
     def test_update_snapshot_with_update(self):
         """Calling update_snapshot when not running latest snapshot calls modify_group with new config"""
         mock_lc = self.mock_launchconfig(self._autoscale.environment_name, "mhcfoo", 1)
-        self._autoscale.get_launch_config = MagicMock(return_value=mock_lc)
+        self._autoscale._get_launch_config = MagicMock(return_value=mock_lc)
         self._autoscale.modify_group = MagicMock()
         self._autoscale.get_existing_group = MagicMock(return_value="group")
         self._autoscale.update_snapshot("snap-NEW", 99, hostclass="mhcfoo")

--- a/tests/unit/test_disco_storage.py
+++ b/tests/unit/test_disco_storage.py
@@ -77,6 +77,17 @@ class DiscoStorageTests(TestCase):
         self.assertEquals(1, len(self.storage.get_snapshots()))
 
     @mock_ec2
+    def test_get_snapshot_from_id(self):
+        """Test getting all of the snapshots for an environment"""
+        first_snapshot = self._create_snapshot('boo', 'unittestenv')
+        second_snapshot = self._create_snapshot('boo', 'unittestenv')
+
+        self.assertFalse(first_snapshot['SnapshotId'] == second_snapshot['SnapshotId'])
+
+        self.assertEquals(first_snapshot['SnapshotId'],
+                          self.storage.get_snapshot_from_id(first_snapshot['SnapshotId']).id)
+
+    @mock_ec2
     def test_delete_snapshot(self):
         """Test deleting a snapshot"""
         snapshot = self._create_snapshot('foo', 'unittestenv')

--- a/tests/unit/test_disco_storage.py
+++ b/tests/unit/test_disco_storage.py
@@ -84,8 +84,8 @@ class DiscoStorageTests(TestCase):
 
         self.assertFalse(first_snapshot['SnapshotId'] == second_snapshot['SnapshotId'])
 
-        self.assertEquals(first_snapshot['SnapshotId'],
-                          self.storage.get_snapshot_from_id(first_snapshot['SnapshotId']).id)
+        self.assertEqual(first_snapshot['SnapshotId'],
+                         self.storage.get_snapshot_from_id(first_snapshot['SnapshotId']).id)
 
     @mock_ec2
     def test_delete_snapshot(self):

--- a/tests/unit/test_disco_storage.py
+++ b/tests/unit/test_disco_storage.py
@@ -78,7 +78,7 @@ class DiscoStorageTests(TestCase):
 
     @mock_ec2
     def test_get_snapshot_from_id(self):
-        """Test getting all of the snapshots for an environment"""
+        """Given a snapshot id get the boto2 snapshot object"""
         first_snapshot = self._create_snapshot('boo', 'unittestenv')
         second_snapshot = self._create_snapshot('boo', 'unittestenv')
 


### PR DESCRIPTION
Adding the option `--snapshot-id` to update autoscaling group when we already have the snapshot_id in hand.

- [x] code
- [ ] test with a hostclass