### PR TITLE
Delete RDS subnet group when RDS instance is deleted

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Deleting subnet groups function was called before RDS instance was deleted, and that would fail due to dependency.

Deleting RDS subnet group after RDS instance is deleted by calling function repeatedly (until RDS instance deletion times out) 