### PR TITLE
Adding option to create sandboxes from existing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,12 @@ in the location `$REMOTE_DIRECTORY/$SANDBOX_NAME`.  So, by way of example:
     sandbox_sync_config=zk_blacklist zookeeper-sync-black-lists
         trusted_ip_list   firewall-trusted-cidrs
 
+To spin up a sandbox from existing sandbox config, e.g. Incase you want to 
+spin up more than one sandbox from the same sandbox config, simply run:
+
+    asiaq sandbox $SANDBOX_NAME --reference-name $REFERENCE_NAME
+
+The above command with spin up $REFERENCE_NAME sandbox.
 
 Provisioning a pipeline
 -----------------------

--- a/README.md
+++ b/README.md
@@ -752,9 +752,10 @@ in the location `$REMOTE_DIRECTORY/$SANDBOX_NAME`.  So, by way of example:
 To spin up a sandbox from existing sandbox config, e.g. Incase you want to 
 spin up more than one sandbox from the same sandbox config, simply run:
 
-    asiaq sandbox $SANDBOX_NAME --reference-name $REFERENCE_NAME
+    asiaq sandbox $SANDBOX_NAME --config-dir $EXISTING_SANDBOX_NAME
 
-The above command with spin up $REFERENCE_NAME sandbox.
+The above command will spin up $SANDBOX_NAME sandbox using 
+$EXISTING_SANDBOX_NAME config.
 
 Provisioning a pipeline
 -----------------------

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -66,7 +66,7 @@ class SandboxCommand(CliCommand):
     @classmethod
     def init_args(cls, parser):
         parser.add_argument("sandbox_name", help="Name of the sandbox VPC to create or update.")
-        parser.add_argument("--reference-name", dest="reference_name", default=None, 
+        parser.add_argument("--reference-name", dest="reference_name", default=None,
                             help="Alternate name of the sandbox VPC to create or update. \
                             Creates additional sandboxes from `sandbox_name` config", )
 

--- a/disco_aws_automation/asiaq_cli.py
+++ b/disco_aws_automation/asiaq_cli.py
@@ -66,30 +66,29 @@ class SandboxCommand(CliCommand):
     @classmethod
     def init_args(cls, parser):
         parser.add_argument("sandbox_name", help="Name of the sandbox VPC to create or update.")
-        parser.add_argument("--reference-name", dest="reference_name", default=None,
-                            help="Alternate name of the sandbox VPC to create or update. \
-                            Creates additional sandboxes from `sandbox_name` config", )
+        parser.add_argument("--config-dir", dest="config_dir", default=None,
+                            help="The sandbox folder with the configs.")
 
     def run(self):
         self.logger.debug("Updating sandbox %s", self.args.sandbox_name)
         sandbox_name = self.args.sandbox_name
-        pipeline_file = os.path.join("sandboxes", sandbox_name, "pipeline.csv")
-        reference_name = self.args.reference_name
+        config_dir = self.args.config_dir
 
-        if not reference_name:
-            reference_name = sandbox_name
+        if not config_dir:
+            config_dir = sandbox_name
 
+        pipeline_file = os.path.join("sandboxes", config_dir, "pipeline.csv")
         hostclass_dicts = read_pipeline_file(pipeline_file)
 
-        self._update_s3_configs(sandbox_name, reference_name)
+        self._update_s3_configs(sandbox_name, config_dir)
 
-        self.logger.info("Checking if environment '%s' already exists", reference_name)
-        vpc = DiscoVPC.fetch_environment(environment_name=reference_name)
+        self.logger.info("Checking if environment '%s' already exists", sandbox_name)
+        vpc = DiscoVPC.fetch_environment(environment_name=sandbox_name)
         if vpc:
-            self.logger.info("Sandbox %s already exists: updating it.", reference_name)
+            self.logger.info("Sandbox %s already exists: updating it.", sandbox_name)
             vpc.update()
         else:
-            vpc = DiscoVPC(environment_name=reference_name,
+            vpc = DiscoVPC(environment_name=sandbox_name,
                            environment_type='sandbox',
                            defer_creation=True)
             vpc.create()
@@ -97,7 +96,7 @@ class SandboxCommand(CliCommand):
         self.logger.debug("Hostclass definitions for spin-up: %s", hostclass_dicts)
         DiscoAWS(self.config, vpc=vpc).spinup(hostclass_dicts)
 
-    def _update_s3_configs(self, sandbox_name, reference_name):
+    def _update_s3_configs(self, sandbox_name, config_dir):
         config_sync_option = self.config.get_asiaq_option('sandbox_sync_config', required=False)
         bucket_name = self.config.get_asiaq_option('sandbox_config_bucket', required=False)
         if not config_sync_option:
@@ -107,8 +106,8 @@ class SandboxCommand(CliCommand):
         s3_bucket = boto3.resource("s3").Bucket(name=bucket_name)
         for sync_line in config_sync_option.split("\n"):
             local_name, remote_dir = sync_line.split()
-            local_config_path = normalize_path("sandboxes", sandbox_name, local_name)
-            remote_config_path = os.path.join(remote_dir, reference_name)
+            local_config_path = normalize_path("sandboxes", config_dir, local_name)
+            remote_config_path = os.path.join(remote_dir, sandbox_name)
             self.logger.info("Uploading config file file %s to %s", local_config_path, remote_config_path)
             s3_bucket.upload_file(local_config_path, remote_config_path)
 

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.6"
+__version__ = "2.3.7"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
To create a sandbox from config : 
`$> asiaq sandbox oreo`

To create another sandbox from `oreo` config (without creating a temp git branch or symlink):
`$> asiaq sandbox oreo2 --config-dir oreo` 