### PR TITLE
Detach network interfaces before destroying them

### DIFF
--- a/disco_aws_automation/disco_vpc.py
+++ b/disco_aws_automation/disco_vpc.py
@@ -609,7 +609,7 @@ class DiscoVPC(object):
             interfaces = throttled_call(self.boto3_ec2.describe_network_interfaces,
                                         Filters=self.vpc_filters())["NetworkInterfaces"]
             for interface in interfaces:
-                if interface.get('Attachment'):
+                if 'Attachment' in interface:
                     throttled_call(
                         self.boto3_ec2.detach_network_interface,
                         AttachmentId=interface['Attachment']['AttachmentId'],

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Do this in order to be able to more reliably destroy them