### PR TITLE
Exclude ALBs when getting existing groups from elastigroups

### DIFF
--- a/disco_aws_automation/disco_elastigroup.py
+++ b/disco_aws_automation/disco_elastigroup.py
@@ -86,7 +86,8 @@ class DiscoElastigroup(BaseGroup):
                 'vpc_zone_identifier': ','.join(
                     zone['subnetId'] for zone in group['compute']['availabilityZones']
                 ),
-                'load_balancers': [elb['name'] for elb in load_balancer_configs],
+                'load_balancers': [elb['name'] for elb in load_balancer_configs
+                                   if elb['type'] == 'CLASSIC'],
                 'image_id': launch_spec['imageId'],
                 'id': group['id'],
                 'type': 'spot',

--- a/disco_aws_automation/version.py
+++ b/disco_aws_automation/version.py
@@ -1,5 +1,5 @@
 """Place of record for the package version"""
 
-__version__ = "2.4.17"
+__version__ = "2.4.18"
 __rpm_version__ = "WILL_BE_SET_BY_RPM_BUILD"
 __git_hash__ = "WILL_BE_SET_BY_EGG_BUILD"


### PR DESCRIPTION
`disco_autoscale.py  listgroups` breaks when an Elastigroup is configured with an ALB. With this change we will avoid parsing load balancers configurations in Elastigroup for ALBs.