### PR TITLE
Handle SSM Exceptions

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.7"
+__version__ = "2.3.8"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -1114,6 +1114,26 @@ class DiscoDeployTests(TestCase):
             comment=ANY
         )
 
+    def test_setting_testing_mode_ssm_error(self):
+        '''toggles testing mode correctly via ssm'''
+        self._ci_deploy._disco_ssm.execute.return_value = False
+        self.assertEqual(
+            self._ci_deploy._set_testing_mode(
+                "mhcssmdocs",
+                [MagicMock(id="i-12345678")],
+                True
+            ),
+            False
+        )
+        self._ci_deploy._disco_ssm.execute.assert_called_with(
+            instance_ids=["i-12345678"],
+            document_name=SSM_DOC_TESTING_MODE,
+            parameters={
+                "mode": ["on"]
+            },
+            comment=ANY
+        )
+
     def test_run_integration_tests_get_host_fail(self):
         '''run_integration_tests raises exception when a get_host fails to find a host'''
         ami = self.mock_ami("mhcintegrated 1 2")

--- a/tests/unit/test_disco_deploy.py
+++ b/tests/unit/test_disco_deploy.py
@@ -1115,7 +1115,7 @@ class DiscoDeployTests(TestCase):
         )
 
     def test_setting_testing_mode_ssm_error(self):
-        '''toggles testing mode correctly via ssm'''
+        '''toggling testing mode fails if execute fails'''
         self._ci_deploy._disco_ssm.execute.return_value = False
         self.assertEqual(
             self._ci_deploy._set_testing_mode(

--- a/tests/unit/test_disco_ssm.py
+++ b/tests/unit/test_disco_ssm.py
@@ -725,6 +725,25 @@ class DiscoSSMTests(TestCase):
         self.assertEquals(False, is_successful)
 
     @patch('boto3.client', mock_boto3_client)
+    def test_execute_command_with_exception(self):
+        """Verify that we fail if the command fails"""
+        self._ssm._send_command = MagicMock(side_effect=ClientError({'Error': {}}, ''))
+        self._ssm.get_s3_bucket_name = MagicMock(return_value=None)
+        instance_ids = ['i-1', 'i-2']
+        document_name = "foo-doc"
+        comment = "foo-comment"
+        parameters = "foo-parameters"
+
+        is_successful = self._ssm.execute(
+            instance_ids,
+            document_name,
+            comment=comment,
+            parameters=parameters
+        )
+
+        self.assertEquals(False, is_successful)
+
+    @patch('boto3.client', mock_boto3_client)
     def test_read_env_from_config(self):
         """Verify that we read the env from config if none is provided"""
         config_aws = get_mock_config(MOCK_AWS_CONFIG_DEFINITION)

--- a/tests/unit/test_disco_ssm.py
+++ b/tests/unit/test_disco_ssm.py
@@ -726,7 +726,7 @@ class DiscoSSMTests(TestCase):
 
     @patch('boto3.client', mock_boto3_client)
     def test_execute_command_with_exception(self):
-        """Verify that we fail if the command fails"""
+        """Verify that we fail if there is an exception"""
         self._ssm._send_command = MagicMock(side_effect=ClientError({'Error': {}}, ''))
         self._ssm.get_s3_bucket_name = MagicMock(return_value=None)
         instance_ids = ['i-1', 'i-2']


### PR DESCRIPTION
Some changes to catch exceptions when executing an SSM command. If an
exception is caught, SSM returns a False, indicating that the command
did not execute in the desired manner. Also added some unit tests
validating that this works.