### PR TITLE
Fix for ubuntu

### DIFF
--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -198,13 +198,11 @@ def get_or_create_ids(username, groupname):
         logger.info("Creating user %s", username)
         command = '/usr/sbin/adduser'
         command_input = ['--gid', str(gid), '--shell', '/sbin/nologin', username]
-        output = subprocess.call([command,
-                                  '--system',
-                                  command_input])
+        output = subprocess.call([command, '--system'] + command_input)
+        # if the above command fails its highly likely that we are in a Centos 5
+        # system and it doesnt have `--system` option instead it has `-r`.
         if output != 0:
-            subprocess.call([command,
-                             '-r',
-                             command_input])
+            subprocess.call([command, '-r'] + command_input)
         uid = pwd.getpwnam(username).pw_uid
     return uid, gid
 

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -198,10 +198,10 @@ def get_or_create_ids(username, groupname):
         logger.info("Creating user %s", username)
         command = '/usr/sbin/adduser'
         command_input = ['--gid', str(gid), '--shell', '/sbin/nologin', username]
-        output = subprocess.call([command, '--system'] + command_input)
+        exit_code = subprocess.call([command, '--system'] + command_input)
         # if the above command fails its highly likely that we are in a Centos 5
         # system and it doesnt have `--system` option instead it has `-r`.
-        if output != 0:
+        if exit_code != 0:
             subprocess.call([command, '-r'] + command_input)
         uid = pwd.getpwnam(username).pw_uid
     return uid, gid

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -196,12 +196,12 @@ def get_or_create_ids(username, groupname):
         uid = pwd.getpwnam(username).pw_uid
     except KeyError:
         logger.info("Creating user %s", username)
-        command='/usr/sbin/adduser'
+        command = '/usr/sbin/adduser'
         command_input = ['--gid', str(gid), '--shell', '/sbin/nologin', username]
         output = subprocess.call([command,
                                   '--system',
                                   command_input])
-        if output !=0 :
+        if output != 0:
             subprocess.call([command,
                              '-r',
                              command_input])

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -196,11 +196,15 @@ def get_or_create_ids(username, groupname):
         uid = pwd.getpwnam(username).pw_uid
     except KeyError:
         logger.info("Creating user %s", username)
-        subprocess.call(['/usr/sbin/adduser',
-                         '--system',
-                         '--gid', str(gid),
-                         '--shell', '/sbin/nologin',
-                         username])
+        command='/usr/sbin/adduser'
+        command_input = ['--gid', str(gid), '--shell', '/sbin/nologin', username]
+        output = subprocess.call([command,
+                                  '--system',
+                                  command_input])
+        if output !=0 :
+            subprocess.call([command,
+                             '-r',
+                             command_input])
         uid = pwd.getpwnam(username).pw_uid
     return uid, gid
 

--- a/bin/acfg1.py
+++ b/bin/acfg1.py
@@ -197,7 +197,7 @@ def get_or_create_ids(username, groupname):
     except KeyError:
         logger.info("Creating user %s", username)
         subprocess.call(['/usr/sbin/adduser',
-                         '-r',
+                         '--system',
                          '--gid', str(gid),
                          '--shell', '/sbin/nologin',
                          username])

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.5"
+__version__ = "2.3.6"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
The adduser command option to create system users is different in various flavors of linux system. The options that can be used to create system user are `--system` and `-r`. Either can be used but the following is a list of what the different linux systems support.
Centos 5: `-r`
Centos 6/7: `--system` and `-r`
Ubuntu: `--system`