### PR TITLE
Tag AMIs with Hostclass

### DIFF
--- a/disco_aws_automation/disco_bake.py
+++ b/disco_aws_automation/disco_bake.py
@@ -485,7 +485,7 @@ class DiscoBake(object):
 
             productline = self.hc_option_default(hostclass, "product_line", None)
 
-            DiscoBake._tag_ami_with_metadata(image, stage, source_ami_id, productline,
+            DiscoBake._tag_ami_with_metadata(image, hostclass, stage, source_ami_id, productline,
                                              is_private, extra_tags=extra_tags)
 
             logger.info("Waiting for AMI to become available")
@@ -507,7 +507,7 @@ class DiscoBake(object):
         return image
 
     @staticmethod
-    def _tag_ami_with_metadata(ami, stage, source_ami_id, productline=None, is_private=False,
+    def _tag_ami_with_metadata(ami, hostclass, stage, source_ami_id, productline=None, is_private=False,
                                extra_tags=None):
         """
         Tags an AMI with the stage, source_ami, the branch/git-hash of disco_aws_automation,
@@ -519,6 +519,7 @@ class DiscoBake(object):
         # An ordered dictionary is used because AWS has limits on the number of tags that can be applied,
         # so we order the tags by their importance to Asiaq's ability to function. Ergo, stage is first.
         tag_dict = OrderedDict()
+        tag_dict['hostclass'] = hostclass
         tag_dict['stage'] = stage
         tag_dict['source_ami'] = source_ami_id
         tag_dict['baker'] = getpass.getuser()

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"

--- a/tests/unit/test_disco_bake.py
+++ b/tests/unit/test_disco_bake.py
@@ -157,6 +157,7 @@ class DiscoBakeTests(TestCase):
 
         self._bake._tag_ami_with_metadata(
             ami=ami,
+            hostclass="mhcbar",
             source_ami_id='mock_source',
             stage='mock_stage',
             productline='mock_productline',
@@ -167,6 +168,7 @@ class DiscoBakeTests(TestCase):
             ami,
             {
                 "source_ami": "mock_source",
+                "hostclass": "mhcbar",
                 "stage": "mock_stage",
                 "productline": "mock_productline",
                 "is_private": "False",
@@ -184,6 +186,7 @@ class DiscoBakeTests(TestCase):
 
         self._bake._tag_ami_with_metadata(
             ami=ami,
+            hostclass="mhcbar",
             source_ami_id='mock_source',
             stage='mock_stage',
             productline='mock_productline',
@@ -197,6 +200,7 @@ class DiscoBakeTests(TestCase):
             ami,
             {
                 "source_ami": "mock_source",
+                "hostclass": "mhcbar",
                 "stage": "mock_stage",
                 "productline": "mock_productline",
                 "is_private": "False",
@@ -214,6 +218,7 @@ class DiscoBakeTests(TestCase):
 
         self._bake._tag_ami_with_metadata(
             ami=ami,
+            hostclass="mhcbar",
             source_ami_id='mock_source',
             stage='mock_stage',
             productline='mock_productline',
@@ -225,6 +230,7 @@ class DiscoBakeTests(TestCase):
             ami,
             {
                 "source_ami": "mock_source",
+                "hostclass": "mhcbar",
                 "stage": "mock_stage",
                 "productline": "mock_productline",
                 "is_private": "True",


### PR DESCRIPTION
This should let us do searching for AMIs a bit faster by using AWS
filters instead of implementing our own filtering.