### PR TITLE
Disabled Detailed Monitoring by Default

### DIFF
--- a/disco_aws_automation/disco_aws.py
+++ b/disco_aws_automation/disco_aws.py
@@ -340,7 +340,7 @@ class DiscoAWS(object):
 
         return elb
 
-    def provision(self, ami, hostclass=None, owner=None, instance_type=None, monitoring_enabled=True,
+    def provision(self, ami, hostclass=None, owner=None, instance_type=None, monitoring_enabled=False,
                   extra_space=None, extra_disk=None, iops=None, no_destroy=False, min_size=None,
                   desired_size=None, max_size=None, testing=False, termination_policies=None, chaos=None,
                   create_if_exists=False, group_name=None, spotinst=False, spotinst_reserve=None):

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.0"
+__version__ = "2.3.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
We don't use detailed monitoring for anything important anymore, and
it's an expensive thing to default to on, so disabling it.