### PR TITLE
Remove egress rules when destroying a security group

### DIFF
--- a/disco_aws_automation/disco_vpc_sg_rules.py
+++ b/disco_aws_automation/disco_vpc_sg_rules.py
@@ -157,6 +157,16 @@ class DiscoVPCSecurityGroupRules(object):
                                    IpPermissions=[permission])
                 except EC2ResponseError:
                     logger.exception("Skipping error deleting sg rule.")
+            for permission in security_group['IpPermissionsEgress']:
+                try:
+                    logger.debug(
+                        "revoking %s %s %s %s", security_group, permission.get('IpProtocol'),
+                        permission.get('FromPort', '-'), permission.get('ToPort', '-'))
+                    throttled_call(self.boto3_ec2.revoke_security_group_egress,
+                                   GroupId=security_group['GroupId'],
+                                   IpPermissions=[permission])
+                except EC2ResponseError:
+                    logger.exception("Skipping error deleting sg rule.")
 
     def _destroy_security_groups(self):
         """ Find all security groups belonging to vpc and destroy them."""

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.3"
+__version__ = "2.4.4"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
VPC spindown failed when destroying security group due to reference of the security group ID in an egress rule of another security group. Old code was only removing ingress rules from a security group before destroying it. This fix will remove egress rules as well.