### PR TITLE
Handle cases when an elastigroup doesnt have a load balancer better

### DIFF
--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.8"
+__version__ = "2.4.9"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
Spotinst seems to have changed their API and now might not return a loadbalancersconfig if a group doesn't have any ELBs