### PR TITLE
Fixing Incorrect Code Coverage Statistics

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.3.8"
+__version__ = "2.3.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 with-coverage = true
 cover-package = disco_aws_automation
 cover-inclusive = true
-cover-erase = true
 stop = true
 detailed-errors = true
 verbosity = 3


### PR DESCRIPTION
Apparently there is a race condition where if nosetests is configured to
delete coverage files, it will delete some coverage files before the
code coverage statistics are calculated. This only appears to happen if
the tests are run in parallel. Removing the `code-erase` option fixes
this issue, and we already ignore the coverage files that are generated,
so this seems like a good compromise.